### PR TITLE
Fix release workflow by downgrading cosign-installer to v3.10.1

### DIFF
--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -75,7 +75,7 @@ jobs:
         uses: anchore/sbom-action/download-syft@aa0e114b2e19480f157109b9922bda359bd98b90 # v0.20.8
 
       - name: Install Cosign
-        uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
+        uses: sigstore/cosign-installer@7e8b541eb2e61bf99390e1afd4be13a184e9ebc5 # v3.10.1
 
       - name: Build and Verify Binary Version
         env:


### PR DESCRIPTION
## Summary
Fixes the goreleaser signing failure by downgrading cosign-installer from v4.0.0 to v3.10.1.

## Problem
The v0.1.0 release failed during the signing step with:
```
Error: must provide --bundle with --signing-config or --use-signing-config
sign: cosign failed: exit status 1
```

## Root Cause
- **cosign-installer v4.0.0** installs **cosign v3.x** which introduced breaking changes to the `sign-blob` command
- Cosign v3.x requires `--bundle` flag with certain signing configurations
- Our goreleaser config uses the v2.x syntax which is incompatible with v3.x

## Evidence
The main toolhive project encountered the same issue:
- Their v0.3.10 release failed with identical error (Oct 17, 2025)
- Fixed in commit `012d3b88` by reverting to cosign-installer v3.10.1
- See toolhive PR #2248: "reverts cosign installer to `3.10.1` from `4` due to breaking change"

## Solution
Downgrade to **cosign-installer v3.10.1** which installs **cosign v2.6.1**, maintaining compatibility with our existing goreleaser signing configuration.

This aligns the registry-server with the toolhive project's configuration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)