### PR TITLE
build: added ubi variant to image build

### DIFF
--- a/.github/workflows/image-build-and-publish.yml
+++ b/.github/workflows/image-build-and-publish.yml
@@ -49,7 +49,23 @@ jobs:
 
       - name: Setup ko
         uses: ko-build/setup-ko@d006021bd0c28d1ce33a07e7943d48b079944c8d # v0.9
+      
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
+      - name: Extract UBI metadata
+        id: ubi-meta
+        uses: docker/metadata-action@318604b99e75e41977312d83839a89be02ca4893 # v5.9.0
+        with:
+          images: ${{ env.BASE_REPO }}
+          tags: |
+            type=raw,value=${{ steps.version-string.outputs.tag }}-ubi
+            type=raw,value=latest-ubi,enable=${{ startsWith(github.ref, 'refs/tags/') }}
+          labels: |
+            name=toolhive-registry-api
+            vendor=Stacklok
+            maintainer=Stacklok
+        
       - name: Install Cosign
         uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
 
@@ -71,15 +87,30 @@ jobs:
           KO_DOCKER_REPO=$BASE_REPO ko build --platform=linux/amd64,linux/arm64 --bare $TAGS ./cmd/thv-registry-api \
             --image-label=org.opencontainers.image.source=https://github.com/stacklok/toolhive-registry-server,org.opencontainers.image.title="toolhive-registry-server",org.opencontainers.image.vendor=Stacklok
 
+      - name: Build and Push UBI Image to GHCR
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        with:
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.ubi-meta.outputs.tags }}
+          build-args: |
+            VERSION=${{ steps.version-string.outputs.tag }}-ubi
+            COMMIT=${{ github.sha }}
+            BUILD_DATE=${{ github.event.head_commit.timestamp }}
+          labels: ${{ steps.ubi-meta.outputs.labels }}
+
       - name: Sign Image with Cosign
         # This step uses the identity token to provision an ephemeral certificate
         # against the sigstore community Fulcio instance.
         run: |
           TAG=$(echo "${{ steps.version-string.outputs.tag }}" | sed 's/+/_/g')
+          UBI_TAG=$(echo "${{ steps.version-string.outputs.tag }}-ubi" | sed 's/+/_/g')
           # Sign the ko image
           cosign sign -y $BASE_REPO:$TAG
+          cosign sign -y $BASE_REPO:$UBI_TAG
           
           # Sign the latest tag if building from a tag
           if [[ "${{ github.ref }}" == refs/tags/* ]]; then
             cosign sign -y $BASE_REPO:latest
+            cosign sign -y $BASE_REPO:latest-ubi
           fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,38 @@
+# Build the binary
+FROM golang as builder
+
+USER root
+
+WORKDIR /workspace
+
+# Copy the Go Modules manifests
+COPY go.mod go.mod
+COPY go.sum go.sum
+# cache deps before building and copying source so that we don't need to re-download as much
+# and so that source changes don't invalidate our downloaded layer
+RUN go mod download
+
+ARG VERSION \
+COMMIT \
+BUILD_DATE
+
+# Copy the entire Go module structure
+COPY . .
+
+# Build
+RUN CGO_ENABLED=0 LDFLAGS="-s -w \
+-X github.com/stacklok/toolhive/pkg/versions.Version=${VERSION} \
+-X github.com/stacklok/toolhive/pkg/versions.Commit=${COMMIT} \
+-X github.com/stacklok/toolhive/pkg/versions.BuildDate=${BUILD_DATE} \
+-X github.com/stacklok/toolhive/pkg/versions.BuildType=release" \
+GOOS=linux GOARCH=amd64 go build -ldflags "${LDFLAGS}" -o main ./cmd/thv-registry-api/main.go
+
+# Use minimal base image to package the binary
+FROM  --platform=linux/amd64 registry.access.redhat.com/ubi10/ubi-minimal:10.0
+
+COPY --from=builder /workspace/main /
+COPY LICENSE /licenses/LICENSE
+
+USER 1001
+
+ENTRYPOINT ["/main"]

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,5 +1,15 @@
 version: '3'
 
+vars:
+  CONTAINER_RUNTIME:
+    sh: |
+      if command -v podman >/dev/null 2>&1; then
+        echo "podman"
+      else
+        echo "docker"
+      fi
+  REPO: '{{.REPO | default "ghcr.io/stacklok/toolhive-registry-server"}}'
+
 tasks:
   docs:
     desc: Regenerate the registry API documentation
@@ -78,9 +88,28 @@ tasks:
     desc: Build the registry API image with ko
     deps: [install-ko]
     env:
-      KO_DOCKER_REPO: ghcr.io/stacklok/toolhive-registry-server
+      KO_DOCKER_REPO: '{{.REPO}}'
     cmds:
       - ko build --local -B ./cmd/thv-registry-api
+
+  build-image-ubi:
+    desc: Build the registry API image with UBI base image
+    vars:
+      COMMIT:
+        sh: git rev-parse --short HEAD || echo "unknown"
+      BUILD_DATE: '{{dateInZone "2006-01-02T15:04:05Z" (now) "UTC"}}'
+      SHA:  
+        sh: git rev-parse HEAD || echo "unknown"
+    cmds:
+      - >
+        eval "{{.CONTAINER_RUNTIME}} build --load
+        -t {{.REPO}}:{{.SHA}}-ubi
+        --build-arg VERSION={{.SHA}}-ubi
+        --build-arg COMMIT={{.COMMIT}}
+        --build-arg BUILD_DATE={{.BUILD_DATE}}
+        --label name=\"toolhive-registry-api\"
+        --label vendor=\"Stacklok\"
+        --label maintainer=\"Stacklok\" ."
 
   test:
     desc: Run registry API tests


### PR DESCRIPTION
Added a task and a CI step for building and publishing a UBI-based variant of the registry image, for using with OpenShift.

Relates to:
https://github.com/stacklok/toolhive/pull/2491
https://github.com/stacklok/toolhive/pull/2327