### PR TITLE
Update goreleaser for cosign v3

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -51,10 +51,9 @@ signs:
   - cmd: cosign
     args:
       - "sign-blob"
-      - "--output-signature=${signature}"
-      - "--output-certificate=${certificate}"
+      - "--bundle=${signature}" # cosign v3+: bundles signature and certificate together
       - "${artifact}"
       - "--yes" # needed on cosign 2.0.0+
     artifacts: archive
     output: true
-    certificate: '{{ trimsuffix (trimsuffix .Env.artifact ".zip") ".tar.gz" }}.pem'
+    signature: "${artifact}.sigstore.json"


### PR DESCRIPTION
Following instructions from https://goreleaser.com/blog/cosign-v3/#updating-your-goreleaser-configuration