### PR TITLE
ci: fix issue with ubi image name replacing plus with a dash

### DIFF
--- a/.github/workflows/image-build-and-publish.yml
+++ b/.github/workflows/image-build-and-publish.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
             # For main branch, use semver with -dev suffix
-            echo "tag=0.0.1-dev.$GITHUB_RUN_NUMBER+$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+            echo "tag=0.0.1-dev.${GITHUB_RUN_NUMBER}_$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
           elif [[ "${{ github.ref }}" == refs/tags/* ]]; then
             # For tags, use the tag as is (assuming it's semver)
             TAG="${{ github.ref_name }}"
@@ -37,7 +37,7 @@ jobs:
           else
             # For other branches, use branch name and run number
             BRANCH="${{ github.ref_name }}"
-            echo "tag=0.0.1-$BRANCH.$GITHUB_RUN_NUMBER+$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+            echo "tag=0.0.1-$BRANCH.${GITHUB_RUN_NUMBER}_$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Login to GitHub Container Registry
@@ -76,7 +76,7 @@ jobs:
           BUILD_DATE: ${{ github.event.head_commit.timestamp }}
           KO_CONFIG_PATH: ${{ github.workspace }}/.github/ko-ci.yml
         run: |
-          TAG=$(echo "${{ steps.version-string.outputs.tag }}" | sed 's/+/_/g')
+          TAG=$(echo "${{ steps.version-string.outputs.tag }}")
           TAGS="-t $TAG"
           
           # Add latest tag only if building from a tag
@@ -103,8 +103,8 @@ jobs:
         # This step uses the identity token to provision an ephemeral certificate
         # against the sigstore community Fulcio instance.
         run: |
-          TAG=$(echo "${{ steps.version-string.outputs.tag }}" | sed 's/+/_/g')
-          UBI_TAG=$(echo "${{ steps.version-string.outputs.tag }}-ubi" | sed 's/+/_/g')
+          TAG=$(echo "${{ steps.version-string.outputs.tag }}")
+          UBI_TAG=$(echo "${{ steps.version-string.outputs.tag }}-ubi")
           # Sign the ko image
           cosign sign -y $BASE_REPO:$TAG
           cosign sign -y $BASE_REPO:$UBI_TAG


### PR DESCRIPTION
The issue with the latest CI failures starting [this one](https://github.com/stacklok/toolhive-registry-server/actions/runs/19271028967/job/55099271437) originates in https://github.com/stacklok/toolhive-registry-server/pull/85, the addition of the UBI variant of the image. The cause is the _docker build_ command replaces the `+` with `-` and not the expected `_`. A similiar issue was resolved in https://github.com/stacklok/toolhive/pull/2363.

@dmartinol @blkt ^^