### PR TITLE
fix: ubi image build should support multi arch builds

### DIFF
--- a/.github/workflows/image-build-and-publish.yml
+++ b/.github/workflows/image-build-and-publish.yml
@@ -90,7 +90,7 @@ jobs:
       - name: Build and Push UBI Image to GHCR
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.ubi-meta.outputs.tags }}
           build-args: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,10 +25,10 @@ RUN CGO_ENABLED=0 LDFLAGS="-s -w \
 -X github.com/stacklok/toolhive/pkg/versions.Commit=${COMMIT} \
 -X github.com/stacklok/toolhive/pkg/versions.BuildDate=${BUILD_DATE} \
 -X github.com/stacklok/toolhive/pkg/versions.BuildType=release" \
-GOOS=linux GOARCH=amd64 go build -ldflags "${LDFLAGS}" -o main ./cmd/thv-registry-api/main.go
+go build -ldflags "${LDFLAGS}" -o main ./cmd/thv-registry-api/main.go
 
 # Use minimal base image to package the binary
-FROM --platform=linux/amd64 registry.access.redhat.com/ubi10/ubi-minimal:10.1-1763362715
+FROM registry.access.redhat.com/ubi10/ubi-minimal:10.1-1763362715
 
 COPY --from=builder /workspace/main /
 COPY LICENSE /licenses/LICENSE

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -157,9 +157,11 @@ tasks:
       BUILD_DATE: '{{dateInZone "2006-01-02T15:04:05Z" (now) "UTC"}}'
       SHA:
         sh: git rev-parse HEAD || echo "unknown"
+      PLATFORM:
+        sh: echo "${PLATFORM:-linux/$(go env GOARCH)}" 
     cmds:
       - |
-        {{.CONTAINER_RUNTIME}} build --load \
+        {{.CONTAINER_RUNTIME}} build --platform={{.PLATFORM}} --load \
         -t {{.REPO}}:{{.SHA}}-ubi \
         --build-arg VERSION={{.SHA}}-ubi \
         --build-arg COMMIT={{.COMMIT}} \


### PR DESCRIPTION
Replaces https://github.com/stacklok/toolhive-registry-server/pull/121.

Using Mac M2 pro, bulding ARM:
```
task build-image-ubi
```

Building AMD:
```
PLATFORM=linux/amd64 task build-image-ubi
```

cc @dmjb @rdimitrov @dmartinol 
