### PR TITLE
Add queries to list packages and remotes

### DIFF
--- a/database/queries/servers.sql
+++ b/database/queries/servers.sql
@@ -33,7 +33,7 @@ SELECT r.reg_type as registry_type,
  CASE WHEN sqlc.narg(prev)::timestamp with time zone IS NULL THEN s.version END DESC -- acts as tie breaker
  LIMIT sqlc.arg(size)::bigint;
 
- -- name: ListServerPackages :many
+-- name: ListServerPackages :many
 SELECT p.server_id,
        p.registry_type,
        p.pkg_registry_url,
@@ -49,16 +49,16 @@ SELECT p.server_id,
        p.transport_headers
   FROM mcp_server_package p
   JOIN mcp_server s ON p.server_id = s.id
- WHERE s.id IN (sqlc.slice(server_ids)::UUID[])
+ WHERE s.id = ANY(sqlc.slice(server_ids)::UUID[])
  ORDER BY p.pkg_version DESC;
 
- -- name: ListServerRemotes :many
+-- name: ListServerRemotes :many
 SELECT r.server_id,
        r.transport,
        r.transport_url,
        r.transport_headers
   FROM mcp_server_remote r
- WHERE r.server_id IN (sqlc.slice(server_ids)::UUID[])
+ WHERE r.server_id = ANY(sqlc.slice(server_ids)::UUID[])
  ORDER BY r.transport, r.transport_url;
 
 -- name: ListServerVersions :many

--- a/internal/db/sqlc/querier.go
+++ b/internal/db/sqlc/querier.go
@@ -16,6 +16,8 @@ type Querier interface {
 	InsertRegistry(ctx context.Context, arg InsertRegistryParams) (pgtype.UUID, error)
 	InsertRegistrySync(ctx context.Context, arg InsertRegistrySyncParams) (pgtype.UUID, error)
 	ListRegistries(ctx context.Context, arg ListRegistriesParams) ([]Registry, error)
+	ListServerPackages(ctx context.Context, serverIds []pgtype.UUID) ([]McpServerPackage, error)
+	ListServerRemotes(ctx context.Context, serverIds []pgtype.UUID) ([]McpServerRemote, error)
 	ListServerVersions(ctx context.Context, arg ListServerVersionsParams) ([]ListServerVersionsRow, error)
 	ListServers(ctx context.Context, arg ListServersParams) ([]ListServersRow, error)
 	UpdateRegistrySync(ctx context.Context, arg UpdateRegistrySyncParams) error


### PR DESCRIPTION
A spurious space character prevented `sqlc` from generating code for `ListServerPackages` and `ListServerRemotes` queries.

This change fixes it and adds tests for those queries as well.