### PR TITLE
fixes the leftover paths from pkg/ to internal/

### DIFF
--- a/.github/ko-ci.yml
+++ b/.github/ko-ci.yml
@@ -3,7 +3,7 @@ builds:
     dir: ./cmd/thv-registry-api
     ldflags:
       - -s -w
-      - -X github.com/stacklok/toolhive-registry-server/pkg/versions.Version={{.Env.VERSION}}
-      - -X github.com/stacklok/toolhive-registry-server/pkg/versions.Commit={{.Env.COMMIT}}
-      - -X github.com/stacklok/toolhive-registry-server/pkg/versions.BuildDate={{.Env.BUILD_DATE}}
-      - -X github.com/stacklok/toolhive-registry-server/pkg/versions.BuildType=release
+      - -X github.com/stacklok/toolhive-registry-server/internal/versions.Version={{.Env.VERSION}}
+      - -X github.com/stacklok/toolhive-registry-server/internal/versions.Commit={{.Env.COMMIT}}
+      - -X github.com/stacklok/toolhive-registry-server/internal/versions.BuildDate={{.Env.BUILD_DATE}}
+      - -X github.com/stacklok/toolhive-registry-server/internal/versions.BuildType=release

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -85,7 +85,7 @@ jobs:
           TREE_STATE: ${{ needs.compute-build-flags.outputs.tree-state }}
         run: |
           # Build a test binary using the same env vars as GoReleaser
-          go build -ldflags "-s -w -X github.com/stacklok/toolhive-registry-server/pkg/versions.Version=${VERSION} -X github.com/stacklok/toolhive-registry-server/pkg/versions.Commit=${COMMIT} -X github.com/stacklok/toolhive-registry-server/pkg/versions.BuildDate=$(date -Iseconds) -X github.com/stacklok/toolhive-registry-server/pkg/versions.BuildType=release" -o ./thv-test ./cmd/thv-registry-api
+          go build -ldflags "-s -w -X github.com/stacklok/toolhive-registry-server/internal/versions.Version=${VERSION} -X github.com/stacklok/toolhive-registry-server/internal/versions.Commit=${COMMIT} -X github.com/stacklok/toolhive-registry-server/internal/versions.BuildDate=$(date -Iseconds) -X github.com/stacklok/toolhive-registry-server/internal/versions.BuildType=release" -o ./thv-test ./cmd/thv-registry-api
 
           # Get version from binary
           BINARY_VERSION=$(./thv-test version --format json | jq -r '.version')

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -11,10 +11,10 @@ builds:
       - -tags=netgo
     ldflags:
       - "-s -w"
-      - "-X github.com/stacklok/toolhive-registry-server/pkg/versions.Version={{ .Env.VERSION }}"
-      - "-X github.com/stacklok/toolhive-registry-server/pkg/versions.Commit={{ .Env.COMMIT }}"
-      - "-X github.com/stacklok/toolhive-registry-server/pkg/versions.BuildDate={{ .Date }}"
-      - "-X github.com/stacklok/toolhive-registry-server/pkg/versions.BuildType=release"
+      - "-X github.com/stacklok/toolhive-registry-server/internal/versions.Version={{ .Env.VERSION }}"
+      - "-X github.com/stacklok/toolhive-registry-server/internal/versions.Commit={{ .Env.COMMIT }}"
+      - "-X github.com/stacklok/toolhive-registry-server/internal/versions.BuildDate={{ .Date }}"
+      - "-X github.com/stacklok/toolhive-registry-server/internal/versions.BuildType=release"
     goos:
       - linux
       - windows

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,11 +21,11 @@ COPY . .
 
 # Build
 RUN CGO_ENABLED=0 LDFLAGS="-s -w \
--X github.com/stacklok/toolhive/pkg/versions.Version=${VERSION} \
--X github.com/stacklok/toolhive/pkg/versions.Commit=${COMMIT} \
--X github.com/stacklok/toolhive/pkg/versions.BuildDate=${BUILD_DATE} \
--X github.com/stacklok/toolhive/pkg/versions.BuildType=release" \
-go build -ldflags "${LDFLAGS}" -o main ./cmd/thv-registry-api/main.go
+-X github.com/stacklok/toolhive-registry-server/internal/versions.Version=${VERSION} \
+-X github.com/stacklok/toolhive-registry-server/internal/versions.Commit=${COMMIT} \
+-X github.com/stacklok/toolhive-registry-server/internal/versions.BuildDate=${BUILD_DATE} \
+-X github.com/stacklok/toolhive-registry-server/internal/versions.BuildType=release" \
+GOOS=linux GOARCH=amd64 go build -ldflags "${LDFLAGS}" -o main ./cmd/thv-registry-api/main.go
 
 # Use minimal base image to package the binary
 FROM registry.access.redhat.com/ubi10/ubi-minimal:10.1-1763362715


### PR DESCRIPTION
Some paths where missed in https://github.com/stacklok/toolhive-registry-server/pull/105. this PR fixes the ones that fail the release build