### PR TITLE
Make implementation structs private

### DIFF
--- a/internal/filtering/filter_service.go
+++ b/internal/filtering/filter_service.go
@@ -23,23 +23,23 @@ type FilterService interface {
 	) (*toolhivetypes.UpstreamRegistry, error)
 }
 
-// DefaultFilterService implements filtering coordination using name and tag filters
-type DefaultFilterService struct {
+// defaultFilterService implements filtering coordination using name and tag filters
+type defaultFilterService struct {
 	nameFilter NameFilter
 	tagFilter  TagFilter
 }
 
-// NewDefaultFilterService creates a new DefaultFilterService with default filter implementations
-func NewDefaultFilterService() *DefaultFilterService {
-	return &DefaultFilterService{
+// NewDefaultFilterService creates a new defaultFilterService with default filter implementations
+func NewDefaultFilterService() FilterService {
+	return &defaultFilterService{
 		nameFilter: NewDefaultNameFilter(),
 		tagFilter:  NewDefaultTagFilter(),
 	}
 }
 
-// NewFilterService creates a new DefaultFilterService with custom filter implementations
-func NewFilterService(nameFilter NameFilter, tagFilter TagFilter) *DefaultFilterService {
-	return &DefaultFilterService{
+// NewFilterService creates a new defaultFilterService with custom filter implementations
+func NewFilterService(nameFilter NameFilter, tagFilter TagFilter) FilterService {
+	return &defaultFilterService{
 		nameFilter: nameFilter,
 		tagFilter:  tagFilter,
 	}
@@ -53,7 +53,7 @@ func NewFilterService(nameFilter NameFilter, tagFilter TagFilter) *DefaultFilter
 // 3. For each server (both container and remote), apply name and tag filtering
 // 4. Only include servers that pass both name and tag filters
 // 5. Return the filtered registry
-func (s *DefaultFilterService) ApplyFilters(
+func (s *defaultFilterService) ApplyFilters(
 	ctx context.Context,
 	reg *toolhivetypes.UpstreamRegistry,
 	filter *config.FilterConfig) (*toolhivetypes.UpstreamRegistry, error) {
@@ -127,7 +127,7 @@ func (s *DefaultFilterService) ApplyFilters(
 
 // shouldIncludeServerWithReason determines if a server should be included and provides detailed reasoning
 // Both name and tag filters must pass for a server to be included
-func (s *DefaultFilterService) shouldIncludeServerWithReason(
+func (s *defaultFilterService) shouldIncludeServerWithReason(
 	serverName string,
 	serverTags []string,
 	nameInclude, nameExclude, tagInclude, tagExclude []string) (bool, string) {

--- a/internal/filtering/filter_service_test.go
+++ b/internal/filtering/filter_service_test.go
@@ -34,8 +34,10 @@ func TestNewDefaultFilterService(t *testing.T) {
 
 	service := NewDefaultFilterService()
 	assert.NotNil(t, service)
-	assert.NotNil(t, service.nameFilter)
-	assert.NotNil(t, service.tagFilter)
+	// Cast to concrete type to access fields in tests (same package)
+	concreteService := service.(*defaultFilterService)
+	assert.NotNil(t, concreteService.nameFilter)
+	assert.NotNil(t, concreteService.tagFilter)
 }
 
 func TestNewFilterService(t *testing.T) {
@@ -46,8 +48,10 @@ func TestNewFilterService(t *testing.T) {
 
 	service := NewFilterService(nameFilter, tagFilter)
 	assert.NotNil(t, service)
-	assert.Equal(t, nameFilter, service.nameFilter)
-	assert.Equal(t, tagFilter, service.tagFilter)
+	// Cast to concrete type to access fields in tests (same package)
+	concreteService := service.(*defaultFilterService)
+	assert.Equal(t, nameFilter, concreteService.nameFilter)
+	assert.Equal(t, tagFilter, concreteService.tagFilter)
 }
 
 func TestDefaultFilterService_ApplyFilters_NoFilter(t *testing.T) {

--- a/internal/filtering/name_filter.go
+++ b/internal/filtering/name_filter.go
@@ -12,12 +12,14 @@ type NameFilter interface {
 	ShouldInclude(name string, include, exclude []string) (bool, string)
 }
 
-// DefaultNameFilter implements name filtering using Go's filepath.Match for glob patterns
-type DefaultNameFilter struct{}
+// defaultNameFilter implements name filtering using Go's filepath.Match for glob patterns
+type defaultNameFilter struct{}
 
-// NewDefaultNameFilter creates a new DefaultNameFilter
-func NewDefaultNameFilter() *DefaultNameFilter {
-	return &DefaultNameFilter{}
+var _ NameFilter = (*defaultNameFilter)(nil)
+
+// NewDefaultNameFilter creates a new defaultNameFilter
+func NewDefaultNameFilter() NameFilter {
+	return &defaultNameFilter{}
 }
 
 // ShouldInclude determines if a server name should be included based on include/exclude patterns
@@ -28,7 +30,7 @@ func NewDefaultNameFilter() *DefaultNameFilter {
 // 3. If include patterns are specified and name doesn't match any -> exclude
 // 4. If only exclude patterns are specified (no include) and name doesn't match exclude -> include
 // 5. If no patterns are specified -> include (default behavior)
-func (*DefaultNameFilter) ShouldInclude(name string, include, exclude []string) (bool, string) {
+func (*defaultNameFilter) ShouldInclude(name string, include, exclude []string) (bool, string) {
 	// Check exclude patterns first (exclude takes precedence)
 	if len(exclude) > 0 {
 		for _, pattern := range exclude {

--- a/internal/filtering/name_filter_test.go
+++ b/internal/filtering/name_filter_test.go
@@ -11,7 +11,6 @@ func TestNewDefaultNameFilter(t *testing.T) {
 
 	filter := NewDefaultNameFilter()
 	assert.NotNil(t, filter)
-	assert.IsType(t, &DefaultNameFilter{}, filter)
 }
 
 func TestDefaultNameFilter_ShouldInclude(t *testing.T) {

--- a/internal/filtering/tag_filter.go
+++ b/internal/filtering/tag_filter.go
@@ -9,12 +9,14 @@ type TagFilter interface {
 	ShouldInclude(tags []string, include, exclude []string) (bool, string)
 }
 
-// DefaultTagFilter implements tag filtering using exact string matching
-type DefaultTagFilter struct{}
+// defaultTagFilter implements tag filtering using exact string matching
+type defaultTagFilter struct{}
 
-// NewDefaultTagFilter creates a new DefaultTagFilter
-func NewDefaultTagFilter() *DefaultTagFilter {
-	return &DefaultTagFilter{}
+var _ TagFilter = (*defaultTagFilter)(nil)
+
+// NewDefaultTagFilter creates a new defaultTagFilter
+func NewDefaultTagFilter() TagFilter {
+	return &defaultTagFilter{}
 }
 
 // ShouldInclude determines if a server with given tags should be included based on include/exclude tag lists
@@ -25,7 +27,7 @@ func NewDefaultTagFilter() *DefaultTagFilter {
 // 3. If include tags are specified and no server tags match any include tag -> exclude
 // 4. If only exclude tags are specified (no include) and no server tags match exclude -> include
 // 5. If no tag filters are specified -> include (default behavior)
-func (*DefaultTagFilter) ShouldInclude(tags []string, include, exclude []string) (bool, string) {
+func (*defaultTagFilter) ShouldInclude(tags []string, include, exclude []string) (bool, string) {
 	// Check exclude tags first (exclude takes precedence)
 	if len(exclude) > 0 {
 		for _, serverTag := range tags {

--- a/internal/filtering/tag_filter_test.go
+++ b/internal/filtering/tag_filter_test.go
@@ -11,7 +11,6 @@ func TestNewDefaultTagFilter(t *testing.T) {
 
 	filter := NewDefaultTagFilter()
 	assert.NotNil(t, filter)
-	assert.IsType(t, &DefaultTagFilter{}, filter)
 }
 
 func TestDefaultTagFilter_ShouldInclude(t *testing.T) {

--- a/internal/git/client.go
+++ b/internal/git/client.go
@@ -26,16 +26,16 @@ type Client interface {
 	Cleanup(ctx context.Context, repoInfo *RepositoryInfo) error
 }
 
-// DefaultGitClient implements GitClient using go-git
-type DefaultGitClient struct{}
+// defaultGitClient implements GitClient using go-git
+type defaultGitClient struct{}
 
-// NewDefaultGitClient creates a new DefaultGitClient
-func NewDefaultGitClient() *DefaultGitClient {
-	return &DefaultGitClient{}
+// NewDefaultGitClient creates a new defaultGitClient
+func NewDefaultGitClient() Client {
+	return &defaultGitClient{}
 }
 
 // Clone clones a repository with the given configuration
-func (c *DefaultGitClient) Clone(ctx context.Context, config *CloneConfig) (*RepositoryInfo, error) {
+func (c *defaultGitClient) Clone(ctx context.Context, config *CloneConfig) (*RepositoryInfo, error) {
 	// Prepare clone options (no authentication for initial version)
 	cloneOptions := &git.CloneOptions{
 		URL: config.URL,
@@ -112,7 +112,7 @@ func (c *DefaultGitClient) Clone(ctx context.Context, config *CloneConfig) (*Rep
 }
 
 // GetFileContent retrieves the content of a file from the repository
-func (*DefaultGitClient) GetFileContent(repoInfo *RepositoryInfo, path string) ([]byte, error) {
+func (*defaultGitClient) GetFileContent(repoInfo *RepositoryInfo, path string) ([]byte, error) {
 	if repoInfo == nil || repoInfo.Repository == nil {
 		return nil, fmt.Errorf("repository is nil")
 	}
@@ -151,7 +151,7 @@ func (*DefaultGitClient) GetFileContent(repoInfo *RepositoryInfo, path string) (
 }
 
 // Cleanup removes local repository directory
-func (*DefaultGitClient) Cleanup(ctx context.Context, repoInfo *RepositoryInfo) error {
+func (*defaultGitClient) Cleanup(ctx context.Context, repoInfo *RepositoryInfo) error {
 	logger := log.FromContext(ctx)
 	if repoInfo == nil || repoInfo.Repository == nil {
 		return fmt.Errorf("repository is nil")
@@ -187,7 +187,7 @@ func (*DefaultGitClient) Cleanup(ctx context.Context, repoInfo *RepositoryInfo) 
 }
 
 // updateRepositoryInfo updates the repository info with current state
-func (*DefaultGitClient) updateRepositoryInfo(repoInfo *RepositoryInfo) error {
+func (*defaultGitClient) updateRepositoryInfo(repoInfo *RepositoryInfo) error {
 	if repoInfo == nil || repoInfo.Repository == nil {
 		return fmt.Errorf("repository is nil")
 	}

--- a/internal/git/client_test.go
+++ b/internal/git/client_test.go
@@ -14,9 +14,9 @@ func TestNewDefaultGitClient(t *testing.T) {
 		t.Fatal("NewDefaultGitClient() returned nil")
 	}
 
-	// Verify it's the correct type
-	if _, ok := any(client).(*DefaultGitClient); !ok {
-		t.Fatal("NewDefaultGitClient() did not return *DefaultGitClient")
+	// Verify it returns the correct concrete type
+	if _, ok := client.(*defaultGitClient); !ok {
+		t.Fatal("NewDefaultGitClient() did not return *defaultGitClient")
 	}
 }
 

--- a/internal/git/integration_test.go
+++ b/internal/git/integration_test.go
@@ -230,7 +230,7 @@ func TestDefaultGitClient_UpdateRepositoryInfo(t *testing.T) {
 		t.Fatalf("Failed to checkout branch: %v", err)
 	}
 
-	client := NewDefaultGitClient()
+	client := &defaultGitClient{}
 	repoInfo := &RepositoryInfo{
 		Repository: repo,
 	}

--- a/internal/httpclient/client.go
+++ b/internal/httpclient/client.go
@@ -26,8 +26,8 @@ type Client interface {
 	Get(ctx context.Context, url string) ([]byte, error)
 }
 
-// DefaultClient is the default HTTP client implementation
-type DefaultClient struct {
+// defaultClient is the default HTTP client implementation
+type defaultClient struct {
 	client  *http.Client
 	timeout time.Duration
 }
@@ -39,7 +39,7 @@ func NewDefaultClient(timeout time.Duration) Client {
 		timeout = DefaultTimeout
 	}
 	// TODO: Use TLS by default
-	return &DefaultClient{
+	return &defaultClient{
 		client: &http.Client{
 			Timeout: timeout,
 		},
@@ -48,7 +48,7 @@ func NewDefaultClient(timeout time.Duration) Client {
 }
 
 // Get performs an HTTP GET request
-func (c *DefaultClient) Get(ctx context.Context, url string) ([]byte, error) {
+func (c *defaultClient) Get(ctx context.Context, url string) ([]byte, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)

--- a/internal/service/file_provider.go
+++ b/internal/service/file_provider.go
@@ -11,10 +11,10 @@ import (
 	"github.com/stacklok/toolhive-registry-server/internal/sources"
 )
 
-// FileRegistryDataProvider implements RegistryDataProvider by delegating to StorageManager.
+// fileRegistryDataProvider implements RegistryDataProvider by delegating to StorageManager.
 // This implementation uses the adapter pattern to reuse storage infrastructure instead of
 // duplicating file reading logic. It delegates to StorageManager for all file operations.
-type FileRegistryDataProvider struct {
+type fileRegistryDataProvider struct {
 	storageManager sources.StorageManager
 	config         *config.Config
 	registryName   string
@@ -23,8 +23,8 @@ type FileRegistryDataProvider struct {
 // NewFileRegistryDataProvider creates a new file-based registry data provider.
 // It accepts a StorageManager to delegate file operations and a Config for registry metadata.
 // This design eliminates code duplication and improves testability through dependency injection.
-func NewFileRegistryDataProvider(storageManager sources.StorageManager, cfg *config.Config) *FileRegistryDataProvider {
-	return &FileRegistryDataProvider{
+func NewFileRegistryDataProvider(storageManager sources.StorageManager, cfg *config.Config) RegistryDataProvider {
+	return &fileRegistryDataProvider{
 		storageManager: storageManager,
 		config:         cfg,
 		registryName:   cfg.GetRegistryName(),
@@ -38,7 +38,7 @@ func NewFileRegistryDataProvider(storageManager sources.StorageManager, cfg *con
 // NOTE: In PR 1, StorageManager returns UpstreamRegistry but RegistryDataProvider interface
 // still expects toolhive Registry. This method converts at the boundary to maintain
 // backward compatibility until PR 2.
-func (p *FileRegistryDataProvider) GetRegistryData(ctx context.Context) (*toolhivetypes.UpstreamRegistry, error) {
+func (p *fileRegistryDataProvider) GetRegistryData(ctx context.Context) (*toolhivetypes.UpstreamRegistry, error) {
 	// Get UpstreamRegistry from storage manager (new format)
 	registry, err := p.storageManager.Get(ctx, p.config)
 	if err != nil {
@@ -50,7 +50,7 @@ func (p *FileRegistryDataProvider) GetRegistryData(ctx context.Context) (*toolhi
 
 // GetSource implements RegistryDataProvider.GetSource.
 // It returns a descriptive string indicating the file source from the configuration.
-func (p *FileRegistryDataProvider) GetSource() string {
+func (p *fileRegistryDataProvider) GetSource() string {
 	if p.config.Source.File == nil || p.config.Source.File.Path == "" {
 		return "file:<not-configured>"
 	}
@@ -59,6 +59,6 @@ func (p *FileRegistryDataProvider) GetSource() string {
 
 // GetRegistryName implements RegistryDataProvider.GetRegistryName.
 // It returns the injected registry name identifier.
-func (p *FileRegistryDataProvider) GetRegistryName() string {
+func (p *fileRegistryDataProvider) GetRegistryName() string {
 	return p.registryName
 }

--- a/internal/service/provider_factory.go
+++ b/internal/service/provider_factory.go
@@ -16,20 +16,22 @@ type RegistryProviderFactory interface {
 	CreateProvider(cfg *config.Config) (RegistryDataProvider, error)
 }
 
-// DefaultRegistryProviderFactory is the default implementation of RegistryProviderFactory
-type DefaultRegistryProviderFactory struct {
+// defaultRegistryProviderFactory is the default implementation of RegistryProviderFactory
+type defaultRegistryProviderFactory struct {
 	storageManager sources.StorageManager
 }
 
+var _ RegistryProviderFactory = (*defaultRegistryProviderFactory)(nil)
+
 // NewRegistryProviderFactory creates a new default registry provider factory
 func NewRegistryProviderFactory(storageManager sources.StorageManager) RegistryProviderFactory {
-	return &DefaultRegistryProviderFactory{
+	return &defaultRegistryProviderFactory{
 		storageManager: storageManager,
 	}
 }
 
 // CreateProvider implements RegistryProviderFactory.CreateProvider
-func (f *DefaultRegistryProviderFactory) CreateProvider(cfg *config.Config) (RegistryDataProvider, error) {
+func (f *defaultRegistryProviderFactory) CreateProvider(cfg *config.Config) (RegistryDataProvider, error) {
 	if cfg == nil {
 		return nil, fmt.Errorf("config cannot be nil")
 	}

--- a/internal/service/provider_factory_test.go
+++ b/internal/service/provider_factory_test.go
@@ -35,7 +35,7 @@ func TestDefaultRegistryProviderFactory_CreateProvider(t *testing.T) {
 			wantErr: false,
 			checkType: func(t *testing.T, provider RegistryDataProvider) {
 				t.Helper()
-				assert.IsType(t, &FileRegistryDataProvider{}, provider)
+				assert.IsType(t, &fileRegistryDataProvider{}, provider)
 				assert.Equal(t, "file:/data/registry.json", provider.GetSource())
 				assert.Equal(t, "test-file-registry", provider.GetRegistryName())
 			},
@@ -85,10 +85,9 @@ func TestNewRegistryProviderFactory(t *testing.T) {
 	factory := NewRegistryProviderFactory(mockStorageManager)
 
 	require.NotNil(t, factory)
-	assert.IsType(t, &DefaultRegistryProviderFactory{}, factory)
 
 	// Verify that the factory has the storage manager injected
-	concreteFactory, ok := factory.(*DefaultRegistryProviderFactory)
+	concreteFactory, ok := factory.(*defaultRegistryProviderFactory)
 	require.True(t, ok)
 	assert.NotNil(t, concreteFactory.storageManager)
 }

--- a/internal/sources/api.go
+++ b/internal/sources/api.go
@@ -10,19 +10,19 @@ import (
 	"github.com/stacklok/toolhive-registry-server/internal/httpclient"
 )
 
-// APISourceHandler handles registry data from API endpoints
+// apiSourceHandler handles registry data from API endpoints
 // It validates the Upstream format and delegates to the appropriate handler
-type APISourceHandler struct {
+type apiSourceHandler struct {
 	httpClient      httpclient.Client
 	validator       SourceDataValidator
-	upstreamHandler *UpstreamAPIHandler
+	upstreamHandler *upstreamAPIHandler
 }
 
 // NewAPISourceHandler creates a new API source handler
-func NewAPISourceHandler() *APISourceHandler {
+func NewAPISourceHandler() SourceHandler {
 	httpClient := httpclient.NewDefaultClient(0) // Use default timeout
 
-	return &APISourceHandler{
+	return &apiSourceHandler{
 		httpClient:      httpClient,
 		validator:       NewSourceDataValidator(),
 		upstreamHandler: NewUpstreamAPIHandler(httpClient),
@@ -30,7 +30,7 @@ func NewAPISourceHandler() *APISourceHandler {
 }
 
 // Validate validates the API source configuration
-func (*APISourceHandler) Validate(source *config.SourceConfig) error {
+func (*apiSourceHandler) Validate(source *config.SourceConfig) error {
 	if source.Type != config.SourceTypeAPI {
 		return fmt.Errorf("invalid source type: expected %s, got %s",
 			config.SourceTypeAPI, source.Type)
@@ -55,7 +55,7 @@ func (*APISourceHandler) Validate(source *config.SourceConfig) error {
 
 // FetchRegistry retrieves registry data from the API endpoint
 // It validates the Upstream format and delegates to the appropriate handler
-func (h *APISourceHandler) FetchRegistry(ctx context.Context, cfg *config.Config) (*FetchResult, error) {
+func (h *apiSourceHandler) FetchRegistry(ctx context.Context, cfg *config.Config) (*FetchResult, error) {
 	logger := log.FromContext(ctx)
 
 	// Validate source configuration
@@ -76,7 +76,7 @@ func (h *APISourceHandler) FetchRegistry(ctx context.Context, cfg *config.Config
 }
 
 // CurrentHash returns the current hash of the API response
-func (h *APISourceHandler) CurrentHash(ctx context.Context, cfg *config.Config) (string, error) {
+func (h *apiSourceHandler) CurrentHash(ctx context.Context, cfg *config.Config) (string, error) {
 	// Validate source configuration
 	if err := h.Validate(&cfg.Source); err != nil {
 		return "", fmt.Errorf("source validation failed: %w", err)
@@ -93,10 +93,10 @@ func (h *APISourceHandler) CurrentHash(ctx context.Context, cfg *config.Config) 
 }
 
 // validateUstreamFormat validates the Upstream format and returns the appropriate handler
-func (h *APISourceHandler) validateUstreamFormat(
+func (h *apiSourceHandler) validateUstreamFormat(
 	ctx context.Context,
 	cfg *config.Config,
-) (*UpstreamAPIHandler, error) {
+) (*upstreamAPIHandler, error) {
 	logger := log.FromContext(ctx)
 	endpoint := h.getBaseURL(cfg)
 
@@ -112,7 +112,7 @@ func (h *APISourceHandler) validateUstreamFormat(
 }
 
 // getBaseURL extracts and normalizes the base URL
-func (*APISourceHandler) getBaseURL(cfg *config.Config) string {
+func (*apiSourceHandler) getBaseURL(cfg *config.Config) string {
 	baseURL := cfg.Source.API.Endpoint
 
 	// Remove trailing slash

--- a/internal/sources/api_test.go
+++ b/internal/sources/api_test.go
@@ -25,7 +25,7 @@ func TestAPISources(t *testing.T) {
 
 var _ = Describe("APISourceHandler", func() {
 	var (
-		handler    *sources.APISourceHandler
+		handler    sources.SourceHandler
 		ctx        context.Context
 		mockServer *httptest.Server
 	)

--- a/internal/sources/api_upstream.go
+++ b/internal/sources/api_upstream.go
@@ -11,17 +11,17 @@ import (
 	"github.com/stacklok/toolhive-registry-server/internal/httpclient"
 )
 
-// UpstreamAPIHandler handles registry data from upstream MCP Registry API endpoints
+// upstreamAPIHandler handles registry data from upstream MCP Registry API endpoints
 // API Format: /v0/servers (paginated list), /v0/servers/{name}/versions, /openapi.yaml
 // Phase 2 implementation - currently validates format but does not fetch data
-type UpstreamAPIHandler struct {
+type upstreamAPIHandler struct {
 	httpClient httpclient.Client
 	validator  SourceDataValidator
 }
 
 // NewUpstreamAPIHandler creates a new upstream MCP Registry API handler
-func NewUpstreamAPIHandler(httpClient httpclient.Client) *UpstreamAPIHandler {
-	return &UpstreamAPIHandler{
+func NewUpstreamAPIHandler(httpClient httpclient.Client) *upstreamAPIHandler {
+	return &upstreamAPIHandler{
 		httpClient: httpClient,
 		validator:  NewSourceDataValidator(),
 	}
@@ -29,7 +29,7 @@ func NewUpstreamAPIHandler(httpClient httpclient.Client) *UpstreamAPIHandler {
 
 // Validate validates that the endpoint is an upstream MCP Registry
 // by checking /openapi.yaml for expected version and description
-func (h *UpstreamAPIHandler) Validate(ctx context.Context, endpoint string) error {
+func (h *upstreamAPIHandler) Validate(ctx context.Context, endpoint string) error {
 	openapiURL := endpoint + "/openapi.yaml"
 
 	data, err := h.httpClient.Get(ctx, openapiURL)
@@ -74,13 +74,13 @@ func (h *UpstreamAPIHandler) Validate(ctx context.Context, endpoint string) erro
 
 // FetchRegistry retrieves registry data from the upstream MCP Registry API endpoint
 // Phase 2: Not yet implemented - will support pagination and format conversion
-func (*UpstreamAPIHandler) FetchRegistry(_ context.Context, _ *config.Config) (*FetchResult, error) {
+func (*upstreamAPIHandler) FetchRegistry(_ context.Context, _ *config.Config) (*FetchResult, error) {
 	return nil, fmt.Errorf("upstream MCP Registry API support not yet implemented (Phase 2)")
 }
 
 // CurrentHash returns the current hash of the API response
 // Phase 2: Not yet implemented
-func (*UpstreamAPIHandler) CurrentHash(_ context.Context, _ *config.Config) (string, error) {
+func (*upstreamAPIHandler) CurrentHash(_ context.Context, _ *config.Config) (string, error) {
 	return "", fmt.Errorf("upstream MCP Registry API support not yet implemented (Phase 2)")
 }
 

--- a/internal/sources/api_upstream_test.go
+++ b/internal/sources/api_upstream_test.go
@@ -1,4 +1,4 @@
-package sources_test
+package sources
 
 import (
 	"context"
@@ -10,21 +10,20 @@ import (
 
 	"github.com/stacklok/toolhive-registry-server/internal/config"
 	"github.com/stacklok/toolhive-registry-server/internal/httpclient"
-	"github.com/stacklok/toolhive-registry-server/internal/sources"
 )
 
 const upstreamOpenapiPath = "/openapi.yaml"
 
 var _ = Describe("UpstreamAPIHandler", func() {
 	var (
-		handler    *sources.UpstreamAPIHandler
+		handler    *upstreamAPIHandler
 		ctx        context.Context
 		mockServer *httptest.Server
 	)
 
 	BeforeEach(func() {
 		httpClient := httpclient.NewDefaultClient(0)
-		handler = sources.NewUpstreamAPIHandler(httpClient)
+		handler = NewUpstreamAPIHandler(httpClient)
 		ctx = context.Background()
 	})
 

--- a/internal/sources/factory.go
+++ b/internal/sources/factory.go
@@ -6,16 +6,18 @@ import (
 	"github.com/stacklok/toolhive-registry-server/internal/config"
 )
 
-// DefaultSourceHandlerFactory is the default implementation of SourceHandlerFactory
-type DefaultSourceHandlerFactory struct{}
+// defaultSourceHandlerFactory is the default implementation of SourceHandlerFactory
+type defaultSourceHandlerFactory struct{}
+
+var _ SourceHandlerFactory = (*defaultSourceHandlerFactory)(nil)
 
 // NewSourceHandlerFactory creates a new source handler factory
 func NewSourceHandlerFactory() SourceHandlerFactory {
-	return &DefaultSourceHandlerFactory{}
+	return &defaultSourceHandlerFactory{}
 }
 
 // CreateHandler creates a source handler for the given source type
-func (*DefaultSourceHandlerFactory) CreateHandler(sourceType string) (SourceHandler, error) {
+func (*defaultSourceHandlerFactory) CreateHandler(sourceType string) (SourceHandler, error) {
 	switch sourceType {
 	case config.SourceTypeGit:
 		return NewGitSourceHandler(), nil

--- a/internal/sources/factory_test.go
+++ b/internal/sources/factory_test.go
@@ -13,7 +13,6 @@ func TestNewSourceHandlerFactory(t *testing.T) {
 
 	factory := NewSourceHandlerFactory()
 	assert.NotNil(t, factory)
-	assert.IsType(t, &DefaultSourceHandlerFactory{}, factory)
 }
 
 func TestDefaultSourceHandlerFactory_CreateHandler(t *testing.T) {
@@ -32,19 +31,19 @@ func TestDefaultSourceHandlerFactory_CreateHandler(t *testing.T) {
 			name:         "file source type",
 			sourceType:   config.SourceTypeFile,
 			expectError:  false,
-			expectedType: &FileSourceHandler{},
+			expectedType: &fileSourceHandler{},
 		},
 		{
 			name:         "git source type",
 			sourceType:   config.SourceTypeGit,
 			expectError:  false,
-			expectedType: &GitSourceHandler{},
+			expectedType: &gitSourceHandler{},
 		},
 		{
 			name:         "api source type",
 			sourceType:   config.SourceTypeAPI,
 			expectError:  false,
-			expectedType: &APISourceHandler{},
+			expectedType: &apiSourceHandler{},
 		},
 		{
 			name:          "unsupported source type",

--- a/internal/sources/file.go
+++ b/internal/sources/file.go
@@ -9,20 +9,20 @@ import (
 	"github.com/stacklok/toolhive-registry-server/internal/config"
 )
 
-// FileSourceHandler handles registry data from local files
-type FileSourceHandler struct {
+// fileSourceHandler handles registry data from local files
+type fileSourceHandler struct {
 	validator SourceDataValidator
 }
 
 // NewFileSourceHandler creates a new file source handler
-func NewFileSourceHandler() *FileSourceHandler {
-	return &FileSourceHandler{
+func NewFileSourceHandler() SourceHandler {
+	return &fileSourceHandler{
 		validator: NewSourceDataValidator(),
 	}
 }
 
 // Validate validates the file source configuration
-func (*FileSourceHandler) Validate(source *config.SourceConfig) error {
+func (*fileSourceHandler) Validate(source *config.SourceConfig) error {
 	if source.Type != config.SourceTypeFile {
 		return fmt.Errorf("invalid source type: expected %s, got %s",
 			config.SourceTypeFile, source.Type)
@@ -41,7 +41,7 @@ func (*FileSourceHandler) Validate(source *config.SourceConfig) error {
 }
 
 // FetchRegistry retrieves registry data from the local file
-func (h *FileSourceHandler) FetchRegistry(ctx context.Context, registryConfig *config.Config) (*FetchResult, error) {
+func (h *fileSourceHandler) FetchRegistry(ctx context.Context, registryConfig *config.Config) (*FetchResult, error) {
 	// Fetch file data
 	data, hash, err := h.fetchFileData(ctx, registryConfig)
 	if err != nil {
@@ -59,7 +59,7 @@ func (h *FileSourceHandler) FetchRegistry(ctx context.Context, registryConfig *c
 }
 
 // fetchFileData reads the file and calculates its hash
-func (h *FileSourceHandler) fetchFileData(_ context.Context, registryConfig *config.Config) ([]byte, string, error) {
+func (h *fileSourceHandler) fetchFileData(_ context.Context, registryConfig *config.Config) ([]byte, string, error) {
 	// Validate source configuration
 	if err := h.Validate(&registryConfig.Source); err != nil {
 		return nil, "", fmt.Errorf("source validation failed: %w", err)
@@ -84,7 +84,7 @@ func (h *FileSourceHandler) fetchFileData(_ context.Context, registryConfig *con
 }
 
 // CurrentHash returns the current hash of the file without performing a full parse
-func (h *FileSourceHandler) CurrentHash(ctx context.Context, registryConfig *config.Config) (string, error) {
+func (h *fileSourceHandler) CurrentHash(ctx context.Context, registryConfig *config.Config) (string, error) {
 	// For file sources, we read and hash the file
 	// This is nearly as expensive as a full fetch, but maintains the interface
 	_, hash, err := h.fetchFileData(ctx, registryConfig)

--- a/internal/sources/file_test.go
+++ b/internal/sources/file_test.go
@@ -17,7 +17,9 @@ func TestNewFileSourceHandler(t *testing.T) {
 
 	handler := NewFileSourceHandler()
 	assert.NotNil(t, handler)
-	assert.NotNil(t, handler.validator)
+	// Cast to concrete type to access fields in tests (same package)
+	concreteHandler := handler.(*fileSourceHandler)
+	assert.NotNil(t, concreteHandler.validator)
 }
 
 func TestFileSourceHandler_Validate(t *testing.T) {

--- a/internal/sources/git.go
+++ b/internal/sources/git.go
@@ -18,22 +18,22 @@ const (
 	DefaultRegistryDataFile = "registry.json"
 )
 
-// GitSourceHandler handles registry data from Git repositories
-type GitSourceHandler struct {
+// gitSourceHandler handles registry data from Git repositories
+type gitSourceHandler struct {
 	gitClient git2.Client
 	validator SourceDataValidator
 }
 
 // NewGitSourceHandler creates a new Git source handler
-func NewGitSourceHandler() *GitSourceHandler {
-	return &GitSourceHandler{
+func NewGitSourceHandler() SourceHandler {
+	return &gitSourceHandler{
 		gitClient: git2.NewDefaultGitClient(),
 		validator: NewSourceDataValidator(),
 	}
 }
 
 // Validate validates the Git source configuration
-func (*GitSourceHandler) Validate(source *config.SourceConfig) error {
+func (*gitSourceHandler) Validate(source *config.SourceConfig) error {
 	if source.Type != config.SourceTypeGit {
 		return fmt.Errorf("invalid source type: expected %s, got %s",
 			config.SourceTypeGit, source.Type)
@@ -75,7 +75,7 @@ func (*GitSourceHandler) Validate(source *config.SourceConfig) error {
 }
 
 // FetchRegistry retrieves registry data from the Git repository
-func (h *GitSourceHandler) fetchRegistryData(ctx context.Context, cfg *config.Config) ([]byte, error) {
+func (h *gitSourceHandler) fetchRegistryData(ctx context.Context, cfg *config.Config) ([]byte, error) {
 
 	// Validate source configuration
 	if err := h.Validate(&cfg.Source); err != nil {
@@ -142,7 +142,7 @@ func (h *GitSourceHandler) fetchRegistryData(ctx context.Context, cfg *config.Co
 }
 
 // FetchRegistry retrieves registry data from the Git repository
-func (h *GitSourceHandler) FetchRegistry(ctx context.Context, cfg *config.Config) (*FetchResult, error) {
+func (h *gitSourceHandler) FetchRegistry(ctx context.Context, cfg *config.Config) (*FetchResult, error) {
 
 	registryData, err := h.fetchRegistryData(ctx, cfg)
 	if err != nil {
@@ -163,7 +163,7 @@ func (h *GitSourceHandler) FetchRegistry(ctx context.Context, cfg *config.Config
 }
 
 // CurrentHash returns the current hash of the source data after fetching the registry data
-func (h *GitSourceHandler) CurrentHash(ctx context.Context, cfg *config.Config) (string, error) {
+func (h *gitSourceHandler) CurrentHash(ctx context.Context, cfg *config.Config) (string, error) {
 	registryData, err := h.fetchRegistryData(ctx, cfg)
 	if err != nil {
 		return "", fmt.Errorf("failed to fetch registry data: %w", err)

--- a/internal/sources/git_test.go
+++ b/internal/sources/git_test.go
@@ -80,8 +80,10 @@ func TestNewGitSourceHandler(t *testing.T) {
 	handler := NewGitSourceHandler()
 
 	assert.NotNil(t, handler)
-	assert.NotNil(t, handler.gitClient)
-	assert.NotNil(t, handler.validator)
+	// Cast to concrete type to access fields in tests (same package)
+	concreteHandler := handler.(*gitSourceHandler)
+	assert.NotNil(t, concreteHandler.gitClient)
+	assert.NotNil(t, concreteHandler.validator)
 }
 
 func TestGitSourceHandler_Validate(t *testing.T) {
@@ -434,7 +436,7 @@ func TestGitSourceHandler_FetchRegistry(t *testing.T) {
 			tt.setupMocks(mockGitClient, mockValidator)
 
 			// Create handler with mocks
-			handler := &GitSourceHandler{
+			handler := &gitSourceHandler{
 				gitClient: mockGitClient,
 				validator: mockValidator,
 			}
@@ -571,7 +573,7 @@ func TestGitSourceHandler_CurrentHash(t *testing.T) {
 			tt.setupMocks(mockGitClient)
 
 			// Create handler with mocks
-			handler := &GitSourceHandler{
+			handler := &gitSourceHandler{
 				gitClient: mockGitClient,
 				validator: NewSourceDataValidator(), // Use real validator for hash tests
 			}
@@ -649,7 +651,7 @@ func TestGitSourceHandler_CleanupFailure(t *testing.T) {
 
 	mockValidator.On("ValidateData", testData, config.SourceFormatToolHive).Return(UpstreamRegistry, nil)
 
-	handler := &GitSourceHandler{
+	handler := &gitSourceHandler{
 		gitClient: mockGitClient,
 		validator: mockValidator,
 	}

--- a/internal/sources/storage_manager.go
+++ b/internal/sources/storage_manager.go
@@ -31,20 +31,20 @@ type StorageManager interface {
 	Delete(ctx context.Context, cfg *config.Config) error
 }
 
-// FileStorageManager implements StorageManager using local filesystem
-type FileStorageManager struct {
+// fileStorageManager implements StorageManager using local filesystem
+type fileStorageManager struct {
 	basePath string
 }
 
 // NewFileStorageManager creates a new file-based storage manager
 func NewFileStorageManager(basePath string) StorageManager {
-	return &FileStorageManager{
+	return &fileStorageManager{
 		basePath: basePath,
 	}
 }
 
 // Store saves the registry data to a JSON file
-func (f *FileStorageManager) Store(_ context.Context, _ *config.Config, reg *toolhivetypes.UpstreamRegistry) error {
+func (f *fileStorageManager) Store(_ context.Context, _ *config.Config, reg *toolhivetypes.UpstreamRegistry) error {
 	// Create base directory if it doesn't exist
 	if err := os.MkdirAll(f.basePath, 0750); err != nil {
 		return fmt.Errorf("failed to create storage directory: %w", err)
@@ -75,7 +75,7 @@ func (f *FileStorageManager) Store(_ context.Context, _ *config.Config, reg *too
 }
 
 // Get retrieves and parses registry data from the JSON file
-func (f *FileStorageManager) Get(_ context.Context, _ *config.Config) (*toolhivetypes.UpstreamRegistry, error) {
+func (f *fileStorageManager) Get(_ context.Context, _ *config.Config) (*toolhivetypes.UpstreamRegistry, error) {
 	filePath := filepath.Join(f.basePath, RegistryFileName)
 
 	// Read file
@@ -98,7 +98,7 @@ func (f *FileStorageManager) Get(_ context.Context, _ *config.Config) (*toolhive
 }
 
 // Delete removes the registry data file
-func (f *FileStorageManager) Delete(_ context.Context, _ *config.Config) error {
+func (f *fileStorageManager) Delete(_ context.Context, _ *config.Config) error {
 	filePath := filepath.Join(f.basePath, RegistryFileName)
 
 	if err := os.Remove(filePath); err != nil {

--- a/internal/sources/types.go
+++ b/internal/sources/types.go
@@ -70,16 +70,18 @@ type SourceHandlerFactory interface {
 	CreateHandler(sourceType string) (SourceHandler, error)
 }
 
-// DefaultSourceDataValidator is the default implementation of SourceValidator
-type DefaultSourceDataValidator struct{}
+// defaultSourceDataValidator is the default implementation of SourceValidator
+type defaultSourceDataValidator struct{}
+
+var _ SourceDataValidator = (*defaultSourceDataValidator)(nil)
 
 // NewSourceDataValidator creates a new default source validator
 func NewSourceDataValidator() SourceDataValidator {
-	return &DefaultSourceDataValidator{}
+	return &defaultSourceDataValidator{}
 }
 
 // ValidateData validates raw data and returns a parsed UpstreamRegistry
-func (*DefaultSourceDataValidator) ValidateData(data []byte, format string) (*toolhivetypes.UpstreamRegistry, error) {
+func (*defaultSourceDataValidator) ValidateData(data []byte, format string) (*toolhivetypes.UpstreamRegistry, error) {
 	if len(data) == 0 {
 		return nil, fmt.Errorf("data cannot be empty")
 	}

--- a/internal/sources/types_test.go
+++ b/internal/sources/types_test.go
@@ -134,7 +134,6 @@ func TestNewSourceDataValidator(t *testing.T) {
 
 	validator := NewSourceDataValidator()
 	assert.NotNil(t, validator)
-	assert.IsType(t, &DefaultSourceDataValidator{}, validator)
 }
 
 func TestDefaultSourceDataValidator_ValidateData(t *testing.T) {

--- a/internal/status/persistence.go
+++ b/internal/status/persistence.go
@@ -26,20 +26,20 @@ type StatusPersistence interface {
 	LoadStatus(ctx context.Context) (*SyncStatus, error)
 }
 
-// FileStatusPersistence implements StatusPersistence using local filesystem
-type FileStatusPersistence struct {
+// fileStatusPersistence implements StatusPersistence using local filesystem
+type fileStatusPersistence struct {
 	filePath string
 }
 
 // NewFileStatusPersistence creates a new file-based status persistence
 func NewFileStatusPersistence(filePath string) StatusPersistence {
-	return &FileStatusPersistence{
+	return &fileStatusPersistence{
 		filePath: filePath,
 	}
 }
 
 // SaveStatus saves the sync status to a JSON file
-func (f *FileStatusPersistence) SaveStatus(_ context.Context, status *SyncStatus) error {
+func (f *fileStatusPersistence) SaveStatus(_ context.Context, status *SyncStatus) error {
 	// Create directory if it doesn't exist
 	dir := filepath.Dir(f.filePath)
 	if err := os.MkdirAll(dir, 0750); err != nil {
@@ -70,7 +70,7 @@ func (f *FileStatusPersistence) SaveStatus(_ context.Context, status *SyncStatus
 
 // LoadStatus loads the sync status from a JSON file
 // Returns an empty SyncStatus if the file doesn't exist
-func (f *FileStatusPersistence) LoadStatus(_ context.Context) (*SyncStatus, error) {
+func (f *fileStatusPersistence) LoadStatus(_ context.Context) (*SyncStatus, error) {
 	// Read file
 	data, err := os.ReadFile(f.filePath)
 	if err != nil {

--- a/internal/sync/coordinator/coordinator.go
+++ b/internal/sync/coordinator/coordinator.go
@@ -25,8 +25,8 @@ type Coordinator interface {
 	GetStatus() *status.SyncStatus
 }
 
-// DefaultCoordinator is the default implementation of Coordinator
-type DefaultCoordinator struct {
+// defaultCoordinator is the default implementation of Coordinator
+type defaultCoordinator struct {
 	manager           pkgsync.Manager
 	statusPersistence status.StatusPersistence
 	config            *config.Config
@@ -46,7 +46,7 @@ func New(
 	statusPersistence status.StatusPersistence,
 	cfg *config.Config,
 ) Coordinator {
-	return &DefaultCoordinator{
+	return &defaultCoordinator{
 		manager:           manager,
 		statusPersistence: statusPersistence,
 		config:            cfg,
@@ -55,7 +55,7 @@ func New(
 }
 
 // Start begins background sync coordination
-func (c *DefaultCoordinator) Start(ctx context.Context) error {
+func (c *defaultCoordinator) Start(ctx context.Context) error {
 	logger.Info("Starting background sync coordinator")
 
 	// Create cancellable context for this coordinator
@@ -92,7 +92,7 @@ func (c *DefaultCoordinator) Start(ctx context.Context) error {
 }
 
 // Stop gracefully stops the coordinator
-func (c *DefaultCoordinator) Stop() error {
+func (c *defaultCoordinator) Stop() error {
 	if c.cancelFunc != nil {
 		logger.Info("Stopping sync coordinator...")
 		c.cancelFunc()
@@ -103,7 +103,7 @@ func (c *DefaultCoordinator) Stop() error {
 }
 
 // GetStatus returns current sync status (thread-safe)
-func (c *DefaultCoordinator) GetStatus() *status.SyncStatus {
+func (c *defaultCoordinator) GetStatus() *status.SyncStatus {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -116,7 +116,7 @@ func (c *DefaultCoordinator) GetStatus() *status.SyncStatus {
 }
 
 // loadOrInitializeStatus loads existing status or creates default
-func (c *DefaultCoordinator) loadOrInitializeStatus(ctx context.Context) {
+func (c *defaultCoordinator) loadOrInitializeStatus(ctx context.Context) {
 	syncStatus, err := c.statusPersistence.LoadStatus(ctx)
 	if err != nil {
 		logger.Warnf("Failed to load sync status, initializing with defaults: %v", err)
@@ -162,7 +162,7 @@ func (c *DefaultCoordinator) loadOrInitializeStatus(ctx context.Context) {
 }
 
 // withStatus executes a function while holding the status lock
-func (c *DefaultCoordinator) withStatus(fn func(*status.SyncStatus)) {
+func (c *defaultCoordinator) withStatus(fn func(*status.SyncStatus)) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	fn(c.cachedStatus)

--- a/internal/sync/coordinator/coordinator_test.go
+++ b/internal/sync/coordinator/coordinator_test.go
@@ -78,7 +78,7 @@ func TestPerformSync_StatusPersistence(t *testing.T) {
 				RegistryName: "test-registry",
 			}
 
-			coord := &DefaultCoordinator{
+			coord := &defaultCoordinator{
 				manager:           mockSyncMgr,
 				statusPersistence: statusPersistence,
 				config:            cfg,
@@ -137,7 +137,7 @@ func TestPerformSync_AlwaysPersists(t *testing.T) {
 		statusPersistence := status.NewFileStatusPersistence(statusFile)
 		cfg := &config.Config{RegistryName: "test"}
 
-		coord := &DefaultCoordinator{
+		coord := &defaultCoordinator{
 			manager:           mockSyncMgr,
 			statusPersistence: statusPersistence,
 			config:            cfg,
@@ -182,7 +182,7 @@ func TestPerformSync_SyncingPhasePersistedImmediately(t *testing.T) {
 			})
 
 		cfg := &config.Config{RegistryName: "test"}
-		coord := &DefaultCoordinator{
+		coord := &defaultCoordinator{
 			manager:           mockSyncMgr,
 			statusPersistence: statusPersistence,
 			config:            cfg,
@@ -275,7 +275,7 @@ func TestPerformSync_PhaseTransitions(t *testing.T) {
 				})
 
 			cfg := &config.Config{RegistryName: "test"}
-			coord := &DefaultCoordinator{
+			coord := &defaultCoordinator{
 				manager:           mockSyncMgr,
 				statusPersistence: statusPersistence,
 				config:            cfg,
@@ -348,7 +348,7 @@ func TestUpdateStatusForSkippedSync(t *testing.T) {
 			statusFile := filepath.Join(tempDir, "status.json")
 			statusPersistence := status.NewFileStatusPersistence(statusFile)
 
-			coord := &DefaultCoordinator{
+			coord := &defaultCoordinator{
 				statusPersistence: statusPersistence,
 				cachedStatus: &status.SyncStatus{
 					Phase:   tt.initialPhase,

--- a/internal/sync/coordinator/sync.go
+++ b/internal/sync/coordinator/sync.go
@@ -11,7 +11,7 @@ import (
 )
 
 // checkSync performs a sync check and updates status accordingly
-func (c *DefaultCoordinator) checkSync(ctx context.Context, checkType string) {
+func (c *defaultCoordinator) checkSync(ctx context.Context, checkType string) {
 	// Check if sync is needed (read status under lock)
 	// ShouldSync will return false with ReasonAlreadyInProgress if Phase == SyncPhaseSyncing
 	var shouldSync bool
@@ -29,7 +29,7 @@ func (c *DefaultCoordinator) checkSync(ctx context.Context, checkType string) {
 }
 
 // performSync executes a sync operation and updates status
-func (c *DefaultCoordinator) performSync(ctx context.Context) {
+func (c *defaultCoordinator) performSync(ctx context.Context) {
 	// Ensure status is persisted at the end, whatever the result
 	defer func() {
 		c.withStatus(func(syncStatus *status.SyncStatus) {
@@ -84,7 +84,7 @@ func (c *DefaultCoordinator) performSync(ctx context.Context) {
 }
 
 // updateStatusForSkippedSync updates the status when a sync check determines sync is not needed
-func (c *DefaultCoordinator) updateStatusForSkippedSync(ctx context.Context, reason string) {
+func (c *defaultCoordinator) updateStatusForSkippedSync(ctx context.Context, reason string) {
 	// Only update if we have a previous successful sync
 	// Don't overwrite Failed/Syncing states with "skipped" messages
 	c.withStatus(func(syncStatus *status.SyncStatus) {

--- a/internal/sync/detectors.go
+++ b/internal/sync/detectors.go
@@ -9,13 +9,13 @@ import (
 	"github.com/stacklok/toolhive-registry-server/internal/status"
 )
 
-// DefaultDataChangeDetector implements DataChangeDetector
-type DefaultDataChangeDetector struct {
+// defaultDataChangeDetector implements DataChangeDetector
+type defaultDataChangeDetector struct {
 	sourceHandlerFactory sources.SourceHandlerFactory
 }
 
 // IsDataChanged checks if source data has changed by comparing hashes
-func (d *DefaultDataChangeDetector) IsDataChanged(
+func (d *defaultDataChangeDetector) IsDataChanged(
 	ctx context.Context, cfg *config.Config, syncStatus *status.SyncStatus,
 ) (bool, error) {
 	// Check for hash in syncStatus first, then fallback
@@ -45,13 +45,13 @@ func (d *DefaultDataChangeDetector) IsDataChanged(
 	return currentHash != lastSyncHash, nil
 }
 
-// DefaultAutomaticSyncChecker implements AutomaticSyncChecker
-type DefaultAutomaticSyncChecker struct{}
+// defaultAutomaticSyncChecker implements AutomaticSyncChecker
+type defaultAutomaticSyncChecker struct{}
 
 // IsIntervalSyncNeeded checks if sync is needed based on time interval
 // Returns: (syncNeeded, nextSyncTime, error)
 // nextSyncTime is a future time when the next sync should occur, or zero time if no policy configured
-func (*DefaultAutomaticSyncChecker) IsIntervalSyncNeeded(
+func (*defaultAutomaticSyncChecker) IsIntervalSyncNeeded(
 	cfg *config.Config, syncStatus *status.SyncStatus,
 ) (bool, time.Time, error) {
 	if cfg.SyncPolicy == nil || cfg.SyncPolicy.Interval == "" {

--- a/internal/sync/detectors_test.go
+++ b/internal/sync/detectors_test.go
@@ -107,7 +107,7 @@ func TestDefaultDataChangeDetector_IsDataChanged(t *testing.T) {
 			t.Parallel()
 
 			sourceHandlerFactory := sources.NewSourceHandlerFactory()
-			detector := &DefaultDataChangeDetector{
+			detector := &defaultDataChangeDetector{
 				sourceHandlerFactory: sourceHandlerFactory,
 			}
 
@@ -235,7 +235,7 @@ func TestDefaultAutomaticSyncChecker_IsIntervalSyncNeeded(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			checker := &DefaultAutomaticSyncChecker{}
+			checker := &defaultAutomaticSyncChecker{}
 			syncNeeded, nextSyncTime, err := checker.IsIntervalSyncNeeded(tt.config, tt.status)
 
 			assert.Equal(t, tt.expectedSyncNeeded, syncNeeded, "Sync needed result should match expected")

--- a/internal/sync/manager.go
+++ b/internal/sync/manager.go
@@ -125,8 +125,8 @@ type AutomaticSyncChecker interface {
 	IsIntervalSyncNeeded(cfg *config.Config, syncStatus *status.SyncStatus) (bool, time.Time, error)
 }
 
-// DefaultSyncManager is the default implementation of Manager
-type DefaultSyncManager struct {
+// defaultSyncManager is the default implementation of Manager
+type defaultSyncManager struct {
 	sourceHandlerFactory sources.SourceHandlerFactory
 	storageManager       sources.StorageManager
 	filterService        filtering.FilterService
@@ -134,22 +134,22 @@ type DefaultSyncManager struct {
 	automaticSyncChecker AutomaticSyncChecker
 }
 
-// NewDefaultSyncManager creates a new DefaultSyncManager
+// NewDefaultSyncManager creates a new defaultSyncManager
 func NewDefaultSyncManager(
-	sourceHandlerFactory sources.SourceHandlerFactory, storageManager sources.StorageManager) *DefaultSyncManager {
-	return &DefaultSyncManager{
+	sourceHandlerFactory sources.SourceHandlerFactory, storageManager sources.StorageManager) Manager {
+	return &defaultSyncManager{
 		sourceHandlerFactory: sourceHandlerFactory,
 		storageManager:       storageManager,
 		filterService:        filtering.NewDefaultFilterService(),
-		dataChangeDetector:   &DefaultDataChangeDetector{sourceHandlerFactory: sourceHandlerFactory},
-		automaticSyncChecker: &DefaultAutomaticSyncChecker{},
+		dataChangeDetector:   &defaultDataChangeDetector{sourceHandlerFactory: sourceHandlerFactory},
+		automaticSyncChecker: &defaultAutomaticSyncChecker{},
 	}
 }
 
 // ShouldSync determines if a sync operation is needed
 // Returns: (shouldSync bool, reason string, nextSyncTime *time.Time)
 // nextSyncTime is always nil - timing is controlled by the configured sync interval
-func (s *DefaultSyncManager) ShouldSync(
+func (s *defaultSyncManager) ShouldSync(
 	ctx context.Context,
 	cfg *config.Config,
 	syncStatus *status.SyncStatus,
@@ -216,7 +216,7 @@ func (s *DefaultSyncManager) ShouldSync(
 }
 
 // isSyncNeededForState checks if sync is needed based on the registry's current state
-func (*DefaultSyncManager) isSyncNeededForState(syncStatus *status.SyncStatus) bool {
+func (*defaultSyncManager) isSyncNeededForState(syncStatus *status.SyncStatus) bool {
 	// If we have sync status, use it to determine sync readiness
 	if syncStatus != nil {
 		syncPhase := syncStatus.Phase
@@ -237,7 +237,7 @@ func (*DefaultSyncManager) isSyncNeededForState(syncStatus *status.SyncStatus) b
 }
 
 // isFilterChanged checks if the filter has changed compared to the last applied configuration
-func (*DefaultSyncManager) isFilterChanged(ctx context.Context, cfg *config.Config, syncStatus *status.SyncStatus) bool {
+func (*defaultSyncManager) isFilterChanged(ctx context.Context, cfg *config.Config, syncStatus *status.SyncStatus) bool {
 	logger := log.FromContext(ctx)
 
 	currentFilter := cfg.Filter
@@ -262,7 +262,7 @@ func (*DefaultSyncManager) isFilterChanged(ctx context.Context, cfg *config.Conf
 
 // PerformSync performs the complete sync operation for the Registry
 // Returns sync result on success, or error on failure
-func (s *DefaultSyncManager) PerformSync(
+func (s *defaultSyncManager) PerformSync(
 	ctx context.Context, cfg *config.Config,
 ) (*Result, *Error) {
 	// Fetch and process registry data
@@ -286,12 +286,12 @@ func (s *DefaultSyncManager) PerformSync(
 }
 
 // Delete cleans up storage resources for the Registry
-func (s *DefaultSyncManager) Delete(ctx context.Context, cfg *config.Config) error {
+func (s *defaultSyncManager) Delete(ctx context.Context, cfg *config.Config) error {
 	return s.storageManager.Delete(ctx, cfg)
 }
 
 // fetchAndProcessRegistryData handles source handler creation, validation, fetch, and filtering
-func (s *DefaultSyncManager) fetchAndProcessRegistryData(
+func (s *defaultSyncManager) fetchAndProcessRegistryData(
 	ctx context.Context,
 	cfg *config.Config) (*sources.FetchResult, *Error) {
 	ctxLogger := log.FromContext(ctx)
@@ -346,7 +346,7 @@ func (s *DefaultSyncManager) fetchAndProcessRegistryData(
 }
 
 // applyFilteringIfConfigured applies filtering to fetch result if registry has filter configuration
-func (s *DefaultSyncManager) applyFilteringIfConfigured(
+func (s *defaultSyncManager) applyFilteringIfConfigured(
 	ctx context.Context,
 	cfg *config.Config,
 	fetchResult *sources.FetchResult) *Error {
@@ -386,7 +386,7 @@ func (s *DefaultSyncManager) applyFilteringIfConfigured(
 }
 
 // storeRegistryData stores the registry data using the storage manager
-func (s *DefaultSyncManager) storeRegistryData(
+func (s *defaultSyncManager) storeRegistryData(
 	ctx context.Context,
 	cfg *config.Config,
 	fetchResult *sources.FetchResult) *Error {

--- a/internal/sync/manager_additional_test.go
+++ b/internal/sync/manager_additional_test.go
@@ -75,7 +75,7 @@ func TestDefaultSyncManager_isSyncNeededForState(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			manager := &DefaultSyncManager{}
+			manager := &defaultSyncManager{}
 			result := manager.isSyncNeededForState(tt.syncStatus)
 
 			assert.Equal(t, tt.expected, result, tt.description)
@@ -136,7 +136,7 @@ func TestConditionReasonConstants(t *testing.T) {
 func TestDefaultSyncManager_isSyncNeededForState_EdgeCases(t *testing.T) {
 	t.Parallel()
 
-	manager := &DefaultSyncManager{}
+	manager := &defaultSyncManager{}
 
 	t.Run("handles nil registry", func(t *testing.T) {
 		t.Parallel()
@@ -218,7 +218,7 @@ func TestDefaultSyncManager_isSyncNeededForState_Integration(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			manager := &DefaultSyncManager{}
+			manager := &defaultSyncManager{}
 			result := manager.isSyncNeededForState(tt.setupSyncStatus())
 
 			assert.Equal(t, tt.expectedSync, result, tt.description)

--- a/internal/sync/manager_test.go
+++ b/internal/sync/manager_test.go
@@ -29,7 +29,7 @@ func TestNewDefaultSyncManager(t *testing.T) {
 	syncManager := NewDefaultSyncManager(sourceHandlerFactory, storageManager)
 
 	assert.NotNil(t, syncManager)
-	assert.IsType(t, &DefaultSyncManager{}, syncManager)
+	assert.IsType(t, &defaultSyncManager{}, syncManager)
 }
 
 func TestDefaultSyncManager_ShouldSync(t *testing.T) {


### PR DESCRIPTION
This changes all Default* and handler implementation structs to private (lowercase) to enforce proper encapsulation. Constructors now return interface types instead of concrete types. Tests are adapted to use interface assertions where appropriate.

Fixes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)