### PR TITLE
Modify `RegistryService` interface

### DIFF
--- a/internal/service/mocks/mock_service.go
+++ b/internal/service/mocks/mock_service.go
@@ -14,6 +14,7 @@ import (
 	reflect "reflect"
 
 	v0 "github.com/modelcontextprotocol/registry/pkg/api/v0"
+	service "github.com/stacklok/toolhive-registry-server/internal/service"
 	registry "github.com/stacklok/toolhive/pkg/registry/registry"
 	gomock "go.uber.org/mock/gomock"
 )
@@ -72,32 +73,62 @@ func (mr *MockRegistryServiceMockRecorder) GetRegistry(ctx any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRegistry", reflect.TypeOf((*MockRegistryService)(nil).GetRegistry), ctx)
 }
 
-// GetServer mocks base method.
-func (m *MockRegistryService) GetServer(ctx context.Context, name string) (v0.ServerJSON, error) {
+// GetServerVersion mocks base method.
+func (m *MockRegistryService) GetServerVersion(ctx context.Context, opts ...service.Option[service.GetServerVersionOptions]) (*v0.ServerJSON, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetServer", ctx, name)
-	ret0, _ := ret[0].(v0.ServerJSON)
+	varargs := []any{ctx}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "GetServerVersion", varargs...)
+	ret0, _ := ret[0].(*v0.ServerJSON)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetServer indicates an expected call of GetServer.
-func (mr *MockRegistryServiceMockRecorder) GetServer(ctx, name any) *gomock.Call {
+// GetServerVersion indicates an expected call of GetServerVersion.
+func (mr *MockRegistryServiceMockRecorder) GetServerVersion(ctx any, opts ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetServer", reflect.TypeOf((*MockRegistryService)(nil).GetServer), ctx, name)
+	varargs := append([]any{ctx}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetServerVersion", reflect.TypeOf((*MockRegistryService)(nil).GetServerVersion), varargs...)
+}
+
+// ListServerVersions mocks base method.
+func (m *MockRegistryService) ListServerVersions(ctx context.Context, opts ...service.Option[service.ListServerVersionsOptions]) ([]*v0.ServerJSON, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{ctx}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ListServerVersions", varargs...)
+	ret0, _ := ret[0].([]*v0.ServerJSON)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListServerVersions indicates an expected call of ListServerVersions.
+func (mr *MockRegistryServiceMockRecorder) ListServerVersions(ctx any, opts ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{ctx}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListServerVersions", reflect.TypeOf((*MockRegistryService)(nil).ListServerVersions), varargs...)
 }
 
 // ListServers mocks base method.
-func (m *MockRegistryService) ListServers(ctx context.Context) ([]v0.ServerJSON, error) {
+func (m *MockRegistryService) ListServers(ctx context.Context, opts ...service.Option[service.ListServersOptions]) ([]*v0.ServerJSON, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListServers", ctx)
-	ret0, _ := ret[0].([]v0.ServerJSON)
+	varargs := []any{ctx}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ListServers", varargs...)
+	ret0, _ := ret[0].([]*v0.ServerJSON)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListServers indicates an expected call of ListServers.
-func (mr *MockRegistryServiceMockRecorder) ListServers(ctx any) *gomock.Call {
+func (mr *MockRegistryServiceMockRecorder) ListServers(ctx any, opts ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListServers", reflect.TypeOf((*MockRegistryService)(nil).ListServers), ctx)
+	varargs := append([]any{ctx}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListServers", reflect.TypeOf((*MockRegistryService)(nil).ListServers), varargs...)
 }

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -4,6 +4,8 @@ package service
 import (
 	"context"
 	"errors"
+	"fmt"
+	"time"
 
 	upstreamv0 "github.com/modelcontextprotocol/registry/pkg/api/v0"
 	toolhivetypes "github.com/stacklok/toolhive/pkg/registry/registry"
@@ -12,6 +14,8 @@ import (
 var (
 	// ErrServerNotFound is returned when a server is not found
 	ErrServerNotFound = errors.New("server not found")
+	// ErrNotImplemented is returned when a feature is not implemented
+	ErrNotImplemented = errors.New("not implemented")
 )
 
 //go:generate mockgen -destination=mocks/mock_service.go -package=mocks -source=service.go Service
@@ -25,8 +29,164 @@ type RegistryService interface {
 	GetRegistry(ctx context.Context) (*toolhivetypes.UpstreamRegistry, string, error) // returns registry, source, error
 
 	// ListServers returns all servers in the registry
-	ListServers(ctx context.Context) ([]upstreamv0.ServerJSON, error)
+	ListServers(ctx context.Context, opts ...Option[ListServersOptions]) ([]*upstreamv0.ServerJSON, error)
+
+	// ListServerVersions returns all versions of a specific server
+	ListServerVersions(ctx context.Context, opts ...Option[ListServerVersionsOptions]) ([]*upstreamv0.ServerJSON, error)
 
 	// GetServer returns a specific server by name
-	GetServer(ctx context.Context, name string) (upstreamv0.ServerJSON, error)
+	GetServerVersion(ctx context.Context, opts ...Option[GetServerVersionOptions]) (*upstreamv0.ServerJSON, error)
+}
+
+// Option is a function that sets an option for the ListServersOptions, ListServerVersionsOptions, or GetServerVersionOptions
+type Option[T ListServersOptions | ListServerVersionsOptions | GetServerVersionOptions] func(*T) error
+
+// ListServersOptions is the options for the ListServers operation
+type ListServersOptions struct {
+	Cursor       string
+	Limit        int
+	Search       string
+	UpdatedSince time.Time
+	Version      string
+	RegistryName string
+}
+
+// ListServerVersionsOptions is the options for the ListServerVersions operation
+type ListServerVersionsOptions struct {
+	Name  string
+	Next  *time.Time
+	Prev  *time.Time
+	Limit int
+}
+
+// GetServerVersionOptions is the options for the GetServerVersion operation
+type GetServerVersionOptions struct {
+	Name    string
+	Version string
+}
+
+// WithCursor sets the cursor for the ListServers operation
+func WithCursor(cursor string) Option[ListServersOptions] {
+	return func(o *ListServersOptions) error {
+		if cursor == "" {
+			return fmt.Errorf("invalid cursor: %s", cursor)
+		}
+		o.Cursor = cursor
+		return nil
+	}
+}
+
+// WithSearch sets the search for the ListServers operation
+func WithSearch(search string) Option[ListServersOptions] {
+	return func(o *ListServersOptions) error {
+		if search == "" {
+			return fmt.Errorf("invalid search: %s", search)
+		}
+		o.Search = search
+		return nil
+	}
+}
+
+// WithUpdatedSince sets the updated since for the ListServers operation
+func WithUpdatedSince(updatedSince time.Time) Option[ListServersOptions] {
+	return func(o *ListServersOptions) error {
+		if updatedSince.IsZero() {
+			return fmt.Errorf("invalid updated since: %s", updatedSince)
+		}
+		o.UpdatedSince = updatedSince
+		return nil
+	}
+}
+
+// WithRegistryName sets the registry name for the ListServers operation
+func WithRegistryName(registryName string) Option[ListServersOptions] {
+	return func(o *ListServersOptions) error {
+		if registryName == "" {
+			return fmt.Errorf("invalid registry name: %s", registryName)
+		}
+		o.RegistryName = registryName
+		return nil
+	}
+}
+
+// WithNext sets the next time for the ListServerVersions operation
+func WithNext(next time.Time) Option[ListServerVersionsOptions] {
+	return func(o *ListServerVersionsOptions) error {
+		if next.IsZero() {
+			return fmt.Errorf("invalid next: %s", next)
+		}
+		o.Next = &next
+		return nil
+	}
+}
+
+// WithPrev sets the prev time for the ListServerVersions operation
+func WithPrev(prev time.Time) Option[ListServerVersionsOptions] {
+	return func(o *ListServerVersionsOptions) error {
+		if prev.IsZero() {
+			return fmt.Errorf("invalid prev: %s", prev)
+		}
+		o.Prev = &prev
+		return nil
+	}
+}
+
+// WithVersion sets the version for the ListServers or GetServerVersion operation
+func WithVersion[T ListServersOptions | GetServerVersionOptions](version string) Option[T] {
+	return func(o *T) error {
+		if version == "" {
+			return fmt.Errorf("invalid version: %s", version)
+		}
+
+		switch o := any(o).(type) {
+		case *ListServersOptions:
+			o.Version = version
+		case *GetServerVersionOptions:
+			o.Version = version
+		default:
+			return fmt.Errorf("invalid option type: %T", o)
+		}
+
+		return nil
+	}
+}
+
+// WithName sets the name for the ListServerVersions or GetServerVersion operation
+func WithName[T ListServerVersionsOptions | GetServerVersionOptions](name string) Option[T] {
+	return func(o *T) error {
+		if name == "" {
+			return fmt.Errorf("invalid name: %s", name)
+		}
+
+		switch o := any(o).(type) {
+		case *ListServerVersionsOptions:
+			o.Name = name
+		case *GetServerVersionOptions:
+			o.Name = name
+		default:
+			return fmt.Errorf("invalid option type: %T", o)
+		}
+
+		return nil
+	}
+}
+
+// WithLimit sets the limit for the ListServers or ListServerVersions operation
+func WithLimit[T ListServersOptions | ListServerVersionsOptions](limit int) Option[T] {
+	return func(o *T) error {
+		if limit <= 0 {
+			return fmt.Errorf("invalid limit: %d", limit)
+		}
+
+		switch o := any(o).(type) {
+		case *ListServersOptions:
+			o.Limit = limit
+		case *ListServerVersionsOptions:
+			o.Limit = limit
+		default:
+			return fmt.Errorf("invalid option type: %T", o)
+		}
+
+		return nil
+	}
 }

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -1,0 +1,535 @@
+package service_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/aws/smithy-go/ptr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stacklok/toolhive-registry-server/internal/service"
+)
+
+func TestWithCursor(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name          string
+		cursor        string
+		expectedValue string
+	}{
+		{
+			name:          "valid cursor",
+			cursor:        "cursor123",
+			expectedValue: "cursor123",
+		},
+		{
+			name:          "empty cursor",
+			cursor:        "",
+			expectedValue: "",
+		},
+		{
+			name:          "cursor with special characters",
+			cursor:        "cursor-abc_123",
+			expectedValue: "cursor-abc_123",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			opt := service.WithCursor(tt.cursor)
+			opts := &service.ListServersOptions{}
+
+			err := opt(opts)
+
+			if tt.expectedValue == "" {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedValue, opts.Cursor)
+		})
+	}
+}
+
+func TestWithSearch(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name          string
+		search        string
+		expectedValue string
+	}{
+		{
+			name:          "valid search",
+			search:        "test server",
+			expectedValue: "test server",
+		},
+		{
+			name:          "empty search",
+			search:        "",
+			expectedValue: "",
+		},
+		{
+			name:          "search with multiple words",
+			search:        "mcp server registry",
+			expectedValue: "mcp server registry",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			opt := service.WithSearch(tt.search)
+			opts := &service.ListServersOptions{}
+
+			err := opt(opts)
+
+			if tt.expectedValue == "" {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedValue, opts.Search)
+		})
+	}
+}
+
+func TestWithUpdatedSince(t *testing.T) {
+	t.Parallel()
+	validTime := time.Date(2024, 1, 15, 10, 30, 0, 0, time.UTC)
+	zeroTime := time.Time{}
+
+	tests := []struct {
+		name          string
+		updatedSince  time.Time
+		expectedValue time.Time
+	}{
+		{
+			name:          "valid time",
+			updatedSince:  validTime,
+			expectedValue: validTime,
+		},
+		{
+			name:          "zero time",
+			updatedSince:  zeroTime,
+			expectedValue: zeroTime,
+		},
+		{
+			name:          "time in the past",
+			updatedSince:  time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),
+			expectedValue: time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			name:          "time in the future",
+			updatedSince:  time.Date(2030, 1, 1, 0, 0, 0, 0, time.UTC),
+			expectedValue: time.Date(2030, 1, 1, 0, 0, 0, 0, time.UTC),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			opt := service.WithUpdatedSince(tt.updatedSince)
+			opts := &service.ListServersOptions{}
+
+			err := opt(opts)
+
+			if tt.expectedValue.IsZero() {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedValue, opts.UpdatedSince)
+		})
+	}
+}
+
+func TestWithRegistryName(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name          string
+		registryName  string
+		expectedValue string
+	}{
+		{
+			name:          "valid registry name",
+			registryName:  "my-registry",
+			expectedValue: "my-registry",
+		},
+		{
+			name:          "empty registry name",
+			registryName:  "",
+			expectedValue: "",
+		},
+		{
+			name:          "registry name with underscores",
+			registryName:  "my_registry_v1",
+			expectedValue: "my_registry_v1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			opt := service.WithRegistryName(tt.registryName)
+			opts := &service.ListServersOptions{}
+
+			err := opt(opts)
+
+			if tt.expectedValue == "" {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedValue, opts.RegistryName)
+		})
+	}
+}
+
+func TestWithNext(t *testing.T) {
+	t.Parallel()
+	validTime := time.Date(2024, 1, 15, 10, 30, 0, 0, time.UTC)
+	zeroTime := time.Time{}
+
+	tests := []struct {
+		name          string
+		next          time.Time
+		expectedValue *time.Time
+	}{
+		{
+			name:          "valid time",
+			next:          validTime,
+			expectedValue: &validTime,
+		},
+		{
+			name:          "zero time",
+			next:          zeroTime,
+			expectedValue: nil,
+		},
+		{
+			name:          "time with nanoseconds",
+			next:          time.Date(2024, 1, 15, 10, 30, 45, 123456789, time.UTC),
+			expectedValue: ptr.Time(time.Date(2024, 1, 15, 10, 30, 45, 123456789, time.UTC)),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			opt := service.WithNext(tt.next)
+			opts := &service.ListServerVersionsOptions{}
+
+			err := opt(opts)
+
+			if tt.expectedValue == nil {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, *tt.expectedValue, *opts.Next)
+		})
+	}
+}
+
+func TestWithPrev(t *testing.T) {
+	t.Parallel()
+	validTime := time.Date(2024, 1, 15, 10, 30, 0, 0, time.UTC)
+	zeroTime := time.Time{}
+
+	tests := []struct {
+		name          string
+		prev          time.Time
+		expectedValue *time.Time
+	}{
+		{
+			name:          "valid time",
+			prev:          validTime,
+			expectedValue: &validTime,
+		},
+		{
+			name:          "zero time",
+			prev:          zeroTime,
+			expectedValue: nil,
+		},
+		{
+			name:          "time in the past",
+			prev:          time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),
+			expectedValue: ptr.Time(time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			opt := service.WithPrev(tt.prev)
+			opts := &service.ListServerVersionsOptions{}
+
+			err := opt(opts)
+
+			if tt.expectedValue == nil {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, *tt.expectedValue, *opts.Prev)
+		})
+	}
+}
+
+func TestWithVersion(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name          string
+		version       string
+		optionType    string // "ListServersOptions" or "GetServerVersionOptions"
+		expectedValue string
+	}{
+		{
+			name:          "valid version for ListServersOptions",
+			version:       "1.0.0",
+			optionType:    "ListServersOptions",
+			expectedValue: "1.0.0",
+		},
+		{
+			name:          "valid version for GetServerVersionOptions",
+			version:       "2.3.4",
+			optionType:    "GetServerVersionOptions",
+			expectedValue: "2.3.4",
+		},
+		{
+			name:          "empty version for ListServersOptions",
+			version:       "",
+			optionType:    "ListServersOptions",
+			expectedValue: "",
+		},
+		{
+			name:          "empty version for GetServerVersionOptions",
+			version:       "",
+			optionType:    "GetServerVersionOptions",
+			expectedValue: "",
+		},
+		{
+			name:          "version with pre-release for ListServersOptions",
+			version:       "1.0.0-alpha.1",
+			optionType:    "ListServersOptions",
+			expectedValue: "1.0.0-alpha.1",
+		},
+		{
+			name:          "version with build metadata for GetServerVersionOptions",
+			version:       "1.0.0+build.123",
+			optionType:    "GetServerVersionOptions",
+			expectedValue: "1.0.0+build.123",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			switch tt.optionType {
+			case "ListServersOptions":
+				opt := service.WithVersion[service.ListServersOptions](tt.version)
+				opts := &service.ListServersOptions{}
+				err := opt(opts)
+
+				if tt.expectedValue == "" {
+					require.Error(t, err)
+					return
+				}
+
+				require.NoError(t, err)
+				assert.Equal(t, tt.expectedValue, opts.Version)
+			case "GetServerVersionOptions":
+				opt := service.WithVersion[service.GetServerVersionOptions](tt.version)
+				opts := &service.GetServerVersionOptions{}
+				err := opt(opts)
+
+				if tt.expectedValue == "" {
+					require.Error(t, err)
+					return
+				}
+
+				require.NoError(t, err)
+				assert.Equal(t, tt.expectedValue, opts.Version)
+			}
+		})
+	}
+}
+
+func TestWithName(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name          string
+		serverName    string
+		optionType    string // "ListServerVersionsOptions" or "GetServerVersionOptions"
+		expectedValue string
+	}{
+		{
+			name:          "valid name for ListServerVersionsOptions",
+			serverName:    "my-server",
+			optionType:    "ListServerVersionsOptions",
+			expectedValue: "my-server",
+		},
+		{
+			name:          "valid name for GetServerVersionOptions",
+			serverName:    "test-server",
+			optionType:    "GetServerVersionOptions",
+			expectedValue: "test-server",
+		},
+		{
+			name:          "empty name for ListServerVersionsOptions",
+			serverName:    "",
+			optionType:    "ListServerVersionsOptions",
+			expectedValue: "",
+		},
+		{
+			name:          "empty name for GetServerVersionOptions",
+			serverName:    "",
+			optionType:    "GetServerVersionOptions",
+			expectedValue: "",
+		},
+		{
+			name:          "name with underscores for ListServerVersionsOptions",
+			serverName:    "my_server_v1",
+			optionType:    "ListServerVersionsOptions",
+			expectedValue: "my_server_v1",
+		},
+		{
+			name:          "name with hyphens for GetServerVersionOptions",
+			serverName:    "my-server-v2",
+			optionType:    "GetServerVersionOptions",
+			expectedValue: "my-server-v2",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			switch tt.optionType {
+			case "ListServerVersionsOptions":
+				opt := service.WithName[service.ListServerVersionsOptions](tt.serverName)
+				opts := &service.ListServerVersionsOptions{}
+				err := opt(opts)
+
+				if tt.expectedValue == "" {
+					require.Error(t, err)
+					return
+				}
+
+				require.NoError(t, err)
+				assert.Equal(t, tt.expectedValue, opts.Name)
+			case "GetServerVersionOptions":
+				opt := service.WithName[service.GetServerVersionOptions](tt.serverName)
+				opts := &service.GetServerVersionOptions{}
+				err := opt(opts)
+
+				if tt.expectedValue == "" {
+					require.Error(t, err)
+					return
+				}
+
+				require.NoError(t, err)
+				assert.Equal(t, tt.expectedValue, opts.Name)
+			}
+		})
+	}
+}
+
+func TestWithLimit(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name          string
+		limit         int
+		optionType    string // "ListServersOptions" or "ListServerVersionsOptions"
+		expectedValue int
+	}{
+		{
+			name:          "valid limit for ListServersOptions",
+			limit:         10,
+			optionType:    "ListServersOptions",
+			expectedValue: 10,
+		},
+		{
+			name:          "valid limit for ListServerVersionsOptions",
+			limit:         20,
+			optionType:    "ListServerVersionsOptions",
+			expectedValue: 20,
+		},
+		{
+			name:          "zero limit for ListServersOptions",
+			limit:         0,
+			optionType:    "ListServersOptions",
+			expectedValue: 0,
+		},
+		{
+			name:          "zero limit for ListServerVersionsOptions",
+			limit:         0,
+			optionType:    "ListServerVersionsOptions",
+			expectedValue: 0,
+		},
+		{
+			name:          "negative limit for ListServersOptions",
+			limit:         -5,
+			optionType:    "ListServersOptions",
+			expectedValue: 0,
+		},
+		{
+			name:          "negative limit for ListServerVersionsOptions",
+			limit:         -10,
+			optionType:    "ListServerVersionsOptions",
+			expectedValue: 0,
+		},
+		{
+			name:          "large limit for ListServersOptions",
+			limit:         1000,
+			optionType:    "ListServersOptions",
+			expectedValue: 1000,
+		},
+		{
+			name:          "limit of 1 for ListServerVersionsOptions",
+			limit:         1,
+			optionType:    "ListServerVersionsOptions",
+			expectedValue: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			switch tt.optionType {
+			case "ListServersOptions":
+				opt := service.WithLimit[service.ListServersOptions](tt.limit)
+				opts := &service.ListServersOptions{}
+				err := opt(opts)
+
+				if tt.expectedValue == 0 {
+					require.Error(t, err)
+					return
+				}
+
+				require.NoError(t, err)
+				assert.Equal(t, tt.expectedValue, opts.Limit)
+			case "ListServerVersionsOptions":
+				opt := service.WithLimit[service.ListServerVersionsOptions](tt.limit)
+				opts := &service.ListServerVersionsOptions{}
+				err := opt(opts)
+
+				if tt.expectedValue == 0 {
+					require.Error(t, err)
+					return
+				}
+
+				require.NoError(t, err)
+				assert.Equal(t, tt.expectedValue, opts.Limit)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This change modifies existing interface methods and adds a new one to accomodate for the need of Upstream API implementation.

This is part of the work to add a db-backed service implementation.