### PR TITLE
Add database service support to app

### DIFF
--- a/internal/app/builder_test.go
+++ b/internal/app/builder_test.go
@@ -483,16 +483,18 @@ func TestBuildServiceComponents(t *testing.T) {
 			// Store original provider to check if it was set
 			originalProvider := tt.config.registryProvider
 
-			svc, err := buildServiceComponents(ctx, tt.config)
+			svc, cleanupFunc, err := buildServiceComponents(ctx, tt.config)
 
 			if tt.wantErr {
 				require.Error(t, err)
 				assert.Nil(t, svc)
+				assert.Nil(t, cleanupFunc)
 				return
 			}
 
 			require.NoError(t, err)
 			require.NotNil(t, svc)
+			require.NotNil(t, cleanupFunc)
 
 			if tt.verify != nil {
 				tt.verify(t, svc, tt.config, originalProvider)


### PR DESCRIPTION
This change allows the application to start using a DB. The needed connection pool is initialized as part of the application configuration and the `Stop()` routine is responsible for shutting it down.