### PR TITLE
Add RFC 9728 protected resource metadata endpoint

### DIFF
--- a/internal/auth/well_known.go
+++ b/internal/auth/well_known.go
@@ -1,0 +1,61 @@
+package auth
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+
+	"github.com/stacklok/toolhive/pkg/logger"
+
+	"github.com/stacklok/toolhive-registry-server/internal/config"
+)
+
+// protectedResourceMetadata represents RFC 9728 OAuth 2.0 Protected Resource Metadata
+type protectedResourceMetadata struct {
+	Resource               string   `json:"resource"`
+	AuthorizationServers   []string `json:"authorization_servers"`
+	BearerMethodsSupported []string `json:"bearer_methods_supported,omitempty"`
+	ScopesSupported        []string `json:"scopes_supported,omitempty"`
+}
+
+// newProtectedResourceHandler creates an RFC 9728 compliant handler.
+// Returns an error if required parameters are missing per RFC 9728:
+// - resourceURL must not be empty
+// - authorizationServers must contain at least one entry
+func newProtectedResourceHandler(
+	resourceURL string,
+	authorizationServers []string,
+	scopes []string,
+) (http.Handler, error) {
+	// Validate required parameters per RFC 9728
+	if resourceURL == "" {
+		return nil, errors.New("resourceURL is required")
+	}
+	if len(authorizationServers) == 0 {
+		return nil, errors.New("at least one authorization server is required")
+	}
+
+	// Apply default scopes if not specified (defensive copy to avoid aliasing)
+	if len(scopes) == 0 {
+		scopes = append([]string{}, config.DefaultScopes...)
+	}
+
+	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		metadata := protectedResourceMetadata{
+			Resource:               resourceURL,
+			AuthorizationServers:   authorizationServers,
+			BearerMethodsSupported: []string{"header"},
+			ScopesSupported:        scopes,
+		}
+
+		data, err := json.Marshal(metadata)
+		if err != nil {
+			logger.Errorf("auth: failed to encode protected resource metadata: %v", err)
+			http.Error(w, `{"error":"internal server error"}`, http.StatusInternalServerError)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(data)
+	}), nil
+}

--- a/internal/auth/well_known_test.go
+++ b/internal/auth/well_known_test.go
@@ -1,0 +1,135 @@
+package auth
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stacklok/toolhive-registry-server/internal/config"
+)
+
+func TestNewProtectedResourceHandler(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		resourceURL     string
+		authServers     []string
+		scopes          []string
+		wantResource    string
+		wantAuthServers []string
+		wantScopes      []string
+	}{
+		{
+			name:            "full configuration",
+			resourceURL:     "https://api.example.com",
+			authServers:     []string{"https://auth.example.com"},
+			scopes:          []string{"read", "write"},
+			wantResource:    "https://api.example.com",
+			wantAuthServers: []string{"https://auth.example.com"},
+			wantScopes:      []string{"read", "write"},
+		},
+		{
+			name:            "default scopes applied when nil",
+			resourceURL:     "https://api.example.com",
+			authServers:     []string{"https://auth.example.com"},
+			scopes:          nil,
+			wantResource:    "https://api.example.com",
+			wantAuthServers: []string{"https://auth.example.com"},
+			wantScopes:      config.DefaultScopes,
+		},
+		{
+			name:            "default scopes applied when empty",
+			resourceURL:     "https://api.example.com",
+			authServers:     []string{"https://auth.example.com"},
+			scopes:          []string{},
+			wantResource:    "https://api.example.com",
+			wantAuthServers: []string{"https://auth.example.com"},
+			wantScopes:      config.DefaultScopes,
+		},
+		{
+			name:            "multiple auth servers",
+			resourceURL:     "https://api.example.com",
+			authServers:     []string{"https://auth1.example.com", "https://auth2.example.com"},
+			scopes:          []string{"admin"},
+			wantResource:    "https://api.example.com",
+			wantAuthServers: []string{"https://auth1.example.com", "https://auth2.example.com"},
+			wantScopes:      []string{"admin"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			handler, err := newProtectedResourceHandler(tt.resourceURL, tt.authServers, tt.scopes)
+			require.NoError(t, err)
+			require.NotNil(t, handler)
+
+			req := httptest.NewRequest("GET", "/.well-known/oauth-protected-resource", nil)
+			rr := httptest.NewRecorder()
+			handler.ServeHTTP(rr, req)
+
+			assert.Equal(t, http.StatusOK, rr.Code)
+			assert.Equal(t, "application/json", rr.Header().Get("Content-Type"))
+
+			var metadata protectedResourceMetadata
+			err = json.Unmarshal(rr.Body.Bytes(), &metadata)
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.wantResource, metadata.Resource)
+			assert.Equal(t, tt.wantAuthServers, metadata.AuthorizationServers)
+			assert.Equal(t, tt.wantScopes, metadata.ScopesSupported)
+			assert.Contains(t, metadata.BearerMethodsSupported, "header")
+		})
+	}
+}
+
+func TestNewProtectedResourceHandler_ValidationErrors(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		resourceURL string
+		authServers []string
+		scopes      []string
+		wantErr     string
+	}{
+		{
+			name:        "empty resource URL",
+			resourceURL: "",
+			authServers: []string{"https://auth.example.com"},
+			scopes:      []string{"read"},
+			wantErr:     "resourceURL is required",
+		},
+		{
+			name:        "nil auth servers",
+			resourceURL: "https://api.example.com",
+			authServers: nil,
+			scopes:      []string{"read"},
+			wantErr:     "at least one authorization server is required",
+		},
+		{
+			name:        "empty auth servers",
+			resourceURL: "https://api.example.com",
+			authServers: []string{},
+			scopes:      []string{"read"},
+			wantErr:     "at least one authorization server is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			handler, err := newProtectedResourceHandler(tt.resourceURL, tt.authServers, tt.scopes)
+			require.Error(t, err)
+			assert.Nil(t, handler)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -233,6 +233,17 @@ type OAuthConfig struct {
 	Realm string `yaml:"realm,omitempty"`
 }
 
+// DefaultScopes are the default OAuth scopes for the registry when not configured
+var DefaultScopes = []string{"mcp-registry:read", "mcp-registry:write"}
+
+// GetScopes returns the configured OAuth scopes or defaults if not specified
+func (o *OAuthConfig) GetScopes() []string {
+	if len(o.ScopesSupported) == 0 {
+		return DefaultScopes
+	}
+	return o.ScopesSupported
+}
+
 // OAuthProviderConfig defines configuration for an OAuth/OIDC provider
 type OAuthProviderConfig struct {
 	// Name is a unique identifier for this provider (e.g., "kubernetes", "keycloak")


### PR DESCRIPTION
Implement /.well-known/oauth-protected-resource handler for OAuth 2.0 Protected Resource Metadata discovery.

- NewProtectedResourceHandler creates compliant metadata endpoint
- Returns resource URL, authorization servers, and supported scopes
- Defaults to standard MCP registry scopes when not configured