### PR TITLE
Add missing operational endpoints to public paths

### DIFF
--- a/internal/app/builder.go
+++ b/internal/app/builder.go
@@ -38,7 +38,7 @@ const (
 )
 
 // defaultPublicPaths are paths that never require authentication
-var defaultPublicPaths = []string{"/health", "/docs", "/swagger", "/.well-known"}
+var defaultPublicPaths = []string{"/health", "/readiness", "/version", "/openapi.json", "/.well-known"}
 
 // RegistryAppOptions is a function that configures the registry app builder
 type RegistryAppOptions func(*registryAppConfig) error


### PR DESCRIPTION
Add /readiness, /version, and /openapi.json to the default public paths
that bypass authentication. Remove /docs and /swagger which are not
served by the registry server.
