### PR TITLE
Change PK constraint on mcp_server_package table

### DIFF
--- a/database/migrations/000003_fix_package_pk.down.sql
+++ b/database/migrations/000003_fix_package_pk.down.sql
@@ -1,0 +1,8 @@
+-- Revert mcp_server_package primary key back to server_id only
+
+-- Drop the composite primary key
+ALTER TABLE mcp_server_package DROP CONSTRAINT mcp_server_package_pkey;
+
+-- Add back the original primary key
+-- Note: This will fail if there are multiple packages per server
+ALTER TABLE mcp_server_package ADD PRIMARY KEY (server_id);

--- a/database/migrations/000003_fix_package_pk.up.sql
+++ b/database/migrations/000003_fix_package_pk.up.sql
@@ -1,0 +1,7 @@
+-- Change mcp_server_package primary key to allow multiple packages per server
+
+-- Drop the existing primary key constraint
+ALTER TABLE mcp_server_package DROP CONSTRAINT mcp_server_package_pkey;
+
+-- Add the new composite primary key
+ALTER TABLE mcp_server_package ADD PRIMARY KEY (server_id, registry_type, pkg_identifier);


### PR DESCRIPTION
Previously, the PK was inadvertantly set to be the same as the foreign key. This led to a constraint where only package could be associated with a registry at once. This didn't show up in testing so far since our sample data only includes a single package per MCP server.

This changes the PK to the triple of (server_id, registry_type, package_identifier). This should provide a meaningful definition of package identity for our needs.