### PR TITLE
Remove redundant columns from temporary tables

### DIFF
--- a/database/queries/temp_tables.sql
+++ b/database/queries/temp_tables.sql
@@ -5,22 +5,9 @@
 -- Temp Server Table Operations
 
 -- name: CreateTempServerTable :exec
-CREATE TEMP TABLE temp_mcp_server (
-    name TEXT NOT NULL,
-    version TEXT NOT NULL,
-    reg_id UUID NOT NULL,
-    created_at TIMESTAMP WITH TIME ZONE,
-    updated_at TIMESTAMP WITH TIME ZONE,
-    description TEXT,
-    title TEXT,
-    website TEXT,
-    upstream_meta JSONB,
-    server_meta JSONB,
-    repository_url TEXT,
-    repository_id TEXT,
-    repository_subfolder TEXT,
-    repository_type TEXT
-) ON COMMIT DROP;
+CREATE TEMP TABLE temp_mcp_server ON COMMIT DROP AS
+SELECT * FROM mcp_server
+  WITH NO DATA;
 
 -- name: UpsertServersFromTemp :exec
 INSERT INTO mcp_server (
@@ -49,21 +36,9 @@ DO UPDATE SET
 -- Temp Package Table Operations
 
 -- name: CreateTempPackageTable :exec
-CREATE TEMP TABLE temp_mcp_server_package (
-    server_id UUID NOT NULL,
-    registry_type TEXT NOT NULL,
-    pkg_registry_url TEXT NOT NULL,
-    pkg_identifier TEXT NOT NULL,
-    pkg_version TEXT NOT NULL,
-    runtime_hint TEXT,
-    runtime_arguments TEXT[],
-    package_arguments TEXT[],
-    env_vars TEXT[],
-    sha256_hash TEXT,
-    transport TEXT NOT NULL,
-    transport_url TEXT,
-    transport_headers TEXT[]
-) ON COMMIT DROP;
+CREATE TEMP TABLE temp_mcp_server_package ON COMMIT DROP AS
+SELECT * FROM mcp_server_package
+  WITH NO DATA;
 
 -- name: UpsertPackagesFromTemp :exec
 INSERT INTO mcp_server_package (
@@ -99,12 +74,9 @@ WHERE server_id = ANY(sqlc.slice(server_ids)::UUID[])
 -- Temp Remote Table Operations
 
 -- name: CreateTempRemoteTable :exec
-CREATE TEMP TABLE temp_mcp_server_remote (
-    server_id UUID NOT NULL,
-    transport TEXT NOT NULL,
-    transport_url TEXT NOT NULL,
-    transport_headers TEXT[]
-) ON COMMIT DROP;
+CREATE TEMP TABLE temp_mcp_server_remote ON COMMIT DROP AS
+SELECT * FROM mcp_server_remote
+  WITH NO DATA;
 
 -- name: UpsertRemotesFromTemp :exec
 INSERT INTO mcp_server_remote (server_id, transport, transport_url, transport_headers)
@@ -123,12 +95,9 @@ WHERE server_id = ANY(sqlc.slice(server_ids)::UUID[])
 -- Temp Icon Table Operations
 
 -- name: CreateTempIconTable :exec
-CREATE TEMP TABLE temp_mcp_server_icon (
-    server_id UUID NOT NULL,
-    source_uri TEXT NOT NULL,
-    mime_type TEXT NOT NULL,
-    theme TEXT NOT NULL
-) ON COMMIT DROP;
+CREATE TEMP TABLE temp_mcp_server_icon ON COMMIT DROP AS
+SELECT * FROM mcp_server_icon
+  WITH NO DATA;
 
 -- name: UpsertIconsFromTemp :exec
 INSERT INTO mcp_server_icon (server_id, source_uri, mime_type, theme)
@@ -140,6 +109,6 @@ DO NOTHING;
 -- name: DeleteOrphanedIcons :exec
 DELETE FROM mcp_server_icon
 WHERE server_id = ANY(sqlc.slice(server_ids)::UUID[])
-  AND (server_id, source_uri, mime_type, theme::text) NOT IN (
+  AND (server_id, source_uri, mime_type, theme) NOT IN (
     SELECT server_id, source_uri, mime_type, theme FROM temp_mcp_server_icon
   );

--- a/database/testcontainers.go
+++ b/database/testcontainers.go
@@ -17,10 +17,13 @@ func (*nopLogger) Printf(_ string, _ ...any) {}
 
 var _ tclog.Logger = (*nopLogger)(nil)
 
-var (
-	dbName = "testdb"
-	dbUser = "testuser"
-	dbPass = "testpass"
+const (
+	// DBName is the name of the test database
+	DBName = "testdb"
+	// DBUser is the username for the root user of the test database
+	DBUser = "testuser"
+	// DBPass is the password for the root user of the test database
+	DBPass = "testpass"
 )
 
 // SetupTestDBContainer creates a Postgres container using testcontainers and returns a connection to the database
@@ -33,11 +36,12 @@ func SetupTestDBContainer(t *testing.T, ctx context.Context) (*pgx.Conn, func())
 	postgresContainer, err := postgres.Run(
 		ctx,
 		"postgres:16-alpine",
-		postgres.WithDatabase(dbName),
-		postgres.WithUsername(dbUser),
-		postgres.WithPassword(dbPass),
+		postgres.WithDatabase(DBName),
+		postgres.WithUsername(DBUser),
+		postgres.WithPassword(DBPass),
 		postgres.BasicWaitStrategies(),
 		tc.WithLogger(&nopLogger{}),
+		tc.WithCmd("postgres", "-c", "fsync=off", "-c", "log_statement=all"),
 	)
 	require.NoError(t, err)
 

--- a/internal/db/sqlc/temp_tables.sql.go
+++ b/internal/db/sqlc/temp_tables.sql.go
@@ -13,12 +13,9 @@ import (
 
 const createTempIconTable = `-- name: CreateTempIconTable :exec
 
-CREATE TEMP TABLE temp_mcp_server_icon (
-    server_id UUID NOT NULL,
-    source_uri TEXT NOT NULL,
-    mime_type TEXT NOT NULL,
-    theme TEXT NOT NULL
-) ON COMMIT DROP
+CREATE TEMP TABLE temp_mcp_server_icon ON COMMIT DROP AS
+SELECT server_id, source_uri, mime_type, theme FROM mcp_server_icon
+  WITH NO DATA
 `
 
 // Temp Icon Table Operations
@@ -29,21 +26,9 @@ func (q *Queries) CreateTempIconTable(ctx context.Context) error {
 
 const createTempPackageTable = `-- name: CreateTempPackageTable :exec
 
-CREATE TEMP TABLE temp_mcp_server_package (
-    server_id UUID NOT NULL,
-    registry_type TEXT NOT NULL,
-    pkg_registry_url TEXT NOT NULL,
-    pkg_identifier TEXT NOT NULL,
-    pkg_version TEXT NOT NULL,
-    runtime_hint TEXT,
-    runtime_arguments TEXT[],
-    package_arguments TEXT[],
-    env_vars TEXT[],
-    sha256_hash TEXT,
-    transport TEXT NOT NULL,
-    transport_url TEXT,
-    transport_headers TEXT[]
-) ON COMMIT DROP
+CREATE TEMP TABLE temp_mcp_server_package ON COMMIT DROP AS
+SELECT server_id, registry_type, pkg_registry_url, pkg_identifier, pkg_version, runtime_hint, runtime_arguments, package_arguments, env_vars, sha256_hash, transport, transport_url, transport_headers FROM mcp_server_package
+  WITH NO DATA
 `
 
 // Temp Package Table Operations
@@ -54,12 +39,9 @@ func (q *Queries) CreateTempPackageTable(ctx context.Context) error {
 
 const createTempRemoteTable = `-- name: CreateTempRemoteTable :exec
 
-CREATE TEMP TABLE temp_mcp_server_remote (
-    server_id UUID NOT NULL,
-    transport TEXT NOT NULL,
-    transport_url TEXT NOT NULL,
-    transport_headers TEXT[]
-) ON COMMIT DROP
+CREATE TEMP TABLE temp_mcp_server_remote ON COMMIT DROP AS
+SELECT server_id, transport, transport_url, transport_headers FROM mcp_server_remote
+  WITH NO DATA
 `
 
 // Temp Remote Table Operations
@@ -71,22 +53,9 @@ func (q *Queries) CreateTempRemoteTable(ctx context.Context) error {
 const createTempServerTable = `-- name: CreateTempServerTable :exec
 
 
-CREATE TEMP TABLE temp_mcp_server (
-    name TEXT NOT NULL,
-    version TEXT NOT NULL,
-    reg_id UUID NOT NULL,
-    created_at TIMESTAMP WITH TIME ZONE,
-    updated_at TIMESTAMP WITH TIME ZONE,
-    description TEXT,
-    title TEXT,
-    website TEXT,
-    upstream_meta JSONB,
-    server_meta JSONB,
-    repository_url TEXT,
-    repository_id TEXT,
-    repository_subfolder TEXT,
-    repository_type TEXT
-) ON COMMIT DROP
+CREATE TEMP TABLE temp_mcp_server ON COMMIT DROP AS
+SELECT id, name, version, reg_id, created_at, updated_at, description, title, website, upstream_meta, server_meta, repository_url, repository_id, repository_subfolder, repository_type FROM mcp_server
+  WITH NO DATA
 `
 
 // Temporary table operations for bulk sync
@@ -101,7 +70,7 @@ func (q *Queries) CreateTempServerTable(ctx context.Context) error {
 const deleteOrphanedIcons = `-- name: DeleteOrphanedIcons :exec
 DELETE FROM mcp_server_icon
 WHERE server_id = ANY($1::UUID[])
-  AND (server_id, source_uri, mime_type, theme::text) NOT IN (
+  AND (server_id, source_uri, mime_type, theme) NOT IN (
     SELECT server_id, source_uri, mime_type, theme FROM temp_mcp_server_icon
   )
 `


### PR DESCRIPTION
This change refactors some SQL statements involving temporary tables removing columns and their types from the statement itself. The reason is that it's tricky to detect when these columns get out of sync with the actual table, and the compiled version of those statements still contains the full list, so it's basically the best of both worlds!

I also took the chance to improve the db setup routine dropping environment variables watched by `libpq`. The net result is that the test db is much more similar to an actual production deployment and is guaranteed to not use any configuration local to the developer's machine.