### PR TITLE
Add proper URL path parameter encoding/decoding

### DIFF
--- a/internal/api/common/url.go
+++ b/internal/api/common/url.go
@@ -1,0 +1,39 @@
+// Package common provides shared HTTP utility functions for API handlers.
+package common
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// GetAndValidateURLParam extracts, decodes, and validates a URL parameter from the request.
+// Returns the decoded value or an error if invalid.
+// Validation rules:
+// - Must not be empty after trimming whitespace
+// - Must not contain any whitespace characters
+func GetAndValidateURLParam(r *http.Request, paramName string) (string, error) {
+	// Extract from chi router
+	encodedValue := chi.URLParam(r, paramName)
+
+	// Decode
+	decoded, err := url.PathUnescape(encodedValue)
+	if err != nil {
+		return "", fmt.Errorf("invalid URL encoding in %s", paramName)
+	}
+
+	// Validate - check if empty
+	if strings.TrimSpace(decoded) == "" {
+		return "", fmt.Errorf("%s cannot be empty", paramName)
+	}
+
+	// Validate - check for whitespace
+	if strings.ContainsAny(decoded, " \t\n\r") {
+		return "", fmt.Errorf("%s cannot contain whitespace", paramName)
+	}
+
+	return decoded, nil
+}

--- a/internal/api/common/url_test.go
+++ b/internal/api/common/url_test.go
@@ -1,0 +1,298 @@
+// Package common provides shared HTTP utility functions for API handlers.
+package common
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetAndValidateURLParam(t *testing.T) {
+	t.Parallel()
+
+	// Test with valid URLs through router
+	routerTests := []struct {
+		name       string
+		paramName  string
+		paramValue string
+		wantValue  string
+		wantErr    bool
+		wantErrMsg string
+	}{
+		// Valid cases
+		{
+			name:       "valid plain string",
+			paramName:  "serverName",
+			paramValue: "test-server",
+			wantValue:  "test-server",
+			wantErr:    false,
+		},
+		{
+			name:       "valid with dashes",
+			paramName:  "serverName",
+			paramValue: "test-server-123",
+			wantValue:  "test-server-123",
+			wantErr:    false,
+		},
+		{
+			name:       "valid with underscores",
+			paramName:  "serverName",
+			paramValue: "test_server_123",
+			wantValue:  "test_server_123",
+			wantErr:    false,
+		},
+		{
+			name:       "valid with dots",
+			paramName:  "version",
+			paramValue: "1.2.3",
+			wantValue:  "1.2.3",
+			wantErr:    false,
+		},
+		{
+			name:       "valid with mixed special chars",
+			paramName:  "serverName",
+			paramValue: "test.server-v1_alpha",
+			wantValue:  "test.server-v1_alpha",
+			wantErr:    false,
+		},
+
+		// URL-encoded cases that should decode properly
+		{
+			name:       "url-encoded slash",
+			paramName:  "serverName",
+			paramValue: "test%2Fserver",
+			wantValue:  "test/server",
+			wantErr:    false,
+		},
+		{
+			name:       "url-encoded at symbol",
+			paramName:  "version",
+			paramValue: "test%40v1",
+			wantValue:  "test@v1",
+			wantErr:    false,
+		},
+		{
+			name:       "url-encoded colon",
+			paramName:  "serverName",
+			paramValue: "test%3Aserver",
+			wantValue:  "test:server",
+			wantErr:    false,
+		},
+		{
+			name:       "url-encoded equals",
+			paramName:  "serverName",
+			paramValue: "test%3Dserver",
+			wantValue:  "test=server",
+			wantErr:    false,
+		},
+		{
+			name:       "url-encoded ampersand",
+			paramName:  "serverName",
+			paramValue: "test%26server",
+			wantValue:  "test&server",
+			wantErr:    false,
+		},
+		{
+			name:       "url-encoded plus",
+			paramName:  "serverName",
+			paramValue: "test%2Bserver",
+			wantValue:  "test+server",
+			wantErr:    false,
+		},
+		// Note: Chi router already partially decodes URLs
+		// %2525 becomes %25 which we then decode to %
+		{
+			name:       "double-encoded percent",
+			paramName:  "serverName",
+			paramValue: "test%2525server",
+			wantValue:  "test%server", // Chi decodes %25 to %, then we decode %25 to %
+			wantErr:    false,
+		},
+		{
+			name:       "multiple url-encoded chars",
+			paramName:  "serverName",
+			paramValue: "test%2Fserver%40v1%2B2",
+			wantValue:  "test/server@v1+2",
+			wantErr:    false,
+		},
+
+		// Empty and whitespace cases
+		{
+			name:       "empty string",
+			paramName:  "serverName",
+			paramValue: "",
+			wantErr:    true,
+			wantErrMsg: "serverName cannot be empty",
+		},
+		{
+			name:       "url-encoded space only",
+			paramName:  "serverName",
+			paramValue: "%20",
+			wantErr:    true,
+			wantErrMsg: "serverName cannot be empty",
+		},
+		{
+			name:       "multiple url-encoded spaces",
+			paramName:  "serverName",
+			paramValue: "%20%20%20",
+			wantErr:    true,
+			wantErrMsg: "serverName cannot be empty",
+		},
+		{
+			name:       "url-encoded tab only",
+			paramName:  "serverName",
+			paramValue: "%09",
+			wantErr:    true,
+			wantErrMsg: "serverName cannot be empty",
+		},
+		{
+			name:       "url-encoded newline only",
+			paramName:  "serverName",
+			paramValue: "%0A",
+			wantErr:    true,
+			wantErrMsg: "serverName cannot be empty",
+		},
+		{
+			name:       "url-encoded carriage return only",
+			paramName:  "serverName",
+			paramValue: "%0D",
+			wantErr:    true,
+			wantErrMsg: "serverName cannot be empty",
+		},
+
+		// Whitespace in middle cases
+		{
+			name:       "space in middle",
+			paramName:  "serverName",
+			paramValue: "test%20server",
+			wantErr:    true,
+			wantErrMsg: "serverName cannot contain whitespace",
+		},
+		{
+			name:       "tab in middle",
+			paramName:  "serverName",
+			paramValue: "test%09server",
+			wantErr:    true,
+			wantErrMsg: "serverName cannot contain whitespace",
+		},
+		{
+			name:       "newline in middle",
+			paramName:  "serverName",
+			paramValue: "test%0Aserver",
+			wantErr:    true,
+			wantErrMsg: "serverName cannot contain whitespace",
+		},
+		{
+			name:       "carriage return in middle",
+			paramName:  "serverName",
+			paramValue: "test%0Dserver",
+			wantErr:    true,
+			wantErrMsg: "serverName cannot contain whitespace",
+		},
+		{
+			name:       "space at start",
+			paramName:  "serverName",
+			paramValue: "%20test",
+			wantErr:    true,
+			wantErrMsg: "serverName cannot contain whitespace",
+		},
+		{
+			name:       "space at end",
+			paramName:  "serverName",
+			paramValue: "test%20",
+			wantErr:    true,
+			wantErrMsg: "serverName cannot contain whitespace",
+		},
+		{
+			name:       "multiple spaces",
+			paramName:  "serverName",
+			paramValue: "test%20%20server",
+			wantErr:    true,
+			wantErrMsg: "serverName cannot contain whitespace",
+		},
+		{
+			name:       "mixed whitespace",
+			paramName:  "serverName",
+			paramValue: "test%20%09%0A%0Dserver",
+			wantErr:    true,
+			wantErrMsg: "serverName cannot contain whitespace",
+		},
+	}
+
+	for _, tt := range routerTests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Create a test router with chi
+			router := chi.NewRouter()
+			router.Get("/{"+tt.paramName+"}", func(_ http.ResponseWriter, r *http.Request) {
+				value, err := GetAndValidateURLParam(r, tt.paramName)
+
+				if tt.wantErr {
+					require.Error(t, err)
+					assert.Equal(t, tt.wantErrMsg, err.Error())
+				} else {
+					require.NoError(t, err)
+					assert.Equal(t, tt.wantValue, value)
+				}
+			})
+
+			// Create test request
+			req, err := http.NewRequest("GET", "/"+tt.paramValue, nil)
+			require.NoError(t, err)
+
+			// Execute request
+			rr := httptest.NewRecorder()
+			router.ServeHTTP(rr, req)
+		})
+	}
+
+	// Test invalid URL encoding directly (chi router won't parse these)
+	directTests := []struct {
+		name       string
+		paramName  string
+		paramValue string
+		wantErrMsg string
+	}{
+		{
+			name:       "invalid url encoding - incomplete",
+			paramName:  "serverName",
+			paramValue: "test%2",
+			wantErrMsg: "invalid URL encoding in serverName",
+		},
+		{
+			name:       "invalid url encoding - invalid hex",
+			paramName:  "serverName",
+			paramValue: "test%ZZ",
+			wantErrMsg: "invalid URL encoding in serverName",
+		},
+		{
+			name:       "invalid url encoding - incomplete percent",
+			paramName:  "serverName",
+			paramValue: "test%",
+			wantErrMsg: "invalid URL encoding in serverName",
+		},
+	}
+
+	for _, tt := range directTests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Create a mock request with chi context
+			req := httptest.NewRequest("GET", "/test", nil)
+			rctx := chi.NewRouteContext()
+			rctx.URLParams.Add(tt.paramName, tt.paramValue)
+			req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+
+			// Call the function directly
+			_, err := GetAndValidateURLParam(req, tt.paramName)
+			require.Error(t, err)
+			assert.Equal(t, tt.wantErrMsg, err.Error())
+		})
+	}
+}

--- a/internal/api/extension/v0/routes.go
+++ b/internal/api/extension/v0/routes.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"strings"
 
 	"github.com/go-chi/chi/v5"
 
@@ -89,9 +88,9 @@ func (r *Routes) listRegistries(w http.ResponseWriter, req *http.Request) {
 // @Failure		501	{object}	map[string]string	"Not implemented"
 // @Router		/extension/v0/registries/{registryName} [get]
 func (r *Routes) getRegistry(w http.ResponseWriter, req *http.Request) {
-	registryName := chi.URLParam(req, "registryName")
-	if strings.TrimSpace(registryName) == "" {
-		common.WriteErrorResponse(w, "Registry name is required", http.StatusBadRequest)
+	registryName, err := common.GetAndValidateURLParam(req, "registryName")
+	if err != nil {
+		common.WriteErrorResponse(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 
@@ -125,9 +124,9 @@ func (r *Routes) getRegistry(w http.ResponseWriter, req *http.Request) {
 // @Failure		501	{object}	map[string]string	"Not implemented"
 // @Router		/extension/v0/registries/{registryName} [put]
 func (*Routes) upsertRegistry(w http.ResponseWriter, r *http.Request) {
-	registryName := chi.URLParam(r, "registryName")
-	if strings.TrimSpace(registryName) == "" {
-		common.WriteErrorResponse(w, "Registry name is required", http.StatusBadRequest)
+	_, err := common.GetAndValidateURLParam(r, "registryName")
+	if err != nil {
+		common.WriteErrorResponse(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 
@@ -146,9 +145,9 @@ func (*Routes) upsertRegistry(w http.ResponseWriter, r *http.Request) {
 // @Failure		501	{object}	map[string]string	"Not implemented"
 // @Router		/extension/v0/registries/{registryName} [delete]
 func (*Routes) deleteRegistry(w http.ResponseWriter, r *http.Request) {
-	registryName := chi.URLParam(r, "registryName")
-	if strings.TrimSpace(registryName) == "" {
-		common.WriteErrorResponse(w, "Registry name is required", http.StatusBadRequest)
+	_, err := common.GetAndValidateURLParam(r, "registryName")
+	if err != nil {
+		common.WriteErrorResponse(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 
@@ -169,20 +168,21 @@ func (*Routes) deleteRegistry(w http.ResponseWriter, r *http.Request) {
 // @Failure		501	{object}	map[string]string	"Not implemented"
 // @Router		/extension/v0/registries/{registryName}/servers/{serverName}/versions/{version} [put]
 func (*Routes) upsertVersion(w http.ResponseWriter, r *http.Request) {
-	registryName := chi.URLParam(r, "registryName")
-	serverName := chi.URLParam(r, "serverName")
-	version := chi.URLParam(r, "version")
+	_, err := common.GetAndValidateURLParam(r, "registryName")
+	if err != nil {
+		common.WriteErrorResponse(w, err.Error(), http.StatusBadRequest)
+		return
+	}
 
-	if strings.TrimSpace(registryName) == "" {
-		common.WriteErrorResponse(w, "Registry name is required", http.StatusBadRequest)
+	_, err = common.GetAndValidateURLParam(r, "serverName")
+	if err != nil {
+		common.WriteErrorResponse(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-	if strings.TrimSpace(serverName) == "" {
-		common.WriteErrorResponse(w, "Server ID is required", http.StatusBadRequest)
-		return
-	}
-	if strings.TrimSpace(version) == "" {
-		common.WriteErrorResponse(w, "Version is required", http.StatusBadRequest)
+
+	_, err = common.GetAndValidateURLParam(r, "version")
+	if err != nil {
+		common.WriteErrorResponse(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 

--- a/internal/api/registry/v01/routes.go
+++ b/internal/api/registry/v01/routes.go
@@ -173,15 +173,20 @@ func (routes *Routes) listServers(w http.ResponseWriter, r *http.Request) {
 // @Failure		400		{object}	map[string]string	"Bad request"
 // @Router		/registry/{registryName}/v0.1/servers [get]
 func (routes *Routes) listServersWithRegistryName(w http.ResponseWriter, r *http.Request) {
-	registryName := chi.URLParam(r, "registryName")
+	registryName, err := common.GetAndValidateURLParam(r, "registryName")
+	if err != nil {
+		common.WriteErrorResponse(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
 	routes.handleListServers(w, r, registryName)
 }
 
 // handleListVersions is a shared helper that handles listing versions with an optional registry name.
 func (routes *Routes) handleListVersions(w http.ResponseWriter, r *http.Request, registryName string) {
-	serverName := chi.URLParam(r, "serverName")
-	if strings.TrimSpace(serverName) == "" {
-		common.WriteErrorResponse(w, "Server name is required", http.StatusBadRequest)
+	serverName, err := common.GetAndValidateURLParam(r, "serverName")
+	if err != nil {
+		common.WriteErrorResponse(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 
@@ -252,16 +257,26 @@ func (routes *Routes) listVersions(w http.ResponseWriter, r *http.Request) {
 // @Failure		404		{object}	map[string]string	"Server not found"
 // @Router		/registry/{registryName}/v0.1/servers/{serverName}/versions [get]
 func (routes *Routes) listVersionsWithRegistryName(w http.ResponseWriter, r *http.Request) {
-	registryName := chi.URLParam(r, "registryName")
+	registryName, err := common.GetAndValidateURLParam(r, "registryName")
+	if err != nil {
+		common.WriteErrorResponse(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
 	routes.handleListVersions(w, r, registryName)
 }
 
 // handleGetVersion is a shared helper that handles getting a version with an optional registry name.
 func (routes *Routes) handleGetVersion(w http.ResponseWriter, r *http.Request, registryName string) {
-	serverName := chi.URLParam(r, "serverName")
-	version := chi.URLParam(r, "version")
-	if strings.TrimSpace(serverName) == "" || strings.TrimSpace(version) == "" {
-		common.WriteErrorResponse(w, "Server name and version are required", http.StatusBadRequest)
+	serverName, err := common.GetAndValidateURLParam(r, "serverName")
+	if err != nil {
+		common.WriteErrorResponse(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	version, err := common.GetAndValidateURLParam(r, "version")
+	if err != nil {
+		common.WriteErrorResponse(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 
@@ -327,7 +342,12 @@ func (routes *Routes) getVersion(w http.ResponseWriter, r *http.Request) {
 // @Failure		404				{object}	map[string]string	"Server or version not found"
 // @Router		/registry/{registryName}/v0.1/servers/{serverName}/versions/{version} [get]
 func (routes *Routes) getVersionWithRegistryName(w http.ResponseWriter, r *http.Request) {
-	registryName := chi.URLParam(r, "registryName")
+	registryName, err := common.GetAndValidateURLParam(r, "registryName")
+	if err != nil {
+		common.WriteErrorResponse(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
 	routes.handleGetVersion(w, r, registryName)
 }
 
@@ -348,28 +368,26 @@ func (routes *Routes) getVersionWithRegistryName(w http.ResponseWriter, r *http.
 // @Failure      500  {object}  map[string]string  "Internal server error"
 // @Router       /{registryName}/v0.1/servers/{serverName}/versions/{version} [delete]
 func (routes *Routes) deleteVersionWithRegistryName(w http.ResponseWriter, r *http.Request) {
-	// Extract URL parameters
-	registryName := chi.URLParam(r, "registryName")
-	serverName := chi.URLParam(r, "serverName")
-	version := chi.URLParam(r, "version")
-
-	if strings.TrimSpace(registryName) == "" {
-		common.WriteErrorResponse(w, "Registry name is required", http.StatusBadRequest)
+	registryName, err := common.GetAndValidateURLParam(r, "registryName")
+	if err != nil {
+		common.WriteErrorResponse(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 
-	if strings.TrimSpace(serverName) == "" {
-		common.WriteErrorResponse(w, "Server name is required", http.StatusBadRequest)
+	serverName, err := common.GetAndValidateURLParam(r, "serverName")
+	if err != nil {
+		common.WriteErrorResponse(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 
-	if strings.TrimSpace(version) == "" {
-		common.WriteErrorResponse(w, "Version is required", http.StatusBadRequest)
+	version, err := common.GetAndValidateURLParam(r, "version")
+	if err != nil {
+		common.WriteErrorResponse(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 
 	// Call service layer
-	err := routes.service.DeleteServerVersion(
+	err = routes.service.DeleteServerVersion(
 		r.Context(),
 		service.WithRegistryName[service.DeleteServerVersionOptions](registryName),
 		service.WithName[service.DeleteServerVersionOptions](serverName),
@@ -412,11 +430,9 @@ func (routes *Routes) deleteVersionWithRegistryName(w http.ResponseWriter, r *ht
 // @Failure      500           {object}  map[string]string         "Internal server error"
 // @Router       /{registryName}/v0.1/publish [post]
 func (routes *Routes) publishWithRegistryName(w http.ResponseWriter, r *http.Request) {
-	// Extract URL parameters
-	registryName := chi.URLParam(r, "registryName")
-
-	if strings.TrimSpace(registryName) == "" {
-		common.WriteErrorResponse(w, "Registry name is required", http.StatusBadRequest)
+	registryName, err := common.GetAndValidateURLParam(r, "registryName")
+	if err != nil {
+		common.WriteErrorResponse(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 


### PR DESCRIPTION
The following PR adds proper URL encoding/decoding of path parameters like registry name, server name and version.