### PR TITLE
Use stderr for logging

### DIFF
--- a/cmd/thv-registry-api/main.go
+++ b/cmd/thv-registry-api/main.go
@@ -33,7 +33,7 @@ func getLogLevel() slog.Level {
 
 func main() {
 	// Setup structured JSON logging with slog
-	handler := slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+	handler := slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{
 		Level:     getLogLevel(),
 		AddSource: false, // Can be enabled for debugging
 	})


### PR DESCRIPTION
The following PR fixes the failing release process (caused by the move to log/slog)