### PR TITLE
Build with SSL certificates so we can clone from GitHub

### DIFF
--- a/.github/ko-ci.yml
+++ b/.github/ko-ci.yml
@@ -1,3 +1,6 @@
+# Use distroless/static which includes CA certificates for TLS verification
+defaultBaseImage: gcr.io/distroless/static:nonroot
+
 builds:
   - id: thv-registry-api
     dir: ./cmd/thv-registry-api

--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,0 +1,2 @@
+# Use distroless/static which includes CA certificates for TLS verification
+defaultBaseImage: gcr.io/distroless/static:nonroot

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,10 @@ GOOS=linux GOARCH=amd64 go build -ldflags "${LDFLAGS}" -o main ./cmd/thv-registr
 # Use minimal base image to package the binary
 FROM registry.access.redhat.com/ubi10/ubi-minimal:10.1-1764604111
 
+# Install CA certificates for TLS verification
+RUN microdnf install -y ca-certificates && \
+    microdnf clean all
+
 COPY --from=builder /workspace/main /
 COPY LICENSE /licenses/LICENSE
 


### PR DESCRIPTION
The following PR adds SSL certificates to the container images we build so we can clone from GitHub (for the git registry type)

Solving:
```json
{"time":"2025-12-04T14:47:09.180049387Z","level":"ERROR","msg":"Git clone failed","error":"failed to clone repository: Get \"https://github.com/stacklok/toolhive.git/info/refs?service=git-upload-pack\": tls: failed to verify certificate: x509: certificate signed by unknown authority","repository":"https://github.com/stacklok/toolhive.git","duration":"172.938542ms"}
{"time":"2025-12-04T14:47:09.180230471Z","level":"ERROR","msg":"Fetch operation failed","error":"failed to fetch registry data: failed to clone repository: failed to clone repository: Get \"https://github.com/stacklok/toolhive.git/info/refs?service=git-upload-pack\": tls: failed to verify certificate: x509: certificate signed by unknown authority"}
{"time":"2025-12-04T14:47:09.180270679Z","level":"ERROR","msg":"Sync failed","registry":"git-registry","error":"Fetch failed: failed to fetch registry data: failed to clone repository: failed to clone repository: Get \"https://github.com/stacklok/toolhive.git/info/refs?service=git-upload-pack\": tls: failed to verify certificate: x509: certificate signed by unknown authority"}
```