### PR TITLE
Add `Kind` to entries exported from kubernetes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ go.work.sum
 # Editor/IDE
 .idea/
 .vscode/
+.task/
 
 # IDE specific files
 *.swp

--- a/internal/app/builder.go
+++ b/internal/app/builder.go
@@ -281,7 +281,7 @@ func buildSyncComponents(
 	}
 
 	// Build storage manager
-	if b.storageManager == nil {
+	if b.config.GetStorageType() == config.StorageTypeFile && b.storageManager == nil {
 		// Use config's file storage base directory (defaults to "./data")
 		baseDir := b.config.GetFileStorageBaseDir()
 		// Ensure data directory exists
@@ -292,7 +292,7 @@ func buildSyncComponents(
 	}
 
 	// Build status persistence (now uses dataDir as base path for per-registry status files)
-	if b.statusPersistence == nil {
+	if b.config.GetStorageType() == config.StorageTypeFile && b.statusPersistence == nil {
 		b.statusPersistence = status.NewFileStatusPersistence(b.dataDir)
 	}
 

--- a/internal/kubernetes/types.go
+++ b/internal/kubernetes/types.go
@@ -56,15 +56,22 @@ func extractServer(mcpServer *mcpv1alpha1.MCPServer) (*upstreamv0.ServerJSON, er
 
 	// Initialize metadata
 	serverJSON.Meta = &upstreamv0.ServerMeta{
-		PublisherProvided: make(map[string]interface{}),
+		PublisherProvided: make(map[string]any),
 	}
 
 	// Add Kubernetes metadata to publisher provided metadata
-	serverJSON.Meta.PublisherProvided["kubernetes_namespace"] = mcpServer.Namespace
-	serverJSON.Meta.PublisherProvided["kubernetes_name"] = mcpServer.Name
-	serverJSON.Meta.PublisherProvided["kubernetes_uid"] = string(mcpServer.UID)
-	serverJSON.Meta.PublisherProvided["kubernetes_image"] = mcpServer.Spec.Image
-	serverJSON.Meta.PublisherProvided["kubernetes_transport"] = mcpServer.Spec.Transport
+	serverJSON.Meta.PublisherProvided["io.github.stacklok"] = map[string]any{
+		transportURL: map[string]any{
+			"metadata": map[string]any{
+				"kubernetes_kind":      mcpServer.Kind,
+				"kubernetes_namespace": mcpServer.Namespace,
+				"kubernetes_name":      mcpServer.Name,
+				"kubernetes_image":     mcpServer.Spec.Image,
+				"kubernetes_uid":       string(mcpServer.UID),
+				"kubernetes_transport": mcpServer.Spec.Transport,
+			},
+		},
+	}
 
 	return serverJSON, nil
 }
@@ -112,12 +119,19 @@ func extractVirtualMCPServer(virtualMCPServer *mcpv1alpha1.VirtualMCPServer) (*u
 
 	// Initialize metadata
 	serverJSON.Meta = &upstreamv0.ServerMeta{
-		PublisherProvided: make(map[string]interface{}),
+		PublisherProvided: make(map[string]any),
 	}
 	// Add Kubernetes metadata to publisher provided metadata
-	serverJSON.Meta.PublisherProvided["kubernetes_namespace"] = virtualMCPServer.Namespace
-	serverJSON.Meta.PublisherProvided["kubernetes_name"] = virtualMCPServer.Name
-	serverJSON.Meta.PublisherProvided["kubernetes_uid"] = string(virtualMCPServer.UID)
+	serverJSON.Meta.PublisherProvided["io.github.stacklok"] = map[string]any{
+		transportURL: map[string]any{
+			"metadata": map[string]any{
+				"kubernetes_kind":      virtualMCPServer.Kind,
+				"kubernetes_namespace": virtualMCPServer.Namespace,
+				"kubernetes_name":      virtualMCPServer.Name,
+				"kubernetes_uid":       string(virtualMCPServer.UID),
+			},
+		},
+	}
 
 	return serverJSON, nil
 }
@@ -172,12 +186,19 @@ func extractMCPRemoteProxy(mcpRemoteProxy *mcpv1alpha1.MCPRemoteProxy) (*upstrea
 
 	// Initialize metadata
 	serverJSON.Meta = &upstreamv0.ServerMeta{
-		PublisherProvided: make(map[string]interface{}),
+		PublisherProvided: make(map[string]any),
 	}
 	// Add Kubernetes metadata to publisher provided metadata
-	serverJSON.Meta.PublisherProvided["kubernetes_namespace"] = mcpRemoteProxy.Namespace
-	serverJSON.Meta.PublisherProvided["kubernetes_name"] = mcpRemoteProxy.Name
-	serverJSON.Meta.PublisherProvided["kubernetes_uid"] = string(mcpRemoteProxy.UID)
+	serverJSON.Meta.PublisherProvided["io.github.stacklok"] = map[string]any{
+		transportURL: map[string]any{
+			"metadata": map[string]any{
+				"kubernetes_kind":      mcpRemoteProxy.Kind,
+				"kubernetes_namespace": mcpRemoteProxy.Namespace,
+				"kubernetes_name":      mcpRemoteProxy.Name,
+				"kubernetes_uid":       string(mcpRemoteProxy.UID),
+			},
+		},
+	}
 
 	return serverJSON, nil
 }

--- a/internal/kubernetes/types_test.go
+++ b/internal/kubernetes/types_test.go
@@ -60,11 +60,20 @@ func TestExtractServer(t *testing.T) {
 			//nolint:thelper // We want to see these lines in the test output
 			checkMeta: func(t *testing.T, sj *upstreamv0.ServerJSON) {
 				assert.Equal(t, "A test MCP server", sj.Description)
-				assert.Equal(t, "default", sj.Meta.PublisherProvided["kubernetes_namespace"])
-				assert.Equal(t, "test-server", sj.Meta.PublisherProvided["kubernetes_name"])
-				assert.Equal(t, "test/image:latest", sj.Meta.PublisherProvided["kubernetes_image"])
-				assert.Equal(t, "stdio", sj.Meta.PublisherProvided["kubernetes_transport"])
-				assert.NotEmpty(t, sj.Meta.PublisherProvided["kubernetes_uid"])
+				assert.NotNil(t, sj.Meta.PublisherProvided["io.github.stacklok"])
+				ioStacklok := sj.Meta.PublisherProvided["io.github.stacklok"].(map[string]any)
+
+				assert.NotNil(t, ioStacklok["https://example.com/mcp"])
+				mcpMetadata := ioStacklok["https://example.com/mcp"].(map[string]any)
+
+				assert.NotNil(t, mcpMetadata["metadata"])
+				kubernetesMetadata := mcpMetadata["metadata"].(map[string]any)
+
+				assert.Equal(t, "default", kubernetesMetadata["kubernetes_namespace"])
+				assert.Equal(t, "test-server", kubernetesMetadata["kubernetes_name"])
+				assert.Equal(t, "test/image:latest", kubernetesMetadata["kubernetes_image"])
+				assert.Equal(t, "stdio", kubernetesMetadata["kubernetes_transport"])
+				assert.NotEmpty(t, kubernetesMetadata["kubernetes_uid"])
 				require.Len(t, sj.Remotes, 1)
 				assert.Equal(t, model.TransportTypeStreamableHTTP, sj.Remotes[0].Type)
 				assert.Equal(t, "https://example.com/mcp", sj.Remotes[0].URL)
@@ -151,10 +160,20 @@ func TestExtractServer(t *testing.T) {
 			//nolint:thelper // We want to see these lines in the test output
 			checkMeta: func(t *testing.T, sj *upstreamv0.ServerJSON) {
 				assert.Equal(t, "Full featured server", sj.Description)
-				assert.Equal(t, "custom-ns", sj.Meta.PublisherProvided["kubernetes_namespace"])
-				assert.Equal(t, "full-server", sj.Meta.PublisherProvided["kubernetes_name"])
-				assert.Equal(t, "registry.example.com/image:tag", sj.Meta.PublisherProvided["kubernetes_image"])
-				assert.Equal(t, "sse", sj.Meta.PublisherProvided["kubernetes_transport"])
+				assert.NotNil(t, sj.Meta.PublisherProvided["io.github.stacklok"])
+				ioStacklok := sj.Meta.PublisherProvided["io.github.stacklok"].(map[string]any)
+
+				assert.NotNil(t, ioStacklok["https://api.example.com/mcp-server"])
+				mcpMetadata := ioStacklok["https://api.example.com/mcp-server"].(map[string]any)
+
+				assert.NotNil(t, mcpMetadata["metadata"])
+				kubernetesMetadata := mcpMetadata["metadata"].(map[string]any)
+
+				assert.Equal(t, "custom-ns", kubernetesMetadata["kubernetes_namespace"])
+				assert.Equal(t, "full-server", kubernetesMetadata["kubernetes_name"])
+				assert.Equal(t, "registry.example.com/image:tag", kubernetesMetadata["kubernetes_image"])
+				assert.Equal(t, "sse", kubernetesMetadata["kubernetes_transport"])
+				assert.NotEmpty(t, kubernetesMetadata["kubernetes_uid"])
 				require.Len(t, sj.Remotes, 1)
 				assert.Equal(t, model.TransportTypeStreamableHTTP, sj.Remotes[0].Type)
 				assert.Equal(t, "https://api.example.com/mcp-server", sj.Remotes[0].URL)
@@ -386,9 +405,18 @@ func TestExtractVirtualMCPServer(t *testing.T) {
 			//nolint:thelper // We want to see these lines in the test output
 			checkMeta: func(t *testing.T, sj *upstreamv0.ServerJSON) {
 				assert.Equal(t, "A test Virtual MCP server", sj.Description)
-				assert.Equal(t, "default", sj.Meta.PublisherProvided["kubernetes_namespace"])
-				assert.Equal(t, "test-vmcp-server", sj.Meta.PublisherProvided["kubernetes_name"])
-				assert.NotEmpty(t, sj.Meta.PublisherProvided["kubernetes_uid"])
+				assert.NotNil(t, sj.Meta.PublisherProvided["io.github.stacklok"])
+				ioStacklok := sj.Meta.PublisherProvided["io.github.stacklok"].(map[string]any)
+
+				assert.NotNil(t, ioStacklok["https://example.com/vmcp"])
+				mcpMetadata := ioStacklok["https://example.com/vmcp"].(map[string]any)
+
+				assert.NotNil(t, mcpMetadata["metadata"])
+				kubernetesMetadata := mcpMetadata["metadata"].(map[string]any)
+
+				assert.Equal(t, "default", kubernetesMetadata["kubernetes_namespace"])
+				assert.Equal(t, "test-vmcp-server", kubernetesMetadata["kubernetes_name"])
+				assert.NotEmpty(t, kubernetesMetadata["kubernetes_uid"])
 				require.Len(t, sj.Remotes, 1)
 				assert.Equal(t, model.TransportTypeStreamableHTTP, sj.Remotes[0].Type)
 				assert.Equal(t, "https://example.com/vmcp", sj.Remotes[0].URL)
@@ -455,8 +483,15 @@ func TestExtractVirtualMCPServer(t *testing.T) {
 			//nolint:thelper // We want to see these lines in the test output
 			checkMeta: func(t *testing.T, sj *upstreamv0.ServerJSON) {
 				assert.Equal(t, "Production Virtual MCP server", sj.Description)
-				assert.Equal(t, "production", sj.Meta.PublisherProvided["kubernetes_namespace"])
-				assert.Equal(t, "vmcp-server", sj.Meta.PublisherProvided["kubernetes_name"])
+				assert.NotNil(t, sj.Meta.PublisherProvided["io.github.stacklok"])
+				ioStacklok := sj.Meta.PublisherProvided["io.github.stacklok"].(map[string]any)
+
+				assert.NotNil(t, ioStacklok["https://api.prod.example.com/vmcp"])
+				mcpMetadata := ioStacklok["https://api.prod.example.com/vmcp"].(map[string]any)
+
+				assert.NotNil(t, mcpMetadata["metadata"])
+				kubernetesMetadata := mcpMetadata["metadata"].(map[string]any)
+				assert.Equal(t, "production", kubernetesMetadata["kubernetes_namespace"])
 				require.Len(t, sj.Remotes, 1)
 				assert.Equal(t, "https://api.prod.example.com/vmcp", sj.Remotes[0].URL)
 			},
@@ -534,9 +569,18 @@ func TestExtractMCPRemoteProxy(t *testing.T) {
 			//nolint:thelper // We want to see these lines in the test output
 			checkMeta: func(t *testing.T, sj *upstreamv0.ServerJSON) {
 				assert.Equal(t, "A test MCP Remote Proxy", sj.Description)
-				assert.Equal(t, "default", sj.Meta.PublisherProvided["kubernetes_namespace"])
-				assert.Equal(t, "test-proxy", sj.Meta.PublisherProvided["kubernetes_name"])
-				assert.NotEmpty(t, sj.Meta.PublisherProvided["kubernetes_uid"])
+				assert.NotNil(t, sj.Meta.PublisherProvided["io.github.stacklok"])
+				ioStacklok := sj.Meta.PublisherProvided["io.github.stacklok"].(map[string]any)
+
+				assert.NotNil(t, ioStacklok["https://example.com/proxy"])
+				mcpMetadata := ioStacklok["https://example.com/proxy"].(map[string]any)
+
+				assert.NotNil(t, mcpMetadata["metadata"])
+				kubernetesMetadata := mcpMetadata["metadata"].(map[string]any)
+
+				assert.Equal(t, "default", kubernetesMetadata["kubernetes_namespace"])
+				assert.Equal(t, "test-proxy", kubernetesMetadata["kubernetes_name"])
+				assert.NotEmpty(t, kubernetesMetadata["kubernetes_uid"])
 				require.Len(t, sj.Remotes, 1)
 				assert.Equal(t, model.TransportTypeStreamableHTTP, sj.Remotes[0].Type)
 				assert.Equal(t, "https://example.com/proxy", sj.Remotes[0].URL)
@@ -603,9 +647,18 @@ func TestExtractMCPRemoteProxy(t *testing.T) {
 			//nolint:thelper // We want to see these lines in the test output
 			checkMeta: func(t *testing.T, sj *upstreamv0.ServerJSON) {
 				assert.Equal(t, "Proxy with description", sj.Description)
-				assert.Equal(t, "custom-ns", sj.Meta.PublisherProvided["kubernetes_namespace"])
-				assert.Equal(t, "proxy-server", sj.Meta.PublisherProvided["kubernetes_name"])
-				assert.NotEmpty(t, sj.Meta.PublisherProvided["kubernetes_uid"])
+				assert.NotNil(t, sj.Meta.PublisherProvided["io.github.stacklok"])
+				ioStacklok := sj.Meta.PublisherProvided["io.github.stacklok"].(map[string]any)
+
+				assert.NotNil(t, ioStacklok["https://proxy.example.com"])
+				mcpMetadata := ioStacklok["https://proxy.example.com"].(map[string]any)
+
+				assert.NotNil(t, mcpMetadata["metadata"])
+				kubernetesMetadata := mcpMetadata["metadata"].(map[string]any)
+
+				assert.Equal(t, "custom-ns", kubernetesMetadata["kubernetes_namespace"])
+				assert.Equal(t, "proxy-server", kubernetesMetadata["kubernetes_name"])
+				assert.NotEmpty(t, kubernetesMetadata["kubernetes_uid"])
 				require.Len(t, sj.Remotes, 1)
 				assert.Equal(t, model.TransportTypeStreamableHTTP, sj.Remotes[0].Type)
 				assert.Equal(t, "https://proxy.example.com", sj.Remotes[0].URL)


### PR DESCRIPTION
This change adds the Kubernetes `Kind` to metadata exported as part of the MCP Server entries created in the Registry when auto-discovery is active.

This change also modifies the structure of metadata making it a structured object, following the same convention we follow in upstream registry JSON format.

Finally, this also fixes a small bug that caused the Registry Server to fail when creating a folder when DB storage is configured.

Fixes #279