### PR TITLE
Add introspectionUrl config for opaque token validation

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -162,6 +162,7 @@ Additional public paths can be configured using the `publicPaths` option.
 | `clientId` | No | OAuth client ID for token introspection |
 | `clientSecretFile` | No | Path to file containing client secret |
 | `caCertPath` | No | Path to CA certificate for TLS verification |
+| `introspectionUrl` | No | Token introspection endpoint (RFC 7662) for opaque tokens |
 
 ### Kubernetes Provider
 

--- a/internal/auth/factory.go
+++ b/internal/auth/factory.go
@@ -76,11 +76,12 @@ func createOAuthMiddleware(
 			Name:      p.Name,
 			IssuerURL: p.IssuerURL,
 			ValidatorConfig: thvauth.TokenValidatorConfig{
-				Issuer:       p.IssuerURL,
-				Audience:     p.Audience,
-				ClientID:     p.ClientID,
-				ClientSecret: clientSecret,
-				CACertPath:   p.CACertPath,
+				Issuer:           p.IssuerURL,
+				Audience:         p.Audience,
+				ClientID:         p.ClientID,
+				ClientSecret:     clientSecret,
+				CACertPath:       p.CACertPath,
+				IntrospectionURL: p.IntrospectionURL,
 			},
 		}
 		issuerURLs[i] = p.IssuerURL

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -306,6 +306,11 @@ type OAuthProviderConfig struct {
 	// Required for Kubernetes in-cluster authentication or self-signed certificates
 	// TODO: Add GetCACert() method with path validation when implementing auth middleware
 	CACertPath string `yaml:"caCertPath,omitempty"`
+
+	// IntrospectionURL is the OAuth 2.0 Token Introspection endpoint (RFC 7662)
+	// Used for validating opaque (non-JWT) tokens
+	// If not specified, only JWT tokens can be validated via JWKS
+	IntrospectionURL string `yaml:"introspectionUrl,omitempty"`
 }
 
 // GetClientSecret returns the client secret by reading from the file specified in ClientSecretFile.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1639,6 +1639,36 @@ auth:
 			},
 		},
 		{
+			name: "oauth provider with introspection url",
+			yaml: `registries:
+  - name: test-registry
+    file:
+      path: /data/registry.json
+    syncPolicy:
+      interval: "30m"
+auth:
+  mode: oauth
+  oauth:
+    resourceUrl: https://registry.example.com
+    providers:
+      - name: google
+        issuerUrl: https://accounts.google.com
+        audience: my-google-client-id
+        introspectionUrl: https://oauth2.googleapis.com/tokeninfo`,
+			//nolint:thelper // We want to see errors here
+			check: func(t *testing.T, cfg *Config) {
+				require.NotNil(t, cfg.Auth)
+				assert.Equal(t, AuthModeOAuth, cfg.Auth.Mode)
+				require.NotNil(t, cfg.Auth.OAuth)
+				require.Len(t, cfg.Auth.OAuth.Providers, 1)
+				p := cfg.Auth.OAuth.Providers[0]
+				assert.Equal(t, "google", p.Name)
+				assert.Equal(t, "https://accounts.google.com", p.IssuerURL)
+				assert.Equal(t, "my-google-client-id", p.Audience)
+				assert.Equal(t, "https://oauth2.googleapis.com/tokeninfo", p.IntrospectionURL)
+			},
+		},
+		{
 			name: "explicit anonymous mode is parsed correctly",
 			yaml: `registries:
   - name: test-registry


### PR DESCRIPTION
Exposes the ToolHive library's IntrospectionURL field in the OAuth
provider configuration. This enables validation of opaque (non-JWT)
tokens via RFC 7662 token introspection.

I tested against Google auth using the following configuration:
```yaml
  oauth:
    resourceUrl: http://localhost:8080
    realm: mcp-registry
    scopesSupported:
      - mcp-registry:read
      - mcp-registry:write
    providers:
      - name: google
        issuerUrl: https://accounts.google.com
        introspectionUrl: https://oauth2.googleapis.com/tokeninfo
        audience: 407408718192.apps.googleusercontent.com
```

Fixes: #291
