### PR TITLE
Discover current Kubernetes namespace dinamically

### DIFF
--- a/internal/app/builder.go
+++ b/internal/app/builder.go
@@ -286,7 +286,7 @@ func buildSyncComponents(
 					kubernetes.WithSyncWriter(syncWriter),
 					kubernetes.WithRegistryName(reg.Name),
 					// TODO make it configurable
-					kubernetes.WithNamespaces("toolhive-system"),
+					kubernetes.WithCurrentNamespace(),
 				)
 				if err != nil {
 					return nil, fmt.Errorf("failed to create kubernetes reconciler: %w", err)


### PR DESCRIPTION
This change removes the hardcoded `toolhive-system` namespace from configuration and adds a new option `WihCurrentNamespace()` that adds the namespace written in
`/var/run/secrets/kubernetes.io/serviceaccount/namespace` to the list of namespaces watched, which currently amounts to just that one because we do not yet support multi-namespace setups.

Note that this is not only a code quality improvement since it allows running the Registry Server in namespaces other than `toolhive-system` while still maintaining its auto-discovery capability.

Fixes #289