### PR TITLE
Add Kubernetes OAuth configuration options

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -163,6 +163,7 @@ Additional public paths can be configured using the `publicPaths` option.
 | `clientId` | No | OAuth client ID for token introspection |
 | `clientSecretFile` | No | Path to file containing client secret |
 | `caCertPath` | No | Path to CA certificate for TLS verification |
+| `authTokenFile` | No | Path to bearer token file for authenticating to OIDC/JWKS endpoints |
 | `introspectionUrl` | No | Token introspection endpoint (RFC 7662) for opaque tokens |
 | `allowPrivateIP` | No | Allow OIDC endpoints on private IP addresses (required for in-cluster Kubernetes) |
 
@@ -176,11 +177,13 @@ For Kubernetes service account tokens:
   jwksUrl: https://kubernetes.default.svc/openid/v1/jwks  # Skip OIDC discovery
   audience: https://kubernetes.default.svc
   caCertPath: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+  authTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token  # Optional: for authenticated endpoints
   allowPrivateIP: true  # Required for in-cluster Kubernetes API server
 ```
 
 > **Note:** Using `jwksUrl` is useful in Kubernetes where the OIDC discovery endpoint
-> requires authentication. The JWKS endpoint is typically unauthenticated.
+> requires authentication. The JWKS endpoint is typically unauthenticated, but you can
+> use `authTokenFile` if authentication is required.
 
 ### External IDP Provider
 

--- a/internal/auth/factory.go
+++ b/internal/auth/factory.go
@@ -82,6 +82,7 @@ func createOAuthMiddleware(
 				ClientID:         p.ClientID,
 				ClientSecret:     clientSecret,
 				CACertPath:       p.CACertPath,
+				AuthTokenFile:    p.AuthTokenFile,
 				IntrospectionURL: p.IntrospectionURL,
 				AllowPrivateIP:   p.AllowPrivateIP,
 			},

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -310,8 +310,12 @@ type OAuthProviderConfig struct {
 
 	// CACertPath is the path to a CA certificate bundle for verifying the provider's TLS certificate
 	// Required for Kubernetes in-cluster authentication or self-signed certificates
-	// TODO: Add GetCACert() method with path validation when implementing auth middleware
 	CACertPath string `yaml:"caCertPath,omitempty"`
+
+	// AuthTokenFile is the path to a file containing a bearer token for authenticating to OIDC/JWKS endpoints
+	// Useful when the OIDC discovery or JWKS endpoint requires authentication
+	// Example: /var/run/secrets/kubernetes.io/serviceaccount/token
+	AuthTokenFile string `yaml:"authTokenFile,omitempty"`
 
 	// IntrospectionURL is the OAuth 2.0 Token Introspection endpoint (RFC 7662)
 	// Used for validating opaque (non-JWT) tokens


### PR DESCRIPTION
Adds three configuration options needed for OAuth authentication with Kubernetes as the identity provider:

- `allowPrivateIP` - allow JWKS/OIDC endpoints on private IP addresses (required for in-cluster Kubernetes)
- `jwksUrl` - directly specify JWKS URL to skip OIDC discovery (useful when discovery endpoint requires auth)
- `authTokenFile` - bearer token file for authenticating to OIDC/JWKS endpoints

### Kubernetes configuration example

```yaml
auth:
  mode: oauth
  oauth:
    resourceUrl: https://registry.example.com
    providers:
      - name: kubernetes
        issuerUrl: https://kubernetes.default.svc
        jwksUrl: https://kubernetes.default.svc/openid/v1/jwks
        audience: registry
        caCertPath: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
        authTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
        allowPrivateIP: true
```

Client workloads use a projected service account token with matching audience:

```yaml
volumes:
  - name: registry-token
    projected:
      sources:
        - serviceAccountToken:
            audience: registry
            path: token
```

---

### Idea for future: type-based provider presets

The Kubernetes config requires several fields with well-known defaults. We could potentially add a `type` field:

```yaml
providers:
  - name: kubernetes
    type: kubernetes  # sets all k8s defaults
    audience: registry  # only required field
```

This would set issuerUrl, jwksUrl, caCertPath, authTokenFile, and allowPrivateIP automatically. Just an idea for now.