### PR TITLE
adds actions that creates tag on release

### DIFF
--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -1,0 +1,214 @@
+# Create Release Tag Workflow
+#
+# This workflow is triggered when the VERSION file is updated on main.
+# It verifies the release PR, creates a git tag, and creates a GitHub Release.
+# The tag then triggers the releaser workflow for image and Helm chart publishing.
+
+name: Create Release Tag
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'VERSION'
+
+permissions:
+  contents: write
+
+jobs:
+  create-tag:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Read version
+        id: version
+        run: |
+          VERSION=$(cat VERSION | tr -d '[:space:]')
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Error: VERSION file does not contain valid semver: $VERSION"
+            exit 1
+          fi
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Read version: $VERSION"
+
+      - name: Verify release PR
+        id: verify
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+
+          # Get commit details
+          COMMIT_MSG=$(git log -1 --pretty=%s)
+          COMMIT_SHA=$(git rev-parse HEAD)
+
+          echo "Commit SHA: $COMMIT_SHA"
+          echo "Commit message: $COMMIT_MSG"
+          echo ""
+
+          # Track verification status
+          VERIFIED=true
+
+          # Check 1: Verify commit message matches release pattern
+          # Squash merge: "Release v1.0.0 (#123)"
+          # Merge commit: "Merge pull request #123 from user/release/v1.0.0"
+          # Direct: "Release v1.0.0"
+          if [[ "$COMMIT_MSG" =~ ^Release\ v[0-9]+\.[0-9]+\.[0-9]+ ]] || \
+             [[ "$COMMIT_MSG" =~ release/v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+            echo "✅ Commit message matches release pattern"
+            echo "message_verified=true" >> $GITHUB_OUTPUT
+          else
+            echo "❌ Commit message does not match release pattern"
+            echo "Expected: 'Release v{semver}' or merge from 'release/v{semver}'"
+            echo "Got: '$COMMIT_MSG'"
+            echo "message_verified=false" >> $GITHUB_OUTPUT
+            VERIFIED=false
+          fi
+
+          # Check 2: Verify the version in commit message matches VERSION file
+          if [[ "$COMMIT_MSG" =~ v${VERSION} ]]; then
+            echo "✅ VERSION file matches version in commit message"
+            echo "version_match=true" >> $GITHUB_OUTPUT
+          else
+            echo "❌ VERSION file does not match version in commit message"
+            echo "VERSION file: $VERSION"
+            echo "Commit message: $COMMIT_MSG"
+            echo "version_match=false" >> $GITHUB_OUTPUT
+            VERIFIED=false
+          fi
+
+          echo ""
+          if [ "$VERIFIED" = true ]; then
+            echo "✅ All verification checks passed"
+            echo "verified=true" >> $GITHUB_OUTPUT
+          else
+            echo "❌ Verification failed"
+            echo ""
+            echo "This could indicate:"
+            echo "  - A manual VERSION file edit (not via release PR)"
+            echo "  - An unexpected commit message format"
+            echo ""
+            echo "Blocking release. Please investigate."
+            echo "verified=false" >> $GITHUB_OUTPUT
+            exit 1
+          fi
+
+      - name: Verify only release files changed
+        id: verify-files
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+
+          # Get the parent commit (before the merge)
+          PARENT_SHA=$(git rev-parse HEAD^)
+
+          echo "Checking files changed in this commit..."
+          echo "Parent commit: $PARENT_SHA"
+          echo ""
+
+          # Get files changed in this commit
+          CHANGED_FILES=$(git diff --name-only "$PARENT_SHA" HEAD)
+          echo "Changed files:"
+          echo "$CHANGED_FILES"
+          echo ""
+
+          # Check each file
+          UNEXPECTED_CHANGES=false
+
+          for FILE in $CHANGED_FILES; do
+            echo -n "  $FILE: "
+
+            # Check if file matches allowed patterns
+            ALLOWED=false
+            if [[ "$FILE" == "VERSION" ]]; then
+              ALLOWED=true
+            elif [[ "$FILE" =~ ^deploy/charts/.*/Chart\.yaml$ ]]; then
+              ALLOWED=true
+            elif [[ "$FILE" =~ ^deploy/charts/.*/values\.yaml$ ]]; then
+              ALLOWED=true
+            fi
+
+            if [ "$ALLOWED" = true ]; then
+              echo "✅ Allowed"
+            else
+              echo "❌ UNEXPECTED"
+              UNEXPECTED_CHANGES=true
+            fi
+          done
+
+          echo ""
+          if [ "$UNEXPECTED_CHANGES" = true ]; then
+            echo "❌ Unexpected file changes detected!"
+            echo ""
+            echo "Only the following files should be modified in a release PR:"
+            echo "  - VERSION"
+            echo "  - deploy/charts/*/Chart.yaml"
+            echo "  - deploy/charts/*/values.yaml"
+            echo ""
+            echo "Blocking release for safety."
+            exit 1
+          else
+            echo "✅ Only release-related files were modified"
+          fi
+
+      - name: Check if tag exists
+        id: check-tag
+        run: |
+          TAG="v${{ steps.version.outputs.version }}"
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            echo "Tag $TAG already exists"
+            echo "exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "Tag $TAG does not exist"
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create tag and GitHub Release
+        if: steps.check-tag.outputs.exists == 'false'
+        run: |
+          TAG="v${{ steps.version.outputs.version }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "$TAG" -m "Release $TAG"
+          git push https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git "$TAG"
+          echo "Created and pushed tag: $TAG"
+
+          # Create GitHub Release (triggers releaser.yml via release event)
+          # Note: Must use PAT (GH_TOKEN) because GITHUB_TOKEN cannot trigger other workflows
+          gh release create "$TAG" \
+            --title "Release $TAG" \
+            --generate-notes
+          echo "Created GitHub Release: $TAG"
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+
+      - name: Summary
+        run: |
+          TAG="v${{ steps.version.outputs.version }}"
+
+          if [ "${{ steps.check-tag.outputs.exists }}" == "true" ]; then
+            echo "## Tag Already Exists" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "Tag \`$TAG\` already exists. No action taken." >> $GITHUB_STEP_SUMMARY
+          else
+            echo "## Release Tag Created" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "### Verification Results" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "| Check | Status |" >> $GITHUB_STEP_SUMMARY
+            echo "|-------|--------|" >> $GITHUB_STEP_SUMMARY
+            echo "| Commit Message | ✅ Release pattern |" >> $GITHUB_STEP_SUMMARY
+            echo "| VERSION Match | ✅ Matches commit |" >> $GITHUB_STEP_SUMMARY
+            echo "| File Changes | ✅ Only release files |" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "### Release Details" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "| Property | Value |" >> $GITHUB_STEP_SUMMARY
+            echo "|----------|-------|" >> $GITHUB_STEP_SUMMARY
+            echo "| Tag | \`$TAG\` |" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "The following workflows will now run:" >> $GITHUB_STEP_SUMMARY
+            echo "- \`releaser.yml\` - Build image and publish Helm chart to GHCR" >> $GITHUB_STEP_SUMMARY
+          fi

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -19,19 +19,56 @@
 # Windows, and macOS.
 # The provenance file can be verified using https://github.com/slsa-framework/slsa-verifier.
 # For more information about SLSA and how it improves the supply-chain, visit slsa.dev.
+#
+# Triggered by: GitHub Release published event (from create-release-tag.yml)
 
 name: Release
 on:
-  push:
-    tags:
-      - 'v*'
+  release:
+    types: [published]
 
 permissions:
   contents: write
 
 jobs:
+  # This job must pass before any other jobs run
+  verify-release:
+    name: Verify Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+
+      - name: Verify tag matches VERSION file
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          VERSION=$(cat VERSION | tr -d '[:space:]')
+
+          echo "Release tag: $TAG"
+          echo "VERSION file: $VERSION"
+
+          # Tag should be "v" + VERSION (e.g., v1.0.0)
+          EXPECTED_TAG="v${VERSION}"
+
+          if [[ "$TAG" != "$EXPECTED_TAG" ]]; then
+            echo ""
+            echo "❌ VERSION MISMATCH!"
+            echo "  Tag:      $TAG"
+            echo "  Expected: $EXPECTED_TAG (from VERSION file)"
+            echo ""
+            echo "The release tag does not match the VERSION file."
+            echo "This could indicate:"
+            echo "  - VERSION file was not updated correctly"
+            echo "  - Tag was created manually with wrong version"
+            exit 1
+          fi
+
+          echo ""
+          echo "✅ Tag matches VERSION file: $TAG"
+
   compute-build-flags:
     name: Compute Build Flags
+    needs: [verify-release]
     runs-on: ubuntu-latest
     outputs:
       commit-date: ${{ steps.ldflags.outputs.commit-date }}
@@ -43,12 +80,14 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
         with:
           fetch-depth: 0
+
       - id: ldflags
         run: |
           echo "commit=$GITHUB_SHA" >> $GITHUB_OUTPUT
           echo "commit-date=$(git log --date=iso8601-strict -1 --pretty=%ct)" >> $GITHUB_OUTPUT
           echo "version=$(git describe --tags --always --dirty)" >> $GITHUB_OUTPUT
           echo "tree-state=$(if git diff --quiet; then echo "clean"; else echo "dirty"; fi)" >> $GITHUB_OUTPUT
+
   release-binaries:
     needs:
       - compute-build-flags

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -198,7 +198,7 @@ git commit -m "Release v${NEW_VERSION}"
 
 # Push branch
 echo "Pushing branch to origin..."
-# git push -u origin "$BRANCH_NAME"
+git push -u origin "$BRANCH_NAME"
 
 # Create PR body
 PR_BODY="## Release v${NEW_VERSION}
@@ -241,12 +241,12 @@ PR_BODY="${PR_BODY}
 
 # Create PR
 echo "Creating pull request..."
-# PR_URL=$(gh pr create \
-#   --title "Release v${NEW_VERSION}" \
-#   --body "$PR_BODY" \
-#   --label "release" \
-#   --head "$BRANCH_NAME" \
-#   --base "main")
+PR_URL=$(gh pr create \
+  --title "Release v${NEW_VERSION}" \
+  --body "$PR_BODY" \
+  --label "release" \
+  --head "$BRANCH_NAME" \
+  --base "main")
 
 # Switch back to main
 echo "Switching back to main branch..."


### PR DESCRIPTION
- changes the trigger for release.yml to happen on published releases
- adds logic into release.yml that ensures the version file has been changed before building images. this stops folks from using Github UI to trigger releases as opposed to `task`
- adds a custom action that creates published releases and tags when a release PR has been merged