### PR TITLE
PR1: database schema and query foundation

### DIFF
--- a/database/migrations/000008_add_registry_config.down.sql
+++ b/database/migrations/000008_add_registry_config.down.sql
@@ -1,0 +1,15 @@
+-- Remove registry configuration columns
+
+-- Drop the partial index
+DROP INDEX IF EXISTS idx_registry_syncable;
+
+-- Drop constraints
+ALTER TABLE registry DROP CONSTRAINT IF EXISTS registry_format_check;
+ALTER TABLE registry DROP CONSTRAINT IF EXISTS registry_source_type_check;
+
+-- Drop columns
+ALTER TABLE registry DROP COLUMN IF EXISTS syncable;
+ALTER TABLE registry DROP COLUMN IF EXISTS filter_config;
+ALTER TABLE registry DROP COLUMN IF EXISTS source_config;
+ALTER TABLE registry DROP COLUMN IF EXISTS format;
+ALTER TABLE registry DROP COLUMN IF EXISTS source_type;

--- a/database/migrations/000008_add_registry_config.up.sql
+++ b/database/migrations/000008_add_registry_config.up.sql
@@ -1,0 +1,27 @@
+-- Add registry configuration columns for API-created registries
+--
+-- These columns store the full registry configuration, enabling registries
+-- to be created via API with all necessary metadata for syncing.
+
+-- Source configuration columns
+ALTER TABLE registry
+ADD COLUMN source_type TEXT,                    -- git, api, file, managed, kubernetes
+ADD COLUMN format TEXT,                         -- toolhive or upstream
+ADD COLUMN source_config JSONB,                 -- source-specific config (URLs, paths)
+ADD COLUMN filter_config JSONB,                 -- name/tag filtering rules
+ADD COLUMN syncable BOOLEAN NOT NULL DEFAULT true;  -- whether registry needs syncing
+
+-- Validation constraints
+ALTER TABLE registry
+ADD CONSTRAINT registry_source_type_check
+    CHECK (source_type IS NULL OR source_type IN ('git', 'api', 'file', 'managed', 'kubernetes')),
+ADD CONSTRAINT registry_format_check
+    CHECK (format IS NULL OR format IN ('toolhive', 'upstream'));
+
+-- Set syncable=false for non-synced registry types
+UPDATE registry SET syncable = false
+WHERE reg_type IN ('MANAGED', 'KUBERNETES')
+   OR (source_type = 'file' AND source_config->>'data' IS NOT NULL AND source_config->>'data' != '');
+
+-- Index for efficient sync job queries
+CREATE INDEX idx_registry_syncable ON registry(syncable) WHERE syncable = true;

--- a/database/queries/registry.sql
+++ b/database/queries/registry.sql
@@ -3,6 +3,10 @@ SELECT id,
        name,
        reg_type,
        creation_type,
+       source_type,
+       format,
+       source_config,
+       filter_config,
        sync_schedule,
        created_at,
        updated_at
@@ -23,6 +27,10 @@ SELECT id,
        name,
        reg_type,
        creation_type,
+       source_type,
+       format,
+       source_config,
+       filter_config,
        sync_schedule,
        created_at,
        updated_at
@@ -34,13 +42,217 @@ SELECT id,
        name,
        reg_type,
        creation_type,
+       source_type,
+       format,
+       source_config,
+       filter_config,
        sync_schedule,
        created_at,
        updated_at
   FROM registry
  WHERE name = sqlc.arg(name);
 
+-- ============================================================================
+-- CONFIG Registry Queries (only operate on creation_type='CONFIG')
+-- ============================================================================
+
+-- name: InsertConfigRegistry :one
+-- Insert a new CONFIG registry with full configuration
+INSERT INTO registry (
+    name,
+    reg_type,
+    creation_type,
+    source_type,
+    format,
+    source_config,
+    filter_config,
+    sync_schedule,
+    syncable,
+    created_at,
+    updated_at
+) VALUES (
+    sqlc.arg(name),
+    sqlc.arg(reg_type),
+    'CONFIG',
+    sqlc.arg(source_type),
+    sqlc.narg(format),
+    sqlc.narg(source_config),
+    sqlc.narg(filter_config),
+    sqlc.narg(sync_schedule),
+    sqlc.arg(syncable),
+    sqlc.arg(created_at),
+    sqlc.arg(updated_at)
+) RETURNING id;
+
+-- name: UpsertConfigRegistry :one
+-- Insert or update a CONFIG registry (only updates if existing is CONFIG type)
+INSERT INTO registry (
+    name,
+    reg_type,
+    creation_type,
+    source_type,
+    format,
+    source_config,
+    filter_config,
+    sync_schedule,
+    syncable,
+    created_at,
+    updated_at
+) VALUES (
+    sqlc.arg(name),
+    sqlc.arg(reg_type),
+    'CONFIG',
+    sqlc.arg(source_type),
+    sqlc.narg(format),
+    sqlc.narg(source_config),
+    sqlc.narg(filter_config),
+    sqlc.narg(sync_schedule),
+    sqlc.arg(syncable),
+    sqlc.arg(created_at),
+    sqlc.arg(updated_at)
+)
+ON CONFLICT (name) DO UPDATE SET
+    reg_type = EXCLUDED.reg_type,
+    source_type = EXCLUDED.source_type,
+    format = EXCLUDED.format,
+    source_config = EXCLUDED.source_config,
+    filter_config = EXCLUDED.filter_config,
+    sync_schedule = EXCLUDED.sync_schedule,
+    syncable = EXCLUDED.syncable,
+    updated_at = EXCLUDED.updated_at
+WHERE registry.creation_type = 'CONFIG'
+RETURNING id;
+
+-- name: BulkUpsertConfigRegistries :many
+-- Bulk insert or update CONFIG registries (only updates existing CONFIG registries)
+INSERT INTO registry (
+    name,
+    reg_type,
+    creation_type,
+    source_type,
+    format,
+    source_config,
+    filter_config,
+    sync_schedule,
+    syncable,
+    created_at,
+    updated_at
+)
+SELECT
+    unnest(sqlc.arg(names)::text[]),
+    unnest(sqlc.arg(reg_types)::registry_type[]),
+    'CONFIG',
+    unnest(sqlc.arg(source_types)::text[]),
+    unnest(sqlc.arg(formats)::text[]),
+    unnest(sqlc.arg(source_configs)::jsonb[]),
+    unnest(sqlc.arg(filter_configs)::jsonb[]),
+    unnest(sqlc.arg(sync_schedules)::interval[]),
+    unnest(sqlc.arg(syncables)::boolean[]),
+    unnest(sqlc.arg(created_ats)::timestamp with time zone[]),
+    unnest(sqlc.arg(updated_ats)::timestamp with time zone[])
+ON CONFLICT (name) DO UPDATE SET
+    reg_type = EXCLUDED.reg_type,
+    source_type = EXCLUDED.source_type,
+    format = EXCLUDED.format,
+    source_config = EXCLUDED.source_config,
+    filter_config = EXCLUDED.filter_config,
+    sync_schedule = EXCLUDED.sync_schedule,
+    syncable = EXCLUDED.syncable,
+    updated_at = EXCLUDED.updated_at
+WHERE registry.creation_type = 'CONFIG'
+RETURNING id, name;
+
+-- name: DeleteConfigRegistriesNotInList :exec
+-- Delete CONFIG registries not in the provided list (for config file sync)
+DELETE FROM registry
+WHERE id NOT IN (SELECT unnest(sqlc.arg(ids)::uuid[]))
+  AND creation_type = 'CONFIG';
+
+-- name: DeleteConfigRegistry :execrows
+-- Delete a CONFIG registry by name (returns 0 if not found or is API type)
+DELETE FROM registry
+WHERE name = sqlc.arg(name)
+  AND creation_type = 'CONFIG';
+
+-- ============================================================================
+-- API Registry Queries (only operate on creation_type='API')
+-- ============================================================================
+
+-- name: InsertAPIRegistry :one
+-- Insert a new API registry with full configuration
+INSERT INTO registry (
+    name,
+    reg_type,
+    creation_type,
+    source_type,
+    format,
+    source_config,
+    filter_config,
+    sync_schedule,
+    syncable,
+    created_at,
+    updated_at
+) VALUES (
+    sqlc.arg(name),
+    sqlc.arg(reg_type),
+    'API',
+    sqlc.arg(source_type),
+    sqlc.narg(format),
+    sqlc.narg(source_config),
+    sqlc.narg(filter_config),
+    sqlc.narg(sync_schedule),
+    sqlc.arg(syncable),
+    sqlc.arg(created_at),
+    sqlc.arg(updated_at)
+) RETURNING *;
+
+-- name: UpdateAPIRegistry :one
+-- Update an existing API registry (returns NULL if not found or is CONFIG type)
+UPDATE registry SET
+    reg_type = sqlc.arg(reg_type),
+    source_type = sqlc.arg(source_type),
+    format = sqlc.narg(format),
+    source_config = sqlc.narg(source_config),
+    filter_config = sqlc.narg(filter_config),
+    sync_schedule = sqlc.narg(sync_schedule),
+    syncable = sqlc.arg(syncable),
+    updated_at = sqlc.arg(updated_at)
+WHERE name = sqlc.arg(name)
+  AND creation_type = 'API'
+RETURNING *;
+
+-- name: DeleteAPIRegistry :execrows
+-- Delete an API registry by name (returns 0 if not found or is CONFIG type)
+DELETE FROM registry
+WHERE name = sqlc.arg(name)
+  AND creation_type = 'API';
+
+-- name: ListAllRegistryNames :many
+SELECT name FROM registry ORDER BY name;
+
+-- name: GetAPIRegistriesByNames :many
+SELECT id,
+       name,
+       reg_type,
+       creation_type,
+       source_type,
+       format,
+       source_config,
+       filter_config,
+       sync_schedule,
+       created_at,
+       updated_at
+FROM registry
+WHERE name = ANY(sqlc.arg(names)::text[])
+  AND creation_type = 'API';
+
+-- ============================================================================
+-- Legacy Queries (to be removed after sync/state migration in PR4)
+-- These maintain backward compatibility with existing callers
+-- ============================================================================
+
 -- name: InsertRegistry :one
+-- DEPRECATED: Use InsertConfigRegistry or InsertAPIRegistry instead
 INSERT INTO registry (
     name,
     reg_type,
@@ -58,6 +270,7 @@ INSERT INTO registry (
 ) RETURNING id;
 
 -- name: UpsertRegistry :one
+-- DEPRECATED: Use UpsertConfigRegistry instead
 INSERT INTO registry (
     name,
     reg_type,
@@ -79,6 +292,7 @@ ON CONFLICT (name) DO UPDATE SET
 RETURNING id;
 
 -- name: BulkUpsertRegistries :many
+-- DEPRECATED: Use BulkUpsertConfigRegistries instead
 INSERT INTO registry (
     name,
     reg_type,
@@ -101,18 +315,11 @@ WHERE registry.creation_type = 'CONFIG'
 RETURNING id, name;
 
 -- name: DeleteRegistriesNotInList :exec
+-- DEPRECATED: Use DeleteConfigRegistriesNotInList instead
 DELETE FROM registry
 WHERE id NOT IN (SELECT unnest(sqlc.arg(ids)::uuid[]))
   AND creation_type = 'CONFIG';
 
 -- name: DeleteRegistry :exec
+-- DEPRECATED: Use DeleteConfigRegistry or DeleteAPIRegistry instead
 DELETE FROM registry WHERE name = sqlc.arg(name);
-
--- name: ListAllRegistryNames :many
-SELECT name FROM registry ORDER BY name;
-
--- name: GetAPIRegistriesByNames :many
-SELECT id, name, reg_type, creation_type, sync_schedule, created_at, updated_at
-FROM registry
-WHERE name = ANY(sqlc.arg(names)::text[])
-  AND creation_type = 'API';

--- a/database/queries/sync.sql
+++ b/database/queries/sync.sql
@@ -135,6 +135,7 @@ SELECT r.name,
        r.sync_schedule::interval AS sync_schedule
 FROM registry_sync rs
 INNER JOIN registry r ON rs.reg_id = r.id
+WHERE r.syncable = true
 ORDER BY rs.ended_at ASC NULLS FIRST, r.name ASC
 FOR UPDATE OF rs SKIP LOCKED;
 

--- a/internal/db/sqlc/models.go
+++ b/internal/db/sqlc/models.go
@@ -247,6 +247,11 @@ type Registry struct {
 	UpdatedAt    *time.Time       `json:"updated_at"`
 	CreationType CreationType     `json:"creation_type"`
 	SyncSchedule pgtypes.Interval `json:"sync_schedule"`
+	SourceType   *string          `json:"source_type"`
+	Format       *string          `json:"format"`
+	SourceConfig []byte           `json:"source_config"`
+	FilterConfig []byte           `json:"filter_config"`
+	Syncable     bool             `json:"syncable"`
 }
 
 type RegistrySync struct {

--- a/internal/db/sqlc/querier.go
+++ b/internal/db/sqlc/querier.go
@@ -12,6 +12,9 @@ import (
 
 type Querier interface {
 	BulkInitializeRegistrySyncs(ctx context.Context, arg BulkInitializeRegistrySyncsParams) error
+	// Bulk insert or update CONFIG registries (only updates existing CONFIG registries)
+	BulkUpsertConfigRegistries(ctx context.Context, arg BulkUpsertConfigRegistriesParams) ([]BulkUpsertConfigRegistriesRow, error)
+	// DEPRECATED: Use BulkUpsertConfigRegistries instead
 	BulkUpsertRegistries(ctx context.Context, arg BulkUpsertRegistriesParams) ([]BulkUpsertRegistriesRow, error)
 	// Temp Icon Table Operations
 	CreateTempIconTable(ctx context.Context) error
@@ -24,11 +27,19 @@ type Querier interface {
 	// sqlc cannot validate these, but we organize them here for maintainability.
 	// Temp Server Table Operations
 	CreateTempServerTable(ctx context.Context) error
+	// Delete an API registry by name (returns 0 if not found or is CONFIG type)
+	DeleteAPIRegistry(ctx context.Context, name string) (int64, error)
+	// Delete CONFIG registries not in the provided list (for config file sync)
+	DeleteConfigRegistriesNotInList(ctx context.Context, ids []uuid.UUID) error
+	// Delete a CONFIG registry by name (returns 0 if not found or is API type)
+	DeleteConfigRegistry(ctx context.Context, name string) (int64, error)
 	DeleteOrphanedIcons(ctx context.Context, serverIds []uuid.UUID) error
 	DeleteOrphanedPackages(ctx context.Context, serverIds []uuid.UUID) error
 	DeleteOrphanedRemotes(ctx context.Context, serverIds []uuid.UUID) error
 	DeleteOrphanedServers(ctx context.Context, arg DeleteOrphanedServersParams) error
+	// DEPRECATED: Use DeleteConfigRegistriesNotInList instead
 	DeleteRegistriesNotInList(ctx context.Context, ids []uuid.UUID) error
+	// DEPRECATED: Use DeleteConfigRegistry or DeleteAPIRegistry instead
 	DeleteRegistry(ctx context.Context, name string) error
 	DeleteServerIconsByServerId(ctx context.Context, serverID uuid.UUID) error
 	DeleteServerPackagesByServerId(ctx context.Context, serverID uuid.UUID) error
@@ -43,6 +54,21 @@ type Querier interface {
 	GetServerIDsByRegistryNameVersion(ctx context.Context, regID uuid.UUID) ([]GetServerIDsByRegistryNameVersionRow, error)
 	GetServerVersion(ctx context.Context, arg GetServerVersionParams) (GetServerVersionRow, error)
 	InitializeRegistrySync(ctx context.Context, arg InitializeRegistrySyncParams) error
+	// ============================================================================
+	// API Registry Queries (only operate on creation_type='API')
+	// ============================================================================
+	// Insert a new API registry with full configuration
+	InsertAPIRegistry(ctx context.Context, arg InsertAPIRegistryParams) (Registry, error)
+	// ============================================================================
+	// CONFIG Registry Queries (only operate on creation_type='CONFIG')
+	// ============================================================================
+	// Insert a new CONFIG registry with full configuration
+	InsertConfigRegistry(ctx context.Context, arg InsertConfigRegistryParams) (uuid.UUID, error)
+	// ============================================================================
+	// Legacy Queries (to be removed after sync/state migration in PR4)
+	// These maintain backward compatibility with existing callers
+	// ============================================================================
+	// DEPRECATED: Use InsertConfigRegistry or InsertAPIRegistry instead
 	InsertRegistry(ctx context.Context, arg InsertRegistryParams) (uuid.UUID, error)
 	InsertRegistrySync(ctx context.Context, arg InsertRegistrySyncParams) (uuid.UUID, error)
 	InsertServerIcon(ctx context.Context, arg InsertServerIconParams) error
@@ -58,11 +84,16 @@ type Querier interface {
 	ListServerRemotes(ctx context.Context, serverIds []uuid.UUID) ([]McpServerRemote, error)
 	ListServerVersions(ctx context.Context, arg ListServerVersionsParams) ([]ListServerVersionsRow, error)
 	ListServers(ctx context.Context, arg ListServersParams) ([]ListServersRow, error)
+	// Update an existing API registry (returns NULL if not found or is CONFIG type)
+	UpdateAPIRegistry(ctx context.Context, arg UpdateAPIRegistryParams) (Registry, error)
 	UpdateRegistrySync(ctx context.Context, arg UpdateRegistrySyncParams) error
 	UpdateRegistrySyncStatusByName(ctx context.Context, arg UpdateRegistrySyncStatusByNameParams) error
+	// Insert or update a CONFIG registry (only updates if existing is CONFIG type)
+	UpsertConfigRegistry(ctx context.Context, arg UpsertConfigRegistryParams) (uuid.UUID, error)
 	UpsertIconsFromTemp(ctx context.Context) error
 	UpsertLatestServerVersion(ctx context.Context, arg UpsertLatestServerVersionParams) (uuid.UUID, error)
 	UpsertPackagesFromTemp(ctx context.Context) error
+	// DEPRECATED: Use UpsertConfigRegistry instead
 	UpsertRegistry(ctx context.Context, arg UpsertRegistryParams) (uuid.UUID, error)
 	UpsertRegistrySyncByName(ctx context.Context, arg UpsertRegistrySyncByNameParams) error
 	UpsertRemotesFromTemp(ctx context.Context) error

--- a/internal/db/sqlc/registry.sql.go
+++ b/internal/db/sqlc/registry.sql.go
@@ -13,6 +13,95 @@ import (
 	"github.com/stacklok/toolhive-registry-server/internal/db/pgtypes"
 )
 
+const bulkUpsertConfigRegistries = `-- name: BulkUpsertConfigRegistries :many
+INSERT INTO registry (
+    name,
+    reg_type,
+    creation_type,
+    source_type,
+    format,
+    source_config,
+    filter_config,
+    sync_schedule,
+    syncable,
+    created_at,
+    updated_at
+)
+SELECT
+    unnest($1::text[]),
+    unnest($2::registry_type[]),
+    'CONFIG',
+    unnest($3::text[]),
+    unnest($4::text[]),
+    unnest($5::jsonb[]),
+    unnest($6::jsonb[]),
+    unnest($7::interval[]),
+    unnest($8::boolean[]),
+    unnest($9::timestamp with time zone[]),
+    unnest($10::timestamp with time zone[])
+ON CONFLICT (name) DO UPDATE SET
+    reg_type = EXCLUDED.reg_type,
+    source_type = EXCLUDED.source_type,
+    format = EXCLUDED.format,
+    source_config = EXCLUDED.source_config,
+    filter_config = EXCLUDED.filter_config,
+    sync_schedule = EXCLUDED.sync_schedule,
+    syncable = EXCLUDED.syncable,
+    updated_at = EXCLUDED.updated_at
+WHERE registry.creation_type = 'CONFIG'
+RETURNING id, name
+`
+
+type BulkUpsertConfigRegistriesParams struct {
+	Names         []string           `json:"names"`
+	RegTypes      []RegistryType     `json:"reg_types"`
+	SourceTypes   []string           `json:"source_types"`
+	Formats       []string           `json:"formats"`
+	SourceConfigs [][]byte           `json:"source_configs"`
+	FilterConfigs [][]byte           `json:"filter_configs"`
+	SyncSchedules []pgtypes.Interval `json:"sync_schedules"`
+	Syncables     []bool             `json:"syncables"`
+	CreatedAts    []time.Time        `json:"created_ats"`
+	UpdatedAts    []time.Time        `json:"updated_ats"`
+}
+
+type BulkUpsertConfigRegistriesRow struct {
+	ID   uuid.UUID `json:"id"`
+	Name string    `json:"name"`
+}
+
+// Bulk insert or update CONFIG registries (only updates existing CONFIG registries)
+func (q *Queries) BulkUpsertConfigRegistries(ctx context.Context, arg BulkUpsertConfigRegistriesParams) ([]BulkUpsertConfigRegistriesRow, error) {
+	rows, err := q.db.Query(ctx, bulkUpsertConfigRegistries,
+		arg.Names,
+		arg.RegTypes,
+		arg.SourceTypes,
+		arg.Formats,
+		arg.SourceConfigs,
+		arg.FilterConfigs,
+		arg.SyncSchedules,
+		arg.Syncables,
+		arg.CreatedAts,
+		arg.UpdatedAts,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []BulkUpsertConfigRegistriesRow{}
+	for rows.Next() {
+		var i BulkUpsertConfigRegistriesRow
+		if err := rows.Scan(&i.ID, &i.Name); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const bulkUpsertRegistries = `-- name: BulkUpsertRegistries :many
 INSERT INTO registry (
     name,
@@ -50,6 +139,7 @@ type BulkUpsertRegistriesRow struct {
 	Name string    `json:"name"`
 }
 
+// DEPRECATED: Use BulkUpsertConfigRegistries instead
 func (q *Queries) BulkUpsertRegistries(ctx context.Context, arg BulkUpsertRegistriesParams) ([]BulkUpsertRegistriesRow, error) {
 	rows, err := q.db.Query(ctx, bulkUpsertRegistries,
 		arg.Names,
@@ -77,12 +167,55 @@ func (q *Queries) BulkUpsertRegistries(ctx context.Context, arg BulkUpsertRegist
 	return items, nil
 }
 
+const deleteAPIRegistry = `-- name: DeleteAPIRegistry :execrows
+DELETE FROM registry
+WHERE name = $1
+  AND creation_type = 'API'
+`
+
+// Delete an API registry by name (returns 0 if not found or is CONFIG type)
+func (q *Queries) DeleteAPIRegistry(ctx context.Context, name string) (int64, error) {
+	result, err := q.db.Exec(ctx, deleteAPIRegistry, name)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
+const deleteConfigRegistriesNotInList = `-- name: DeleteConfigRegistriesNotInList :exec
+DELETE FROM registry
+WHERE id NOT IN (SELECT unnest($1::uuid[]))
+  AND creation_type = 'CONFIG'
+`
+
+// Delete CONFIG registries not in the provided list (for config file sync)
+func (q *Queries) DeleteConfigRegistriesNotInList(ctx context.Context, ids []uuid.UUID) error {
+	_, err := q.db.Exec(ctx, deleteConfigRegistriesNotInList, ids)
+	return err
+}
+
+const deleteConfigRegistry = `-- name: DeleteConfigRegistry :execrows
+DELETE FROM registry
+WHERE name = $1
+  AND creation_type = 'CONFIG'
+`
+
+// Delete a CONFIG registry by name (returns 0 if not found or is API type)
+func (q *Queries) DeleteConfigRegistry(ctx context.Context, name string) (int64, error) {
+	result, err := q.db.Exec(ctx, deleteConfigRegistry, name)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
 const deleteRegistriesNotInList = `-- name: DeleteRegistriesNotInList :exec
 DELETE FROM registry
 WHERE id NOT IN (SELECT unnest($1::uuid[]))
   AND creation_type = 'CONFIG'
 `
 
+// DEPRECATED: Use DeleteConfigRegistriesNotInList instead
 func (q *Queries) DeleteRegistriesNotInList(ctx context.Context, ids []uuid.UUID) error {
 	_, err := q.db.Exec(ctx, deleteRegistriesNotInList, ids)
 	return err
@@ -92,13 +225,24 @@ const deleteRegistry = `-- name: DeleteRegistry :exec
 DELETE FROM registry WHERE name = $1
 `
 
+// DEPRECATED: Use DeleteConfigRegistry or DeleteAPIRegistry instead
 func (q *Queries) DeleteRegistry(ctx context.Context, name string) error {
 	_, err := q.db.Exec(ctx, deleteRegistry, name)
 	return err
 }
 
 const getAPIRegistriesByNames = `-- name: GetAPIRegistriesByNames :many
-SELECT id, name, reg_type, creation_type, sync_schedule, created_at, updated_at
+SELECT id,
+       name,
+       reg_type,
+       creation_type,
+       source_type,
+       format,
+       source_config,
+       filter_config,
+       sync_schedule,
+       created_at,
+       updated_at
 FROM registry
 WHERE name = ANY($1::text[])
   AND creation_type = 'API'
@@ -109,6 +253,10 @@ type GetAPIRegistriesByNamesRow struct {
 	Name         string           `json:"name"`
 	RegType      RegistryType     `json:"reg_type"`
 	CreationType CreationType     `json:"creation_type"`
+	SourceType   *string          `json:"source_type"`
+	Format       *string          `json:"format"`
+	SourceConfig []byte           `json:"source_config"`
+	FilterConfig []byte           `json:"filter_config"`
 	SyncSchedule pgtypes.Interval `json:"sync_schedule"`
 	CreatedAt    *time.Time       `json:"created_at"`
 	UpdatedAt    *time.Time       `json:"updated_at"`
@@ -128,6 +276,10 @@ func (q *Queries) GetAPIRegistriesByNames(ctx context.Context, names []string) (
 			&i.Name,
 			&i.RegType,
 			&i.CreationType,
+			&i.SourceType,
+			&i.Format,
+			&i.SourceConfig,
+			&i.FilterConfig,
 			&i.SyncSchedule,
 			&i.CreatedAt,
 			&i.UpdatedAt,
@@ -147,6 +299,10 @@ SELECT id,
        name,
        reg_type,
        creation_type,
+       source_type,
+       format,
+       source_config,
+       filter_config,
        sync_schedule,
        created_at,
        updated_at
@@ -159,6 +315,10 @@ type GetRegistryRow struct {
 	Name         string           `json:"name"`
 	RegType      RegistryType     `json:"reg_type"`
 	CreationType CreationType     `json:"creation_type"`
+	SourceType   *string          `json:"source_type"`
+	Format       *string          `json:"format"`
+	SourceConfig []byte           `json:"source_config"`
+	FilterConfig []byte           `json:"filter_config"`
 	SyncSchedule pgtypes.Interval `json:"sync_schedule"`
 	CreatedAt    *time.Time       `json:"created_at"`
 	UpdatedAt    *time.Time       `json:"updated_at"`
@@ -172,6 +332,10 @@ func (q *Queries) GetRegistry(ctx context.Context, id uuid.UUID) (GetRegistryRow
 		&i.Name,
 		&i.RegType,
 		&i.CreationType,
+		&i.SourceType,
+		&i.Format,
+		&i.SourceConfig,
+		&i.FilterConfig,
 		&i.SyncSchedule,
 		&i.CreatedAt,
 		&i.UpdatedAt,
@@ -184,6 +348,10 @@ SELECT id,
        name,
        reg_type,
        creation_type,
+       source_type,
+       format,
+       source_config,
+       filter_config,
        sync_schedule,
        created_at,
        updated_at
@@ -196,6 +364,10 @@ type GetRegistryByNameRow struct {
 	Name         string           `json:"name"`
 	RegType      RegistryType     `json:"reg_type"`
 	CreationType CreationType     `json:"creation_type"`
+	SourceType   *string          `json:"source_type"`
+	Format       *string          `json:"format"`
+	SourceConfig []byte           `json:"source_config"`
+	FilterConfig []byte           `json:"filter_config"`
 	SyncSchedule pgtypes.Interval `json:"sync_schedule"`
 	CreatedAt    *time.Time       `json:"created_at"`
 	UpdatedAt    *time.Time       `json:"updated_at"`
@@ -209,6 +381,10 @@ func (q *Queries) GetRegistryByName(ctx context.Context, name string) (GetRegist
 		&i.Name,
 		&i.RegType,
 		&i.CreationType,
+		&i.SourceType,
+		&i.Format,
+		&i.SourceConfig,
+		&i.FilterConfig,
 		&i.SyncSchedule,
 		&i.CreatedAt,
 		&i.UpdatedAt,
@@ -216,7 +392,149 @@ func (q *Queries) GetRegistryByName(ctx context.Context, name string) (GetRegist
 	return i, err
 }
 
+const insertAPIRegistry = `-- name: InsertAPIRegistry :one
+
+INSERT INTO registry (
+    name,
+    reg_type,
+    creation_type,
+    source_type,
+    format,
+    source_config,
+    filter_config,
+    sync_schedule,
+    syncable,
+    created_at,
+    updated_at
+) VALUES (
+    $1,
+    $2,
+    'API',
+    $3,
+    $4,
+    $5,
+    $6,
+    $7,
+    $8,
+    $9,
+    $10
+) RETURNING id, name, reg_type, created_at, updated_at, creation_type, sync_schedule, source_type, format, source_config, filter_config, syncable
+`
+
+type InsertAPIRegistryParams struct {
+	Name         string           `json:"name"`
+	RegType      RegistryType     `json:"reg_type"`
+	SourceType   *string          `json:"source_type"`
+	Format       *string          `json:"format"`
+	SourceConfig []byte           `json:"source_config"`
+	FilterConfig []byte           `json:"filter_config"`
+	SyncSchedule pgtypes.Interval `json:"sync_schedule"`
+	Syncable     bool             `json:"syncable"`
+	CreatedAt    *time.Time       `json:"created_at"`
+	UpdatedAt    *time.Time       `json:"updated_at"`
+}
+
+// ============================================================================
+// API Registry Queries (only operate on creation_type='API')
+// ============================================================================
+// Insert a new API registry with full configuration
+func (q *Queries) InsertAPIRegistry(ctx context.Context, arg InsertAPIRegistryParams) (Registry, error) {
+	row := q.db.QueryRow(ctx, insertAPIRegistry,
+		arg.Name,
+		arg.RegType,
+		arg.SourceType,
+		arg.Format,
+		arg.SourceConfig,
+		arg.FilterConfig,
+		arg.SyncSchedule,
+		arg.Syncable,
+		arg.CreatedAt,
+		arg.UpdatedAt,
+	)
+	var i Registry
+	err := row.Scan(
+		&i.ID,
+		&i.Name,
+		&i.RegType,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.CreationType,
+		&i.SyncSchedule,
+		&i.SourceType,
+		&i.Format,
+		&i.SourceConfig,
+		&i.FilterConfig,
+		&i.Syncable,
+	)
+	return i, err
+}
+
+const insertConfigRegistry = `-- name: InsertConfigRegistry :one
+
+INSERT INTO registry (
+    name,
+    reg_type,
+    creation_type,
+    source_type,
+    format,
+    source_config,
+    filter_config,
+    sync_schedule,
+    syncable,
+    created_at,
+    updated_at
+) VALUES (
+    $1,
+    $2,
+    'CONFIG',
+    $3,
+    $4,
+    $5,
+    $6,
+    $7,
+    $8,
+    $9,
+    $10
+) RETURNING id
+`
+
+type InsertConfigRegistryParams struct {
+	Name         string           `json:"name"`
+	RegType      RegistryType     `json:"reg_type"`
+	SourceType   *string          `json:"source_type"`
+	Format       *string          `json:"format"`
+	SourceConfig []byte           `json:"source_config"`
+	FilterConfig []byte           `json:"filter_config"`
+	SyncSchedule pgtypes.Interval `json:"sync_schedule"`
+	Syncable     bool             `json:"syncable"`
+	CreatedAt    *time.Time       `json:"created_at"`
+	UpdatedAt    *time.Time       `json:"updated_at"`
+}
+
+// ============================================================================
+// CONFIG Registry Queries (only operate on creation_type='CONFIG')
+// ============================================================================
+// Insert a new CONFIG registry with full configuration
+func (q *Queries) InsertConfigRegistry(ctx context.Context, arg InsertConfigRegistryParams) (uuid.UUID, error) {
+	row := q.db.QueryRow(ctx, insertConfigRegistry,
+		arg.Name,
+		arg.RegType,
+		arg.SourceType,
+		arg.Format,
+		arg.SourceConfig,
+		arg.FilterConfig,
+		arg.SyncSchedule,
+		arg.Syncable,
+		arg.CreatedAt,
+		arg.UpdatedAt,
+	)
+	var id uuid.UUID
+	err := row.Scan(&id)
+	return id, err
+}
+
 const insertRegistry = `-- name: InsertRegistry :one
+
 INSERT INTO registry (
     name,
     reg_type,
@@ -243,6 +561,11 @@ type InsertRegistryParams struct {
 	UpdatedAt    *time.Time       `json:"updated_at"`
 }
 
+// ============================================================================
+// Legacy Queries (to be removed after sync/state migration in PR4)
+// These maintain backward compatibility with existing callers
+// ============================================================================
+// DEPRECATED: Use InsertConfigRegistry or InsertAPIRegistry instead
 func (q *Queries) InsertRegistry(ctx context.Context, arg InsertRegistryParams) (uuid.UUID, error) {
 	row := q.db.QueryRow(ctx, insertRegistry,
 		arg.Name,
@@ -286,6 +609,10 @@ SELECT id,
        name,
        reg_type,
        creation_type,
+       source_type,
+       format,
+       source_config,
+       filter_config,
        sync_schedule,
        created_at,
        updated_at
@@ -313,6 +640,10 @@ type ListRegistriesRow struct {
 	Name         string           `json:"name"`
 	RegType      RegistryType     `json:"reg_type"`
 	CreationType CreationType     `json:"creation_type"`
+	SourceType   *string          `json:"source_type"`
+	Format       *string          `json:"format"`
+	SourceConfig []byte           `json:"source_config"`
+	FilterConfig []byte           `json:"filter_config"`
 	SyncSchedule pgtypes.Interval `json:"sync_schedule"`
 	CreatedAt    *time.Time       `json:"created_at"`
 	UpdatedAt    *time.Time       `json:"updated_at"`
@@ -332,6 +663,10 @@ func (q *Queries) ListRegistries(ctx context.Context, arg ListRegistriesParams) 
 			&i.Name,
 			&i.RegType,
 			&i.CreationType,
+			&i.SourceType,
+			&i.Format,
+			&i.SourceConfig,
+			&i.FilterConfig,
 			&i.SyncSchedule,
 			&i.CreatedAt,
 			&i.UpdatedAt,
@@ -344,6 +679,135 @@ func (q *Queries) ListRegistries(ctx context.Context, arg ListRegistriesParams) 
 		return nil, err
 	}
 	return items, nil
+}
+
+const updateAPIRegistry = `-- name: UpdateAPIRegistry :one
+UPDATE registry SET
+    reg_type = $1,
+    source_type = $2,
+    format = $3,
+    source_config = $4,
+    filter_config = $5,
+    sync_schedule = $6,
+    syncable = $7,
+    updated_at = $8
+WHERE name = $9
+  AND creation_type = 'API'
+RETURNING id, name, reg_type, created_at, updated_at, creation_type, sync_schedule, source_type, format, source_config, filter_config, syncable
+`
+
+type UpdateAPIRegistryParams struct {
+	RegType      RegistryType     `json:"reg_type"`
+	SourceType   *string          `json:"source_type"`
+	Format       *string          `json:"format"`
+	SourceConfig []byte           `json:"source_config"`
+	FilterConfig []byte           `json:"filter_config"`
+	SyncSchedule pgtypes.Interval `json:"sync_schedule"`
+	Syncable     bool             `json:"syncable"`
+	UpdatedAt    *time.Time       `json:"updated_at"`
+	Name         string           `json:"name"`
+}
+
+// Update an existing API registry (returns NULL if not found or is CONFIG type)
+func (q *Queries) UpdateAPIRegistry(ctx context.Context, arg UpdateAPIRegistryParams) (Registry, error) {
+	row := q.db.QueryRow(ctx, updateAPIRegistry,
+		arg.RegType,
+		arg.SourceType,
+		arg.Format,
+		arg.SourceConfig,
+		arg.FilterConfig,
+		arg.SyncSchedule,
+		arg.Syncable,
+		arg.UpdatedAt,
+		arg.Name,
+	)
+	var i Registry
+	err := row.Scan(
+		&i.ID,
+		&i.Name,
+		&i.RegType,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.CreationType,
+		&i.SyncSchedule,
+		&i.SourceType,
+		&i.Format,
+		&i.SourceConfig,
+		&i.FilterConfig,
+		&i.Syncable,
+	)
+	return i, err
+}
+
+const upsertConfigRegistry = `-- name: UpsertConfigRegistry :one
+INSERT INTO registry (
+    name,
+    reg_type,
+    creation_type,
+    source_type,
+    format,
+    source_config,
+    filter_config,
+    sync_schedule,
+    syncable,
+    created_at,
+    updated_at
+) VALUES (
+    $1,
+    $2,
+    'CONFIG',
+    $3,
+    $4,
+    $5,
+    $6,
+    $7,
+    $8,
+    $9,
+    $10
+)
+ON CONFLICT (name) DO UPDATE SET
+    reg_type = EXCLUDED.reg_type,
+    source_type = EXCLUDED.source_type,
+    format = EXCLUDED.format,
+    source_config = EXCLUDED.source_config,
+    filter_config = EXCLUDED.filter_config,
+    sync_schedule = EXCLUDED.sync_schedule,
+    syncable = EXCLUDED.syncable,
+    updated_at = EXCLUDED.updated_at
+WHERE registry.creation_type = 'CONFIG'
+RETURNING id
+`
+
+type UpsertConfigRegistryParams struct {
+	Name         string           `json:"name"`
+	RegType      RegistryType     `json:"reg_type"`
+	SourceType   *string          `json:"source_type"`
+	Format       *string          `json:"format"`
+	SourceConfig []byte           `json:"source_config"`
+	FilterConfig []byte           `json:"filter_config"`
+	SyncSchedule pgtypes.Interval `json:"sync_schedule"`
+	Syncable     bool             `json:"syncable"`
+	CreatedAt    *time.Time       `json:"created_at"`
+	UpdatedAt    *time.Time       `json:"updated_at"`
+}
+
+// Insert or update a CONFIG registry (only updates if existing is CONFIG type)
+func (q *Queries) UpsertConfigRegistry(ctx context.Context, arg UpsertConfigRegistryParams) (uuid.UUID, error) {
+	row := q.db.QueryRow(ctx, upsertConfigRegistry,
+		arg.Name,
+		arg.RegType,
+		arg.SourceType,
+		arg.Format,
+		arg.SourceConfig,
+		arg.FilterConfig,
+		arg.SyncSchedule,
+		arg.Syncable,
+		arg.CreatedAt,
+		arg.UpdatedAt,
+	)
+	var id uuid.UUID
+	err := row.Scan(&id)
+	return id, err
 }
 
 const upsertRegistry = `-- name: UpsertRegistry :one
@@ -377,6 +841,7 @@ type UpsertRegistryParams struct {
 	UpdatedAt    *time.Time       `json:"updated_at"`
 }
 
+// DEPRECATED: Use UpsertConfigRegistry instead
 func (q *Queries) UpsertRegistry(ctx context.Context, arg UpsertRegistryParams) (uuid.UUID, error) {
 	row := q.db.QueryRow(ctx, upsertRegistry,
 		arg.Name,

--- a/internal/db/sqlc/sync.sql.go
+++ b/internal/db/sqlc/sync.sql.go
@@ -242,6 +242,7 @@ SELECT r.name,
        r.sync_schedule::interval AS sync_schedule
 FROM registry_sync rs
 INNER JOIN registry r ON rs.reg_id = r.id
+WHERE r.syncable = true
 ORDER BY rs.ended_at ASC NULLS FIRST, r.name ASC
 FOR UPDATE OF rs SKIP LOCKED
 `


### PR DESCRIPTION
The following PR is Part 1 of splitting #318 to smaller pieces

**Details:**
- Add new columns to registry table: source_type, format, source_config (JSONB), filter_config (JSONB), syncable                                
- Add creation_type column to distinguish CONFIG vs API registries                                                                              
- Create new SQL queries that respect creation_type separation                                                                                  
- Regenerate sqlc models 