### PR TITLE
Fix name filter to support matching across slashes

### DIFF
--- a/internal/filtering/name_filter_test.go
+++ b/internal/filtering/name_filter_test.go
@@ -126,6 +126,15 @@ func TestDefaultNameFilter_ShouldInclude(t *testing.T) {
 			expected:   false,
 			reason:     "no include match should exclude even if exclude doesn't match",
 		},
+		// Issue #300: exclude pattern with slash-separated names
+		{
+			name:       "exclude pattern should match names with slashes (issue #300)",
+			serverName: "io.github.stacklok/context7-remote",
+			include:    []string{"io.github.stacklok/context7*"},
+			exclude:    []string{"*-remote"},
+			expected:   false,
+			reason:     "exclude pattern '*-remote' should exclude 'io.github.stacklok/context7-remote' even though it matches include pattern",
+		},
 		// Complex glob patterns
 		{
 			name:       "question mark wildcard",


### PR DESCRIPTION
## Description

This PR fixes issue #300 where exclude patterns like `*-remote` didn't match server names containing slashes (e.g., `io.github.stacklok/context7-remote`).

## Problem

The `filepath.Match` function doesn't allow `*` wildcards to match across path separators (`/`), which caused exclude patterns to fail for server names with slashes.

## Solution

- Replaced `filepath.Match` with `gobwas/glob` library (already in dependencies)
- `gobwas/glob` supports matching across slashes when no separators are specified
- Added test case to verify the fix for issue #300

## Changes

- `internal/filtering/name_filter.go`: Use `gobwas/glob` instead of `filepath.Match`
- `internal/filtering/name_filter_test.go`: Add test case for slash-separated names

## Testing

- All existing tests pass
- New test case verifies `*-remote` pattern matches `io.github.stacklok/context7-remote`

Fixes #300