### PR TITLE
Fix data when syncing from toolhive format

### DIFF
--- a/database/migrations/000009_enhance_env_vars_metadata.down.sql
+++ b/database/migrations/000009_enhance_env_vars_metadata.down.sql
@@ -1,0 +1,55 @@
+-- Rollback migration: Convert JSONB back to TEXT[] (only preserves names)
+
+-- Step 1: Add TEXT[] columns to mcp_server_package
+ALTER TABLE mcp_server_package
+    ADD COLUMN env_vars_text TEXT[],
+    ADD COLUMN transport_headers_text TEXT[];
+
+-- Step 2: Extract names from JSONB and store in TEXT[]
+UPDATE mcp_server_package
+SET env_vars_text = CASE
+    WHEN env_vars IS NULL OR env_vars = '[]'::jsonb THEN '{}'::text[]
+    ELSE (
+        SELECT array_agg(elem->>'name')
+        FROM jsonb_array_elements(env_vars) AS elem
+    )
+END,
+transport_headers_text = CASE
+    WHEN transport_headers IS NULL OR transport_headers = '[]'::jsonb THEN '{}'::text[]
+    ELSE (
+        SELECT array_agg(elem->>'name')
+        FROM jsonb_array_elements(transport_headers) AS elem
+    )
+END;
+
+-- Step 3: Drop JSONB columns and rename TEXT[] columns
+ALTER TABLE mcp_server_package
+    DROP COLUMN env_vars,
+    DROP COLUMN transport_headers;
+
+ALTER TABLE mcp_server_package
+    RENAME COLUMN env_vars_text TO env_vars;
+
+ALTER TABLE mcp_server_package
+    RENAME COLUMN transport_headers_text TO transport_headers;
+
+-- Step 4: Add TEXT[] column to mcp_server_remote
+ALTER TABLE mcp_server_remote
+    ADD COLUMN transport_headers_text TEXT[];
+
+-- Step 5: Extract names from JSONB
+UPDATE mcp_server_remote
+SET transport_headers_text = CASE
+    WHEN transport_headers IS NULL OR transport_headers = '[]'::jsonb THEN '{}'::text[]
+    ELSE (
+        SELECT array_agg(elem->>'name')
+        FROM jsonb_array_elements(transport_headers) AS elem
+    )
+END;
+
+-- Step 6: Drop JSONB column and rename TEXT[] column
+ALTER TABLE mcp_server_remote
+    DROP COLUMN transport_headers;
+
+ALTER TABLE mcp_server_remote
+    RENAME COLUMN transport_headers_text TO transport_headers;

--- a/database/migrations/000009_enhance_env_vars_metadata.up.sql
+++ b/database/migrations/000009_enhance_env_vars_metadata.up.sql
@@ -1,0 +1,57 @@
+-- Migration to preserve full metadata for environment variables and transport headers
+-- Changes TEXT[] columns to JSONB to store complete KeyValueInput objects
+
+-- Step 1: Add new JSONB columns to mcp_server_package
+ALTER TABLE mcp_server_package
+    ADD COLUMN env_vars_json JSONB,
+    ADD COLUMN transport_headers_json JSONB;
+
+-- Step 2: Migrate existing data from TEXT[] to JSONB format
+-- Convert ["VAR1", "VAR2"] to [{"name": "VAR1"}, {"name": "VAR2"}]
+UPDATE mcp_server_package
+SET env_vars_json = CASE
+    WHEN env_vars IS NULL OR array_length(env_vars, 1) IS NULL THEN '[]'::jsonb
+    ELSE (
+        SELECT jsonb_agg(jsonb_build_object('name', elem))
+        FROM unnest(env_vars) AS elem
+    )
+END,
+transport_headers_json = CASE
+    WHEN transport_headers IS NULL OR array_length(transport_headers, 1) IS NULL THEN '[]'::jsonb
+    ELSE (
+        SELECT jsonb_agg(jsonb_build_object('name', elem))
+        FROM unnest(transport_headers) AS elem
+    )
+END;
+
+-- Step 3: Drop old columns and rename new ones
+ALTER TABLE mcp_server_package
+    DROP COLUMN env_vars,
+    DROP COLUMN transport_headers;
+
+ALTER TABLE mcp_server_package
+    RENAME COLUMN env_vars_json TO env_vars;
+
+ALTER TABLE mcp_server_package
+    RENAME COLUMN transport_headers_json TO transport_headers;
+
+-- Step 4: Add new JSONB column to mcp_server_remote
+ALTER TABLE mcp_server_remote
+    ADD COLUMN transport_headers_json JSONB;
+
+-- Step 5: Migrate existing data
+UPDATE mcp_server_remote
+SET transport_headers_json = CASE
+    WHEN transport_headers IS NULL OR array_length(transport_headers, 1) IS NULL THEN '[]'::jsonb
+    ELSE (
+        SELECT jsonb_agg(jsonb_build_object('name', elem))
+        FROM unnest(transport_headers) AS elem
+    )
+END;
+
+-- Step 6: Drop old column and rename new one
+ALTER TABLE mcp_server_remote
+    DROP COLUMN transport_headers;
+
+ALTER TABLE mcp_server_remote
+    RENAME COLUMN transport_headers_json TO transport_headers;

--- a/internal/db/sqlc/models.go
+++ b/internal/db/sqlc/models.go
@@ -225,18 +225,18 @@ type McpServerPackage struct {
 	RuntimeHint      *string   `json:"runtime_hint"`
 	RuntimeArguments []string  `json:"runtime_arguments"`
 	PackageArguments []string  `json:"package_arguments"`
-	EnvVars          []string  `json:"env_vars"`
 	Sha256Hash       *string   `json:"sha256_hash"`
 	Transport        string    `json:"transport"`
 	TransportUrl     *string   `json:"transport_url"`
-	TransportHeaders []string  `json:"transport_headers"`
+	EnvVars          []byte    `json:"env_vars"`
+	TransportHeaders []byte    `json:"transport_headers"`
 }
 
 type McpServerRemote struct {
 	ServerID         uuid.UUID `json:"server_id"`
 	Transport        string    `json:"transport"`
 	TransportUrl     string    `json:"transport_url"`
-	TransportHeaders []string  `json:"transport_headers"`
+	TransportHeaders []byte    `json:"transport_headers"`
 }
 
 type Registry struct {

--- a/internal/db/sqlc/querier.go
+++ b/internal/db/sqlc/querier.go
@@ -68,7 +68,7 @@ type Querier interface {
 	ListRegistries(ctx context.Context, arg ListRegistriesParams) ([]ListRegistriesRow, error)
 	ListRegistrySyncs(ctx context.Context) ([]ListRegistrySyncsRow, error)
 	ListRegistrySyncsByLastUpdate(ctx context.Context) ([]ListRegistrySyncsByLastUpdateRow, error)
-	ListServerPackages(ctx context.Context, serverIds []uuid.UUID) ([]McpServerPackage, error)
+	ListServerPackages(ctx context.Context, serverIds []uuid.UUID) ([]ListServerPackagesRow, error)
 	ListServerRemotes(ctx context.Context, serverIds []uuid.UUID) ([]McpServerRemote, error)
 	ListServerVersions(ctx context.Context, arg ListServerVersionsParams) ([]ListServerVersionsRow, error)
 	ListServers(ctx context.Context, arg ListServersParams) ([]ListServersRow, error)

--- a/internal/db/sqlc/servers.sql.go
+++ b/internal/db/sqlc/servers.sql.go
@@ -267,11 +267,11 @@ type InsertServerPackageParams struct {
 	RuntimeHint      *string   `json:"runtime_hint"`
 	RuntimeArguments []string  `json:"runtime_arguments"`
 	PackageArguments []string  `json:"package_arguments"`
-	EnvVars          []string  `json:"env_vars"`
+	EnvVars          []byte    `json:"env_vars"`
 	Sha256Hash       *string   `json:"sha256_hash"`
 	Transport        string    `json:"transport"`
 	TransportUrl     *string   `json:"transport_url"`
-	TransportHeaders []string  `json:"transport_headers"`
+	TransportHeaders []byte    `json:"transport_headers"`
 }
 
 func (q *Queries) InsertServerPackage(ctx context.Context, arg InsertServerPackageParams) error {
@@ -311,7 +311,7 @@ type InsertServerRemoteParams struct {
 	ServerID         uuid.UUID `json:"server_id"`
 	Transport        string    `json:"transport"`
 	TransportUrl     string    `json:"transport_url"`
-	TransportHeaders []string  `json:"transport_headers"`
+	TransportHeaders []byte    `json:"transport_headers"`
 }
 
 func (q *Queries) InsertServerRemote(ctx context.Context, arg InsertServerRemoteParams) error {
@@ -492,15 +492,31 @@ SELECT p.server_id,
  ORDER BY p.pkg_version DESC
 `
 
-func (q *Queries) ListServerPackages(ctx context.Context, serverIds []uuid.UUID) ([]McpServerPackage, error) {
+type ListServerPackagesRow struct {
+	ServerID         uuid.UUID `json:"server_id"`
+	RegistryType     string    `json:"registry_type"`
+	PkgRegistryUrl   string    `json:"pkg_registry_url"`
+	PkgIdentifier    string    `json:"pkg_identifier"`
+	PkgVersion       string    `json:"pkg_version"`
+	RuntimeHint      *string   `json:"runtime_hint"`
+	RuntimeArguments []string  `json:"runtime_arguments"`
+	PackageArguments []string  `json:"package_arguments"`
+	EnvVars          []byte    `json:"env_vars"`
+	Sha256Hash       *string   `json:"sha256_hash"`
+	Transport        string    `json:"transport"`
+	TransportUrl     *string   `json:"transport_url"`
+	TransportHeaders []byte    `json:"transport_headers"`
+}
+
+func (q *Queries) ListServerPackages(ctx context.Context, serverIds []uuid.UUID) ([]ListServerPackagesRow, error) {
 	rows, err := q.db.Query(ctx, listServerPackages, serverIds)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	items := []McpServerPackage{}
+	items := []ListServerPackagesRow{}
 	for rows.Next() {
-		var i McpServerPackage
+		var i ListServerPackagesRow
 		if err := rows.Scan(
 			&i.ServerID,
 			&i.RegistryType,

--- a/internal/db/sqlc/servers_test.go
+++ b/internal/db/sqlc/servers_test.go
@@ -1024,11 +1024,11 @@ func TestInsertServerPackage(t *testing.T) {
 						RuntimeHint:      ptr.String("npx"),
 						RuntimeArguments: []string{"--yes"},
 						PackageArguments: []string{"--arg", "value"},
-						EnvVars:          []string{"NODE_ENV", "API_KEY"},
+						EnvVars:          []byte(`[{"name":"NODE_ENV"},{"name":"API_KEY"}]`),
 						Sha256Hash:       ptr.String("abc123"),
 						Transport:        "stdio",
 						TransportUrl:     ptr.String("https://example.com"),
-						TransportHeaders: []string{"Authorization: Bearer token"},
+						TransportHeaders: []byte(`[{"name":"Authorization: Bearer token"}]`),
 					},
 				)
 				require.NoError(t, err)
@@ -1144,7 +1144,7 @@ func TestInsertServerRemote(t *testing.T) {
 						ServerID:         serverID,
 						Transport:        "sse",
 						TransportUrl:     "https://example.com/sse",
-						TransportHeaders: []string{"Authorization: Bearer token", "X-Custom: value"},
+						TransportHeaders: []byte(`[{"name":"Authorization: Bearer token"},{"name":"X-Custom: value"}]`),
 					},
 				)
 				require.NoError(t, err)
@@ -1175,7 +1175,7 @@ func TestInsertServerRemote(t *testing.T) {
 						ServerID:         serverID,
 						Transport:        "sse",
 						TransportUrl:     "https://example.com/sse",
-						TransportHeaders: []string{"Old-Header: old"},
+						TransportHeaders: []byte(`[{"name":"Old-Header: old"}]`),
 					},
 				)
 				require.NoError(t, err)
@@ -1191,7 +1191,7 @@ func TestInsertServerRemote(t *testing.T) {
 						ServerID:         serverID,
 						Transport:        "sse",
 						TransportUrl:     "https://example.com/sse",
-						TransportHeaders: []string{"New-Header: new"},
+						TransportHeaders: []byte(`[{"name":"New-Header: new"}]`),
 					},
 				)
 				require.Error(t, err)

--- a/internal/db/sqlc/temp_tables.sql.go
+++ b/internal/db/sqlc/temp_tables.sql.go
@@ -27,7 +27,7 @@ func (q *Queries) CreateTempIconTable(ctx context.Context) error {
 const createTempPackageTable = `-- name: CreateTempPackageTable :exec
 
 CREATE TEMP TABLE temp_mcp_server_package ON COMMIT DROP AS
-SELECT server_id, registry_type, pkg_registry_url, pkg_identifier, pkg_version, runtime_hint, runtime_arguments, package_arguments, env_vars, sha256_hash, transport, transport_url, transport_headers FROM mcp_server_package
+SELECT server_id, registry_type, pkg_registry_url, pkg_identifier, pkg_version, runtime_hint, runtime_arguments, package_arguments, sha256_hash, transport, transport_url, env_vars, transport_headers FROM mcp_server_package
   WITH NO DATA
 `
 

--- a/internal/service/db/impl_test.go
+++ b/internal/service/db/impl_test.go
@@ -740,11 +740,11 @@ func TestGetServerVersion(t *testing.T) {
 						RuntimeHint:      ptr.String("npx"),
 						RuntimeArguments: []string{"--yes"},
 						PackageArguments: []string{"--arg", "value"},
-						EnvVars:          []string{"NODE_ENV"},
+						EnvVars:          []byte(`[{"name":"NODE_ENV"}]`),
 						Sha256Hash:       ptr.String("abc123def456"),
 						Transport:        "stdio",
 						TransportUrl:     ptr.String("https://example.com/transport"),
-						TransportHeaders: []string{"X-Custom: header"},
+						TransportHeaders: []byte(`[{"name":"X-Custom: header"}]`),
 					},
 				)
 				require.NoError(t, err)
@@ -756,7 +756,7 @@ func TestGetServerVersion(t *testing.T) {
 						ServerID:         serverID,
 						Transport:        "sse",
 						TransportUrl:     "https://example.com/sse",
-						TransportHeaders: []string{"Authorization: Bearer token"},
+						TransportHeaders: []byte(`[{"name":"Authorization: Bearer token"}]`),
 					},
 				)
 				require.NoError(t, err)


### PR DESCRIPTION
This change fixes a bug due to `env_vars` being represented as `TEXT` rather than a structured object like it actually is. The code used to store only the variable name instead of storing all fields that both ToolHive format and Upstream format use to determine whether it's a secret, or is mandatory, etc.

The fix consists in replacing `TEXT` with `JSONB` and fixing storage routines accordingly.

Fixes #304