### PR TITLE
uses release token & upgrades releaseo action

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -55,7 +55,7 @@ jobs:
             - file: deploy/charts/toolhive-registry-server/values.yaml
               path: image.tag
               prefix: v
-          helm_docs_args: --chart-search-root=deploy/charts --template-files=README.md.gotmpl --template-files=./_templates.gotmpl
+          helm_docs_args: --chart-search-root=deploy/charts
 
       - name: Summary
         run: |


### PR DESCRIPTION
the standard GITHUB_TOKEN  that is usable in the Actions pipelines doesn't trigger workflows if you create PRs with it. Here we use a release token that we associate with the stacklokbot instead so it triggers CI workflows from the PRs that are created with it.

We also want to use the new version of releaseo for trial.

We also remove the templates files flags and let `helm-docs` auto-discover them