### PR TITLE
Add OpenTelemetry foundation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,13 @@ require (
 	github.com/swaggo/swag/v2 v2.0.0-rc5
 	github.com/testcontainers/testcontainers-go v0.40.0
 	github.com/testcontainers/testcontainers-go/modules/postgres v0.40.0
+	go.opentelemetry.io/otel v1.39.0
+	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.39.0
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.39.0
+	go.opentelemetry.io/otel/metric v1.39.0
+	go.opentelemetry.io/otel/sdk v1.39.0
+	go.opentelemetry.io/otel/sdk/metric v1.39.0
+	go.opentelemetry.io/otel/trace v1.39.0
 	go.uber.org/mock v0.6.0
 	golang.org/x/term v0.39.0
 	gopkg.in/yaml.v3 v3.0.1
@@ -162,15 +169,8 @@ require (
 	github.com/zalando/go-keyring v0.2.6 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.63.0 // indirect
-	go.opentelemetry.io/otel v1.39.0 // indirect
-	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.39.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.39.0 // indirect
-	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.39.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.61.0 // indirect
-	go.opentelemetry.io/otel/metric v1.39.0 // indirect
-	go.opentelemetry.io/otel/sdk v1.39.0 // indirect
-	go.opentelemetry.io/otel/sdk/metric v1.39.0 // indirect
-	go.opentelemetry.io/otel/trace v1.39.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.9.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.1 // indirect

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,6 +11,8 @@ import (
 	"time"
 
 	"github.com/spf13/viper"
+
+	"github.com/stacklok/toolhive-registry-server/internal/telemetry"
 )
 
 // SourceType represents the type of registry data source
@@ -110,6 +112,7 @@ type Config struct {
 	Database     *DatabaseConfig    `yaml:"database,omitempty"`
 	FileStorage  *FileStorageConfig `yaml:"fileStorage,omitempty"`
 	Auth         *AuthConfig        `yaml:"auth,omitempty"`
+	Telemetry    *telemetry.Config  `yaml:"telemetry,omitempty"`
 
 	// insecureAllowHTTP allows HTTP URLs for OAuth issuer URLs (development only)
 	// Can be set via THV_REGISTRY_INSECURE_URL environment variable

--- a/internal/telemetry/config.go
+++ b/internal/telemetry/config.go
@@ -1,0 +1,161 @@
+// Package telemetry provides OpenTelemetry instrumentation for the registry server.
+// It supports configurable tracing and metrics with OTLP exporters.
+package telemetry
+
+import (
+	"errors"
+	"fmt"
+)
+
+const (
+	// DefaultServiceName is the default service name for telemetry
+	DefaultServiceName = "thv-registry-api"
+
+	// DefaultEndpoint is the default OTLP endpoint for telemetry
+	DefaultEndpoint = "localhost:4318"
+
+	// DefaultSampling is the default trace sampling rate (5%)
+	// This provides a reasonable balance between observability and overhead
+	DefaultSampling = 0.05
+)
+
+// Config represents the root telemetry configuration
+type Config struct {
+	// Enabled controls whether telemetry is enabled globally
+	// When false, no telemetry providers are initialized
+	Enabled bool `yaml:"enabled"`
+
+	// ServiceName is the name of the service for telemetry identification
+	// Defaults to "thv-registry-api" if not specified
+	ServiceName string `yaml:"serviceName,omitempty"`
+
+	// ServiceVersion is the version of the service for telemetry identification
+	// Defaults to the application version if not specified
+	ServiceVersion string `yaml:"serviceVersion,omitempty"`
+
+	// Endpoint is the OTLP collector endpoint for telemetry
+	// Defaults to "localhost:4318" if not specified
+	// Format: "host:port" for HTTP (uses /v1/traces and /v1/metrics paths automatically)
+	Endpoint string `yaml:"endpoint,omitempty"`
+
+	// Insecure allows HTTP connections instead of HTTPS
+	// Should only be true for development/testing environments
+	Insecure bool `yaml:"insecure,omitempty"`
+
+	// Tracing contains tracing-specific configuration
+	Tracing *TracingConfig `yaml:"tracing,omitempty"`
+
+	// Metrics contains metrics-specific configuration
+	Metrics *MetricsConfig `yaml:"metrics,omitempty"`
+}
+
+// TracingConfig defines tracing-specific configuration
+type TracingConfig struct {
+	// Enabled controls whether tracing is enabled
+	// When false, tracing is disabled even if telemetry is enabled globally
+	Enabled bool `yaml:"enabled"`
+
+	// Sampling controls the trace sampling rate (0.0 to 1.0)
+	// 1.0 means sample all traces, 0.5 means sample 50%, etc.
+	// Defaults to 1.0 if not specified
+	Sampling float64 `yaml:"sampling,omitempty"`
+}
+
+// MetricsConfig defines metrics-specific configuration
+type MetricsConfig struct {
+	// Enabled controls whether metrics collection is enabled
+	// When false, metrics are disabled even if telemetry is enabled globally
+	Enabled bool `yaml:"enabled"`
+}
+
+// GetServiceName returns the service name, using default if not specified
+func (c *Config) GetServiceName() string {
+	if c.ServiceName == "" {
+		return DefaultServiceName
+	}
+	return c.ServiceName
+}
+
+// GetServiceVersion returns the service version, using "unknown" if not specified
+func (c *Config) GetServiceVersion() string {
+	if c.ServiceVersion == "" {
+		return "unknown"
+	}
+	return c.ServiceVersion
+}
+
+// GetEndpoint returns the endpoint, using default if not specified
+func (c *Config) GetEndpoint() string {
+	if c.Endpoint == "" {
+		return DefaultEndpoint
+	}
+	return c.Endpoint
+}
+
+// GetInsecure returns the insecure flag
+func (c *Config) GetInsecure() bool {
+	return c.Insecure
+}
+
+// GetSampling returns the sampling ratio.
+// If Sampling is 0 (unset), it returns DefaultSampling.
+// Note: 0 is treated as "use default" since we cannot distinguish between
+// an unset value and an explicitly configured value of 0 in YAML/JSON.
+// Validation should be performed before calling this method.
+func (c *TracingConfig) GetSampling() float64 {
+	if c.Sampling == 0.0 {
+		return DefaultSampling
+	}
+	return c.Sampling
+}
+
+// Validate validates the telemetry configuration
+func (c *Config) Validate() error {
+	if c == nil {
+		return nil // nil config is valid (telemetry disabled)
+	}
+
+	if !c.Enabled {
+		return nil // disabled telemetry needs no further validation
+	}
+
+	var errs []error
+
+	if c.Tracing != nil {
+		if err := c.Tracing.Validate(); err != nil {
+			errs = append(errs, fmt.Errorf("tracing: %w", err))
+		}
+	}
+
+	if c.Metrics != nil {
+		if err := c.Metrics.Validate(); err != nil {
+			errs = append(errs, fmt.Errorf("metrics: %w", err))
+		}
+	}
+
+	return errors.Join(errs...)
+}
+
+// Validate validates the tracing configuration
+func (c *TracingConfig) Validate() error {
+	if c == nil || !c.Enabled {
+		return nil
+	}
+
+	sampling := c.Sampling
+	if sampling < 0 || sampling > 1.0 {
+		return fmt.Errorf("sampling must be between 0.0 and 1.0, got %f", sampling)
+	}
+
+	return nil
+}
+
+// Validate validates the metrics configuration
+func (c *MetricsConfig) Validate() error {
+	if c == nil || !c.Enabled {
+		return nil
+	}
+
+	// No additional validation needed for OTLP-only configuration
+	return nil
+}

--- a/internal/telemetry/config_test.go
+++ b/internal/telemetry/config_test.go
@@ -1,0 +1,351 @@
+package telemetry
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfig_GetServiceName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		config   *Config
+		expected string
+	}{
+		{
+			name:     "returns default when empty",
+			config:   &Config{},
+			expected: DefaultServiceName,
+		},
+		{
+			name: "returns configured value",
+			config: &Config{
+				ServiceName: "my-service",
+			},
+			expected: "my-service",
+		},
+		{
+			name: "returns default when whitespace only",
+			config: &Config{
+				ServiceName: "",
+			},
+			expected: DefaultServiceName,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := tt.config.GetServiceName()
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestConfig_GetServiceVersion(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		config   *Config
+		expected string
+	}{
+		{
+			name:     "returns unknown when empty",
+			config:   &Config{},
+			expected: "unknown",
+		},
+		{
+			name: "returns configured value",
+			config: &Config{
+				ServiceVersion: "1.2.3",
+			},
+			expected: "1.2.3",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := tt.config.GetServiceVersion()
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestConfig_GetEndpoint(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		config   *Config
+		expected string
+	}{
+		{
+			name:     "returns default when empty",
+			config:   &Config{},
+			expected: DefaultEndpoint,
+		},
+		{
+			name: "returns configured value",
+			config: &Config{
+				Endpoint: "collector.example.com:4318",
+			},
+			expected: "collector.example.com:4318",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := tt.config.GetEndpoint()
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestConfig_GetInsecure(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		config   *Config
+		expected bool
+	}{
+		{
+			name:     "returns false when not set",
+			config:   &Config{},
+			expected: false,
+		},
+		{
+			name: "returns true when set",
+			config: &Config{
+				Insecure: true,
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := tt.config.GetInsecure()
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestConfig_Validate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		config  *Config
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name:    "nil config is valid",
+			config:  nil,
+			wantErr: false,
+		},
+		{
+			name: "disabled config is valid",
+			config: &Config{
+				Enabled: false,
+			},
+			wantErr: false,
+		},
+		{
+			name: "enabled config with no tracing or metrics is valid",
+			config: &Config{
+				Enabled:     true,
+				ServiceName: "test",
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid full config",
+			config: &Config{
+				Enabled:        true,
+				ServiceName:    "test",
+				ServiceVersion: "1.0.0",
+				Endpoint:       "localhost:4318",
+				Insecure:       true,
+				Tracing: &TracingConfig{
+					Enabled:  true,
+					Sampling: 0.5,
+				},
+				Metrics: &MetricsConfig{
+					Enabled: true,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "disabled tracing with invalid config is valid",
+			config: &Config{
+				Enabled: true,
+				Tracing: &TracingConfig{
+					Enabled:  false,
+					Sampling: -1,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "disabled metrics config is valid",
+			config: &Config{
+				Enabled: true,
+				Metrics: &MetricsConfig{
+					Enabled: false,
+				},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := tt.config.Validate()
+
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.errMsg != "" {
+					assert.Contains(t, err.Error(), tt.errMsg)
+				}
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestTracingConfig_Validate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		config  *TracingConfig
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name:    "nil config is valid",
+			config:  nil,
+			wantErr: false,
+		},
+		{
+			name: "disabled config is valid",
+			config: &TracingConfig{
+				Enabled: false,
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid enabled config",
+			config: &TracingConfig{
+				Enabled:  true,
+				Sampling: 1.0,
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid config with custom sampling",
+			config: &TracingConfig{
+				Enabled:  true,
+				Sampling: 0.5,
+			},
+			wantErr: false,
+		},
+		{
+			name: "sampling above 1.0",
+			config: &TracingConfig{
+				Enabled:  true,
+				Sampling: 1.1,
+			},
+			wantErr: true,
+			errMsg:  "sampling must be between",
+		},
+		{
+			name: "negative sampling",
+			config: &TracingConfig{
+				Enabled:  true,
+				Sampling: -0.1,
+			},
+			wantErr: true,
+			errMsg:  "sampling must be between",
+		},
+		{
+			name: "zero sampling is valid",
+			config: &TracingConfig{
+				Enabled:  true,
+				Sampling: 0,
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := tt.config.Validate()
+
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.errMsg != "" {
+					assert.Contains(t, err.Error(), tt.errMsg)
+				}
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestMetricsConfig_Validate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		config  *MetricsConfig
+		wantErr bool
+	}{
+		{
+			name:    "nil config is valid",
+			config:  nil,
+			wantErr: false,
+		},
+		{
+			name: "disabled config is valid",
+			config: &MetricsConfig{
+				Enabled: false,
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid enabled config",
+			config: &MetricsConfig{
+				Enabled: true,
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := tt.config.Validate()
+
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/internal/telemetry/meter.go
+++ b/internal/telemetry/meter.go
@@ -1,0 +1,148 @@
+package telemetry
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/metric/noop"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/resource"
+	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
+)
+
+const (
+	// DefaultMetricsInterval is the default interval for metric collection
+	DefaultMetricsInterval = 60 * time.Second
+)
+
+// MeterProviderOption is a function that configures the meter provider setup
+type MeterProviderOption func(*meterProviderConfig)
+
+// meterProviderConfig holds the configuration for creating a meter provider
+type meterProviderConfig struct {
+	serviceName    string
+	serviceVersion string
+	metricsConfig  *MetricsConfig
+	endpoint       string
+	insecure       bool
+}
+
+// WithMeterServiceName sets the service name for the meter provider
+func WithMeterServiceName(name string) MeterProviderOption {
+	return func(cfg *meterProviderConfig) {
+		cfg.serviceName = name
+	}
+}
+
+// WithMeterServiceVersion sets the service version for the meter provider
+func WithMeterServiceVersion(version string) MeterProviderOption {
+	return func(cfg *meterProviderConfig) {
+		cfg.serviceVersion = version
+	}
+}
+
+// WithMetricsConfig sets the metrics configuration
+func WithMetricsConfig(mc *MetricsConfig) MeterProviderOption {
+	return func(cfg *meterProviderConfig) {
+		cfg.metricsConfig = mc
+	}
+}
+
+// WithMeterEndpoint sets the endpoint for the meter provider
+func WithMeterEndpoint(endpoint string) MeterProviderOption {
+	return func(cfg *meterProviderConfig) {
+		cfg.endpoint = endpoint
+	}
+}
+
+// WithMeterInsecure sets the insecure flag for the meter provider
+func WithMeterInsecure(insecure bool) MeterProviderOption {
+	return func(cfg *meterProviderConfig) {
+		cfg.insecure = insecure
+	}
+}
+
+// NewMeterProvider creates a new OpenTelemetry MeterProvider based on the configuration.
+// Returns a no-op provider if metrics are disabled or configuration is nil.
+// The caller is responsible for calling Shutdown on the returned provider.
+func NewMeterProvider(ctx context.Context, opts ...MeterProviderOption) (metric.MeterProvider, error) {
+	cfg := &meterProviderConfig{
+		serviceName:    DefaultServiceName,
+		serviceVersion: "unknown",
+		endpoint:       DefaultEndpoint,
+	}
+
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
+	// Return no-op provider if metrics are disabled
+	if cfg.metricsConfig == nil || !cfg.metricsConfig.Enabled {
+		slog.Info("Metrics disabled, using no-op meter provider")
+		return noop.NewMeterProvider(), nil
+	}
+
+	// Create resource with service information
+	// We use resource.New to avoid schema URL conflicts with resource.Default()
+	res, err := resource.New(ctx,
+		resource.WithAttributes(
+			semconv.ServiceName(cfg.serviceName),
+			semconv.ServiceVersion(cfg.serviceVersion),
+		),
+		resource.WithHost(),
+		resource.WithTelemetrySDK(),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create resource: %w", err)
+	}
+
+	// Create OTLP exporter
+	exporter, err := createOTLPMetricsExporter(ctx, cfg.endpoint, cfg.insecure)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create OTLP metrics exporter: %w", err)
+	}
+
+	// Create meter provider with periodic reader
+	mp := sdkmetric.NewMeterProvider(
+		sdkmetric.WithResource(res),
+		sdkmetric.WithReader(
+			sdkmetric.NewPeriodicReader(
+				exporter,
+				sdkmetric.WithInterval(DefaultMetricsInterval),
+			),
+		),
+	)
+
+	// Set as global meter provider
+	otel.SetMeterProvider(mp)
+
+	slog.Info("Metrics initialized",
+		"endpoint", cfg.endpoint,
+		"insecure", cfg.insecure,
+	)
+
+	return mp, nil
+}
+
+// createOTLPMetricsExporter creates an OTLP HTTP metric exporter
+func createOTLPMetricsExporter(ctx context.Context, endpoint string, insecure bool) (sdkmetric.Exporter, error) {
+	opts := []otlpmetrichttp.Option{
+		otlpmetrichttp.WithEndpoint(endpoint),
+	}
+
+	if insecure {
+		opts = append(opts, otlpmetrichttp.WithInsecure())
+	}
+
+	exporter, err := otlpmetrichttp.New(ctx, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create OTLP metric exporter: %w", err)
+	}
+
+	return exporter, nil
+}

--- a/internal/telemetry/meter_test.go
+++ b/internal/telemetry/meter_test.go
@@ -1,0 +1,113 @@
+package telemetry
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/metric/noop"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+)
+
+func TestNewMeterProvider(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		opts       []MeterProviderOption
+		expectNoOp bool
+	}{
+		{
+			name:       "returns no-op provider when no config provided",
+			opts:       []MeterProviderOption{},
+			expectNoOp: true,
+		},
+		{
+			name: "returns no-op provider when metrics disabled",
+			opts: []MeterProviderOption{
+				WithMetricsConfig(&MetricsConfig{
+					Enabled: false,
+				}),
+			},
+			expectNoOp: true,
+		},
+		{
+			name: "returns SDK provider when metrics enabled",
+			opts: []MeterProviderOption{
+				WithMetricsConfig(&MetricsConfig{
+					Enabled: true,
+				}),
+				WithMeterInsecure(true),
+			},
+			expectNoOp: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+
+			mp, err := NewMeterProvider(ctx, tt.opts...)
+
+			require.NoError(t, err)
+			require.NotNil(t, mp)
+
+			if tt.expectNoOp {
+				_, ok := mp.(noop.MeterProvider)
+				assert.True(t, ok, "expected no-op meter provider")
+			} else {
+				sdkMP, ok := mp.(*sdkmetric.MeterProvider)
+				assert.True(t, ok, "expected SDK meter provider")
+
+				// Cleanup - ignore shutdown errors as there's no collector running
+				// The OTLP exporter will try to flush metrics on shutdown, which fails
+				// without a collector, but that's expected in tests
+				if sdkMP != nil {
+					_ = sdkMP.Shutdown(ctx)
+				}
+			}
+		})
+	}
+}
+
+func TestMeterProviderOptions(t *testing.T) {
+	t.Parallel()
+
+	t.Run("WithMeterServiceName sets service name", func(t *testing.T) {
+		t.Parallel()
+		cfg := &meterProviderConfig{}
+		WithMeterServiceName("my-service")(cfg)
+		assert.Equal(t, "my-service", cfg.serviceName)
+	})
+
+	t.Run("WithMeterServiceVersion sets service version", func(t *testing.T) {
+		t.Parallel()
+		cfg := &meterProviderConfig{}
+		WithMeterServiceVersion("2.0.0")(cfg)
+		assert.Equal(t, "2.0.0", cfg.serviceVersion)
+	})
+
+	t.Run("WithMetricsConfig sets metrics config", func(t *testing.T) {
+		t.Parallel()
+		metricsCfg := &MetricsConfig{Enabled: true}
+		cfg := &meterProviderConfig{}
+		WithMetricsConfig(metricsCfg)(cfg)
+		assert.Equal(t, metricsCfg, cfg.metricsConfig)
+	})
+
+	t.Run("WithMeterEndpoint sets endpoint", func(t *testing.T) {
+		t.Parallel()
+		cfg := &meterProviderConfig{}
+		WithMeterEndpoint("collector.example.com:4318")(cfg)
+		assert.Equal(t, "collector.example.com:4318", cfg.endpoint)
+	})
+
+	t.Run("WithMeterInsecure sets insecure flag", func(t *testing.T) {
+		t.Parallel()
+		cfg := &meterProviderConfig{}
+		WithMeterInsecure(true)(cfg)
+		assert.True(t, cfg.insecure)
+	})
+}

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -1,0 +1,169 @@
+package telemetry
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"go.opentelemetry.io/otel/metric"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// Telemetry encapsulates OpenTelemetry providers and handles their lifecycle.
+// It provides a unified interface for initializing and shutting down telemetry.
+type Telemetry struct {
+	tracerProvider trace.TracerProvider
+	meterProvider  metric.MeterProvider
+}
+
+// Option is a function that configures the telemetry setup
+type Option func(*telemetryConfig)
+
+// telemetryConfig holds the configuration for creating telemetry
+type telemetryConfig struct {
+	config *Config
+}
+
+// WithTelemetryConfig sets the telemetry configuration
+func WithTelemetryConfig(cfg *Config) Option {
+	return func(tc *telemetryConfig) {
+		tc.config = cfg
+	}
+}
+
+// New creates and initializes a new Telemetry instance based on the configuration.
+// If telemetry is disabled or configuration is nil, returns a Telemetry with no-op providers.
+// The caller is responsible for calling Shutdown when the application exits.
+func New(ctx context.Context, opts ...Option) (*Telemetry, error) {
+	cfg := &telemetryConfig{}
+
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
+	// Return no-op telemetry if config is nil or disabled
+	if cfg.config == nil || !cfg.config.Enabled {
+		slog.Debug("Telemetry disabled")
+		return newNoOpTelemetry(ctx)
+	}
+
+	// Validate configuration
+	if err := cfg.config.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid telemetry configuration: %w", err)
+	}
+
+	slog.Info("Initializing telemetry",
+		"service_name", cfg.config.GetServiceName(),
+		"service_version", cfg.config.GetServiceVersion(),
+	)
+
+	// Create tracer provider
+	tracerProvider, err := NewTracerProvider(ctx,
+		WithTracerServiceName(cfg.config.GetServiceName()),
+		WithTracerServiceVersion(cfg.config.GetServiceVersion()),
+		WithTracingConfig(cfg.config.Tracing),
+		WithTracerEndpoint(cfg.config.GetEndpoint()),
+		WithTracerInsecure(cfg.config.GetInsecure()),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create tracer provider: %w", err)
+	}
+
+	// Create meter provider
+	meterProvider, err := NewMeterProvider(ctx,
+		WithMeterServiceName(cfg.config.GetServiceName()),
+		WithMeterServiceVersion(cfg.config.GetServiceVersion()),
+		WithMetricsConfig(cfg.config.Metrics),
+		WithMeterEndpoint(cfg.config.GetEndpoint()),
+		WithMeterInsecure(cfg.config.GetInsecure()),
+	)
+	if err != nil {
+		// Clean up tracer provider if meter provider creation fails
+		if shutdownable, ok := tracerProvider.(*sdktrace.TracerProvider); ok {
+			_ = shutdownable.Shutdown(ctx)
+		}
+		return nil, fmt.Errorf("failed to create meter provider: %w", err)
+	}
+
+	slog.Info("Telemetry initialized successfully")
+
+	return &Telemetry{
+		tracerProvider: tracerProvider,
+		meterProvider:  meterProvider,
+	}, nil
+}
+
+// newNoOpTelemetry creates a Telemetry instance with no-op providers
+func newNoOpTelemetry(ctx context.Context) (*Telemetry, error) {
+	tracerProvider, err := NewTracerProvider(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create no-op tracer provider: %w", err)
+	}
+
+	meterProvider, err := NewMeterProvider(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create no-op meter provider: %w", err)
+	}
+
+	return &Telemetry{
+		tracerProvider: tracerProvider,
+		meterProvider:  meterProvider,
+	}, nil
+}
+
+// TracerProvider returns the configured tracer provider
+func (t *Telemetry) TracerProvider() trace.TracerProvider {
+	return t.tracerProvider
+}
+
+// MeterProvider returns the configured meter provider
+func (t *Telemetry) MeterProvider() metric.MeterProvider {
+	return t.meterProvider
+}
+
+// Tracer returns a named tracer from the tracer provider
+func (t *Telemetry) Tracer(name string, opts ...trace.TracerOption) trace.Tracer {
+	return t.tracerProvider.Tracer(name, opts...)
+}
+
+// Meter returns a named meter from the meter provider
+func (t *Telemetry) Meter(name string, opts ...metric.MeterOption) metric.Meter {
+	return t.meterProvider.Meter(name, opts...)
+}
+
+// Shutdown gracefully shuts down all telemetry providers.
+// It should be called when the application is shutting down to flush any pending telemetry data.
+// This method is safe to call multiple times.
+func (t *Telemetry) Shutdown(ctx context.Context) error {
+	slog.Info("Shutting down telemetry")
+
+	var errs []error
+
+	// Shutdown tracer provider if it's an SDK provider
+	if tp, ok := t.tracerProvider.(*sdktrace.TracerProvider); ok {
+		if err := tp.Shutdown(ctx); err != nil {
+			errs = append(errs, fmt.Errorf("failed to shutdown tracer provider: %w", err))
+		} else {
+			slog.Debug("Tracer provider shutdown complete")
+		}
+	}
+
+	// Shutdown meter provider if it's an SDK provider
+	if mp, ok := t.meterProvider.(*sdkmetric.MeterProvider); ok {
+		if err := mp.Shutdown(ctx); err != nil {
+			errs = append(errs, fmt.Errorf("failed to shutdown meter provider: %w", err))
+		} else {
+			slog.Debug("Meter provider shutdown complete")
+		}
+	}
+
+	if len(errs) > 0 {
+		return errors.Join(errs...)
+	}
+
+	slog.Info("Telemetry shutdown complete")
+	return nil
+}

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -1,0 +1,335 @@
+package telemetry
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/metric/noop"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	tracenoop "go.opentelemetry.io/otel/trace/noop"
+)
+
+func TestNew(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		opts             []Option
+		expectNoOpTracer bool
+		expectNoOpMeter  bool
+		expectError      bool
+		errorContains    string
+	}{
+		{
+			name:             "returns no-op telemetry when no config provided",
+			opts:             []Option{},
+			expectNoOpTracer: true,
+			expectNoOpMeter:  true,
+		},
+		{
+			name: "returns no-op telemetry when disabled",
+			opts: []Option{
+				WithTelemetryConfig(&Config{
+					Enabled: false,
+				}),
+			},
+			expectNoOpTracer: true,
+			expectNoOpMeter:  true,
+		},
+		{
+			name: "returns no-op providers when both tracing and metrics disabled",
+			opts: []Option{
+				WithTelemetryConfig(&Config{
+					Enabled: true,
+					Tracing: &TracingConfig{
+						Enabled: false,
+					},
+					Metrics: &MetricsConfig{
+						Enabled: false,
+					},
+				}),
+			},
+			expectNoOpTracer: true,
+			expectNoOpMeter:  true,
+		},
+		{
+			name: "returns error for invalid sampling",
+			opts: []Option{
+				WithTelemetryConfig(&Config{
+					Enabled: true,
+					Tracing: &TracingConfig{
+						Enabled:  true,
+						Sampling: 1.5,
+					},
+				}),
+			},
+			expectError:   true,
+			errorContains: "invalid telemetry configuration",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+
+			tel, err := New(ctx, tt.opts...)
+
+			if tt.expectError {
+				require.Error(t, err)
+				if tt.errorContains != "" {
+					assert.Contains(t, err.Error(), tt.errorContains)
+				}
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, tel)
+
+			// Check tracer provider type
+			if tt.expectNoOpTracer {
+				_, ok := tel.TracerProvider().(tracenoop.TracerProvider)
+				assert.True(t, ok, "expected no-op tracer provider")
+			} else {
+				_, ok := tel.TracerProvider().(*sdktrace.TracerProvider)
+				assert.True(t, ok, "expected SDK tracer provider")
+			}
+
+			// Check meter provider type
+			if tt.expectNoOpMeter {
+				_, ok := tel.MeterProvider().(noop.MeterProvider)
+				assert.True(t, ok, "expected no-op meter provider")
+			} else {
+				_, ok := tel.MeterProvider().(*sdkmetric.MeterProvider)
+				assert.True(t, ok, "expected SDK meter provider")
+			}
+
+			// Cleanup
+			require.NoError(t, tel.Shutdown(ctx))
+		})
+	}
+}
+
+func TestTelemetry_TracerProvider(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	tel, err := New(ctx)
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, tel.Shutdown(ctx))
+	}()
+
+	tp := tel.TracerProvider()
+	require.NotNil(t, tp)
+}
+
+func TestTelemetry_MeterProvider(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	tel, err := New(ctx)
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, tel.Shutdown(ctx))
+	}()
+
+	mp := tel.MeterProvider()
+	require.NotNil(t, mp)
+}
+
+func TestTelemetry_Tracer(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	tel, err := New(ctx)
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, tel.Shutdown(ctx))
+	}()
+
+	tracer := tel.Tracer("test-tracer")
+	require.NotNil(t, tracer)
+}
+
+func TestTelemetry_Meter(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	tel, err := New(ctx)
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, tel.Shutdown(ctx))
+	}()
+
+	meter := tel.Meter("test-meter")
+	require.NotNil(t, meter)
+}
+
+func TestTelemetry_Shutdown(t *testing.T) {
+	t.Parallel()
+
+	t.Run("shutdown no-op telemetry succeeds", func(t *testing.T) {
+		t.Parallel()
+		ctx := context.Background()
+		tel, err := New(ctx)
+		require.NoError(t, err)
+
+		err = tel.Shutdown(ctx)
+		require.NoError(t, err)
+	})
+
+	t.Run("shutdown is idempotent for no-op telemetry", func(t *testing.T) {
+		t.Parallel()
+		ctx := context.Background()
+		tel, err := New(ctx)
+		require.NoError(t, err)
+
+		// First shutdown
+		err = tel.Shutdown(ctx)
+		require.NoError(t, err)
+
+		// Second shutdown should also succeed
+		err = tel.Shutdown(ctx)
+		require.NoError(t, err)
+	})
+
+	t.Run("shutdown SDK tracer provider succeeds", func(t *testing.T) {
+		t.Parallel()
+
+		// Create a mock OTLP server to accept trace exports
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+		endpoint := strings.TrimPrefix(server.URL, "http://")
+
+		ctx := context.Background()
+		tel, err := New(ctx, WithTelemetryConfig(&Config{
+			Enabled:  true,
+			Endpoint: endpoint,
+			Insecure: true,
+			Tracing: &TracingConfig{
+				Enabled:  true,
+				Sampling: 1.0,
+			},
+			Metrics: &MetricsConfig{
+				Enabled: false,
+			},
+		}))
+		require.NoError(t, err)
+
+		// Verify we have an SDK tracer provider
+		_, ok := tel.TracerProvider().(*sdktrace.TracerProvider)
+		assert.True(t, ok, "expected SDK tracer provider")
+
+		err = tel.Shutdown(ctx)
+		require.NoError(t, err)
+	})
+
+	t.Run("shutdown SDK meter provider succeeds", func(t *testing.T) {
+		t.Parallel()
+
+		// Create a mock OTLP server to accept metric exports
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+		endpoint := strings.TrimPrefix(server.URL, "http://")
+
+		ctx := context.Background()
+		tel, err := New(ctx, WithTelemetryConfig(&Config{
+			Enabled:  true,
+			Endpoint: endpoint,
+			Insecure: true,
+			Tracing: &TracingConfig{
+				Enabled: false,
+			},
+			Metrics: &MetricsConfig{
+				Enabled: true,
+			},
+		}))
+		require.NoError(t, err)
+
+		// Verify we have an SDK meter provider
+		_, ok := tel.MeterProvider().(*sdkmetric.MeterProvider)
+		assert.True(t, ok, "expected SDK meter provider")
+
+		err = tel.Shutdown(ctx)
+		require.NoError(t, err)
+	})
+
+	t.Run("shutdown both SDK providers succeeds", func(t *testing.T) {
+		t.Parallel()
+
+		// Create a mock OTLP server to accept trace and metric exports
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+		endpoint := strings.TrimPrefix(server.URL, "http://")
+
+		ctx := context.Background()
+		tel, err := New(ctx, WithTelemetryConfig(&Config{
+			Enabled:  true,
+			Endpoint: endpoint,
+			Insecure: true,
+			Tracing: &TracingConfig{
+				Enabled:  true,
+				Sampling: 1.0,
+			},
+			Metrics: &MetricsConfig{
+				Enabled: true,
+			},
+		}))
+		require.NoError(t, err)
+
+		// Verify we have SDK providers
+		_, okTracer := tel.TracerProvider().(*sdktrace.TracerProvider)
+		assert.True(t, okTracer, "expected SDK tracer provider")
+		_, okMeter := tel.MeterProvider().(*sdkmetric.MeterProvider)
+		assert.True(t, okMeter, "expected SDK meter provider")
+
+		err = tel.Shutdown(ctx)
+		require.NoError(t, err)
+	})
+}
+
+func TestOption_WithTelemetryConfig(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Config{
+		Enabled:     true,
+		ServiceName: "test",
+	}
+
+	tc := &telemetryConfig{}
+	WithTelemetryConfig(cfg)(tc)
+
+	assert.Equal(t, cfg, tc.config)
+}
+
+func TestNewNoOpTelemetry(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	tel, err := newNoOpTelemetry(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, tel)
+
+	// Verify both providers are no-op
+	_, okTracer := tel.TracerProvider().(tracenoop.TracerProvider)
+	assert.True(t, okTracer, "expected no-op tracer provider")
+
+	_, okMeter := tel.MeterProvider().(noop.MeterProvider)
+	assert.True(t, okMeter, "expected no-op meter provider")
+
+	// Cleanup
+	require.NoError(t, tel.Shutdown(ctx))
+}

--- a/internal/telemetry/tracer.go
+++ b/internal/telemetry/tracer.go
@@ -1,0 +1,139 @@
+package telemetry
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
+	"go.opentelemetry.io/otel/sdk/resource"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
+	"go.opentelemetry.io/otel/trace"
+	"go.opentelemetry.io/otel/trace/noop"
+)
+
+// TracerProviderOption is a function that configures the tracer provider setup
+type TracerProviderOption func(*tracerProviderConfig)
+
+// tracerProviderConfig holds the configuration for creating a tracer provider
+type tracerProviderConfig struct {
+	serviceName    string
+	serviceVersion string
+	tracingConfig  *TracingConfig
+	endpoint       string
+	insecure       bool
+}
+
+// WithTracerServiceName sets the service name for the tracer provider
+func WithTracerServiceName(name string) TracerProviderOption {
+	return func(cfg *tracerProviderConfig) {
+		cfg.serviceName = name
+	}
+}
+
+// WithTracerServiceVersion sets the service version for the tracer provider
+func WithTracerServiceVersion(version string) TracerProviderOption {
+	return func(cfg *tracerProviderConfig) {
+		cfg.serviceVersion = version
+	}
+}
+
+// WithTracingConfig sets the tracing configuration
+func WithTracingConfig(tc *TracingConfig) TracerProviderOption {
+	return func(cfg *tracerProviderConfig) {
+		cfg.tracingConfig = tc
+	}
+}
+
+// WithTracerEndpoint sets the endpoint for the tracer provider
+func WithTracerEndpoint(endpoint string) TracerProviderOption {
+	return func(cfg *tracerProviderConfig) {
+		cfg.endpoint = endpoint
+	}
+}
+
+// WithTracerInsecure sets the insecure flag for the tracer provider
+func WithTracerInsecure(insecure bool) TracerProviderOption {
+	return func(cfg *tracerProviderConfig) {
+		cfg.insecure = insecure
+	}
+}
+
+// NewTracerProvider creates a new OpenTelemetry TracerProvider based on the configuration.
+// Returns a no-op provider if tracing is disabled or configuration is nil.
+// The caller is responsible for calling Shutdown on the returned provider.
+func NewTracerProvider(ctx context.Context, opts ...TracerProviderOption) (trace.TracerProvider, error) {
+	cfg := &tracerProviderConfig{
+		serviceName:    DefaultServiceName,
+		serviceVersion: "unknown",
+		endpoint:       DefaultEndpoint,
+	}
+
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
+	// Return no-op provider if tracing is disabled
+	if cfg.tracingConfig == nil || !cfg.tracingConfig.Enabled {
+		slog.Info("Tracing disabled, using no-op tracer provider")
+		return noop.NewTracerProvider(), nil
+	}
+
+	// Create resource with service information
+	// We use NewSchemaless to avoid schema URL conflicts with resource.Default()
+	res, err := resource.New(ctx,
+		resource.WithAttributes(
+			semconv.ServiceName(cfg.serviceName),
+			semconv.ServiceVersion(cfg.serviceVersion),
+		),
+		resource.WithHost(),
+		resource.WithTelemetrySDK(),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create resource: %w", err)
+	}
+
+	// Create OTLP exporter
+	exporter, err := createOTLPTracingExporter(ctx, cfg.endpoint, cfg.insecure)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create OTLP tracing exporter: %w", err)
+	}
+
+	// Create tracer provider with batch span processor
+	tp := sdktrace.NewTracerProvider(
+		sdktrace.WithResource(res),
+		sdktrace.WithBatcher(exporter),
+		sdktrace.WithSampler(sdktrace.TraceIDRatioBased(cfg.tracingConfig.GetSampling())),
+	)
+
+	// Set as global tracer provider
+	otel.SetTracerProvider(tp)
+
+	slog.Info("Tracing initialized",
+		"endpoint", cfg.endpoint,
+		"sampling_ratio", cfg.tracingConfig.GetSampling(),
+		"insecure", cfg.insecure,
+	)
+
+	return tp, nil
+}
+
+// createOTLPTracingExporter creates an OTLP HTTP trace exporter
+func createOTLPTracingExporter(ctx context.Context, endpoint string, insecure bool) (sdktrace.SpanExporter, error) {
+	opts := []otlptracehttp.Option{
+		otlptracehttp.WithEndpoint(endpoint),
+	}
+
+	if insecure {
+		opts = append(opts, otlptracehttp.WithInsecure())
+	}
+
+	exporter, err := otlptracehttp.New(ctx, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create OTLP trace exporter: %w", err)
+	}
+
+	return exporter, nil
+}

--- a/internal/telemetry/tracer_test.go
+++ b/internal/telemetry/tracer_test.go
@@ -1,0 +1,111 @@
+package telemetry
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/trace/noop"
+)
+
+func TestNewTracerProvider(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		opts       []TracerProviderOption
+		expectNoOp bool
+	}{
+		{
+			name:       "returns no-op provider when no config provided",
+			opts:       []TracerProviderOption{},
+			expectNoOp: true,
+		},
+		{
+			name: "returns no-op provider when tracing disabled",
+			opts: []TracerProviderOption{
+				WithTracingConfig(&TracingConfig{
+					Enabled: false,
+				}),
+			},
+			expectNoOp: true,
+		},
+		{
+			name: "returns SDK provider when tracing enabled",
+			opts: []TracerProviderOption{
+				WithTracingConfig(&TracingConfig{
+					Enabled:  true,
+					Sampling: 0.5,
+				}),
+			},
+			expectNoOp: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+
+			tp, err := NewTracerProvider(ctx, tt.opts...)
+
+			require.NoError(t, err)
+			require.NotNil(t, tp)
+
+			if tt.expectNoOp {
+				_, ok := tp.(noop.TracerProvider)
+				assert.True(t, ok, "expected no-op tracer provider")
+			} else {
+				_, ok := tp.(*sdktrace.TracerProvider)
+				assert.True(t, ok, "expected SDK tracer provider")
+
+				// Cleanup
+				if sdkTP, ok := tp.(*sdktrace.TracerProvider); ok {
+					require.NoError(t, sdkTP.Shutdown(ctx))
+				}
+			}
+		})
+	}
+}
+
+func TestTracerProviderOptions(t *testing.T) {
+	t.Parallel()
+
+	t.Run("WithTracerServiceName sets service name", func(t *testing.T) {
+		t.Parallel()
+		cfg := &tracerProviderConfig{}
+		WithTracerServiceName("my-service")(cfg)
+		assert.Equal(t, "my-service", cfg.serviceName)
+	})
+
+	t.Run("WithTracerServiceVersion sets service version", func(t *testing.T) {
+		t.Parallel()
+		cfg := &tracerProviderConfig{}
+		WithTracerServiceVersion("2.0.0")(cfg)
+		assert.Equal(t, "2.0.0", cfg.serviceVersion)
+	})
+
+	t.Run("WithTracingConfig sets tracing config", func(t *testing.T) {
+		t.Parallel()
+		tracingCfg := &TracingConfig{Enabled: true}
+		cfg := &tracerProviderConfig{}
+		WithTracingConfig(tracingCfg)(cfg)
+		assert.Equal(t, tracingCfg, cfg.tracingConfig)
+	})
+
+	t.Run("WithTracerEndpoint sets endpoint", func(t *testing.T) {
+		t.Parallel()
+		cfg := &tracerProviderConfig{}
+		WithTracerEndpoint("collector.example.com:4318")(cfg)
+		assert.Equal(t, "collector.example.com:4318", cfg.endpoint)
+	})
+
+	t.Run("WithTracerInsecure sets insecure flag", func(t *testing.T) {
+		t.Parallel()
+		cfg := &tracerProviderConfig{}
+		WithTracerInsecure(true)(cfg)
+		assert.True(t, cfg.insecure)
+	})
+}


### PR DESCRIPTION
## Summary

Introduces the foundational OpenTelemetry instrumentation package with support for distributed tracing and metrics via OTLP exporters.

**New `internal/telemetry` package includes:**
- Configuration types with validation for tracing and metrics
- TracerProvider setup with OTLP exporter and configurable sampling
- MeterProvider setup with OTLP exporter
- Graceful shutdown handling with context support
- No-op providers when telemetry is disabled (zero overhead)

**Integration:**
- Added `Telemetry` config field to main config struct
- Initialized telemetry in serve command with deferred shutdown

## Configuration

```yaml
telemetry:
  enabled: true
  serviceName: thv-registry-api
  serviceVersion: "1.0.0"
  endpoint: localhost:4318
  insecure: true
  tracing:
    enabled: true
    sampling: 1.0
  metrics:
    enabled: true
```

Relates to https://github.com/stacklok/toolhive-registry-server/issues/259
