### PR TITLE
Add OpenTelemetry metrics instrumentation

### DIFF
--- a/cmd/thv-registry-api/app/serve.go
+++ b/cmd/thv-registry-api/app/serve.go
@@ -113,6 +113,7 @@ func runServe(cmd *cobra.Command, _ []string) error {
 		ctx,
 		registryapp.WithConfig(cfg),
 		registryapp.WithAddress(address),
+		registryapp.WithMeterProvider(tel.MeterProvider()),
 	)
 	if err != nil {
 		return fmt.Errorf("failed to build application: %w", err)

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,179 @@
+# Observability
+
+The ToolHive Registry Server provides comprehensive observability through OpenTelemetry (OTEL), supporting both distributed tracing and metrics collection via OTLP exporters.
+
+## Architecture Overview
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                     Registry Server                                  │
+│  ┌─────────────┐  ┌─────────────┐  ┌─────────────┐                 │
+│  │   HTTP      │  │   Sync      │  │  Registry   │                 │
+│  │ Middleware  │  │  Metrics    │  │  Metrics    │                 │
+│  └──────┬──────┘  └──────┬──────┘  └──────┬──────┘                 │
+│         │                │                │                         │
+│         └────────────────┼────────────────┘                         │
+│                          │                                          │
+│                   ┌──────▼──────┐                                   │
+│                   │  Telemetry  │                                   │
+│                   │   Facade    │                                   │
+│                   └──────┬──────┘                                   │
+│                          │                                          │
+│         ┌────────────────┼────────────────┐                         │
+│         │                │                │                         │
+│  ┌──────▼──────┐  ┌──────▼──────┐  ┌──────▼──────┐                 │
+│  │   Tracer    │  │    Meter    │  │   Resource  │                 │
+│  │  Provider   │  │  Provider   │  │  Attributes │                 │
+│  └──────┬──────┘  └──────┬──────┘  └─────────────┘                 │
+│         │                │                                          │
+│         └────────┬───────┘                                          │
+│                  │ OTLP HTTP                                        │
+└──────────────────┼──────────────────────────────────────────────────┘
+                   │
+                   ▼
+          ┌────────────────┐
+          │      OTEL      │
+          │   Collector    │
+          └───────┬────────┘
+                  │
+        ┌─────────┼─────────┐
+        │         │         │
+        ▼         ▼         ▼
+   ┌────────┐ ┌────────┐ ┌────────┐
+   │ Jaeger │ │Promethe│ │ Grafana│
+   │        │ │   us   │ │        │
+   └────────┘ └────────┘ └────────┘
+```
+
+## Package Structure
+
+The telemetry implementation is located in `internal/telemetry/`:
+
+| File | Responsibility |
+|------|----------------|
+| `telemetry.go` | Main facade orchestrating tracer and meter providers |
+| `config.go` | Configuration types with validation and defaults |
+| `tracer.go` | TracerProvider setup with OTLP HTTP exporter |
+| `meter.go` | MeterProvider setup with OTLP HTTP exporter |
+| `metrics.go` | Application-specific metrics (registry and sync) |
+| `middleware.go` | HTTP metrics middleware for Chi router |
+
+## Configuration
+
+Telemetry is configured via the main application config file:
+
+```yaml
+telemetry:
+  enabled: true
+  serviceName: "thv-registry-api"
+  serviceVersion: "1.0.0"
+  endpoint: "otel-collector:4318"
+  insecure: true
+  tracing:
+    enabled: true
+    sampling: 0.05  # 5% of traces sampled
+  metrics:
+    enabled: true
+```
+
+### Configuration Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `enabled` | bool | `false` | Enable/disable all telemetry |
+| `serviceName` | string | `"thv-registry-api"` | Service name in telemetry data |
+| `serviceVersion` | string | `""` | Service version in telemetry data |
+| `endpoint` | string | `"localhost:4318"` | OTLP HTTP endpoint |
+| `insecure` | bool | `false` | Use insecure connection (no TLS) |
+| `tracing.enabled` | bool | `false` | Enable distributed tracing |
+| `tracing.sampling` | float64 | `0.05` | Trace sampling ratio (0.0-1.0) |
+| `metrics.enabled` | bool | `false` | Enable metrics collection |
+
+## Metrics Reference
+
+All metrics are prefixed with `thv_reg_srv_` to distinguish them from other metrics in the system.
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `thv_reg_srv_http_request_duration_seconds` | Histogram | `method`, `route`, `status_code` | Duration of HTTP requests |
+| `thv_reg_srv_http_requests_total` | Counter | `method`, `route`, `status_code` | Total number of HTTP requests |
+| `thv_reg_srv_http_active_requests` | UpDownCounter | - | Number of in-flight requests |
+| `thv_reg_srv_servers_total` | Gauge | `registry` | Number of servers in each registry |
+| `thv_reg_srv_sync_duration_seconds` | Histogram | `registry`, `success` | Duration of sync operations |
+
+### Histogram Buckets
+
+- **HTTP metrics:** 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10 seconds
+- **Sync metrics:** 0.1, 0.5, 1, 2.5, 5, 10, 30, 60, 120, 300 seconds
+
+## Implementation Details
+
+### Graceful Degradation
+
+The telemetry implementation handles disabled or missing components gracefully:
+
+- When telemetry is disabled, no-op providers are used (zero overhead)
+- Metrics and tracing can be independently enabled/disabled
+- Nil provider checks prevent panics if metrics are not configured
+
+### Route Pattern Extraction
+
+The HTTP middleware extracts Chi route patterns (e.g., `/registry/v0.1/servers/{serverName}`) instead of actual URLs (e.g., `/registry/v0.1/servers/my-server`) to prevent metric cardinality explosion.
+
+### Resource Attributes
+
+All telemetry data includes these resource attributes:
+
+| Attribute | Description |
+|-----------|-------------|
+| `service.name` | Service name from config |
+| `service.version` | Service version from config |
+| `host.name` | Hostname of the running instance |
+| `telemetry.sdk.name` | "opentelemetry" |
+| `telemetry.sdk.language` | "go" |
+| `telemetry.sdk.version` | OTEL SDK version |
+
+### OTLP Export
+
+Both traces and metrics are exported via OTLP HTTP (port 4318 by default):
+
+- Traces use batch processing for efficiency
+- Metrics use a periodic reader with 60-second intervals
+
+## Troubleshooting
+
+### No Metrics Appearing
+
+1. Verify telemetry is enabled in config:
+   ```yaml
+   telemetry:
+     enabled: true
+     metrics:
+       enabled: true
+   ```
+
+2. Check the OTEL endpoint is reachable from the registry server
+
+3. Verify the OTEL Collector is configured to receive OTLP and export to Prometheus
+
+4. Check Prometheus is scraping the OTEL Collector's metrics endpoint (default port 8889)
+
+### High Cardinality Warnings
+
+If you see high cardinality warnings, check for:
+
+- Custom routes not registered with Chi (will show as `unknown_route`)
+- Dynamic path segments not using Chi parameters
+
+### Missing Traces
+
+1. Verify tracing is enabled:
+   ```yaml
+   telemetry:
+     tracing:
+       enabled: true
+   ```
+
+2. Check sampling rate - default is 5% (`sampling: 0.05`)
+
+3. Verify Jaeger or trace backend is configured in OTEL Collector

--- a/examples/otel/grafana/dashboards/registry-server.json
+++ b/examples/otel/grafana/dashboards/registry-server.json
@@ -1,0 +1,482 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "id": 1,
+      "title": "HTTP Metrics",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 1 },
+      "id": 2,
+      "options": {
+        "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum(rate(thv_reg_srv_http_requests_total[5m])) by (route)",
+          "legendFormat": "{{ route }}",
+          "refId": "A"
+        }
+      ],
+      "title": "Request Rate by Route",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 1 },
+      "id": 3,
+      "options": {
+        "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "histogram_quantile(0.95, sum(rate(thv_reg_srv_http_request_duration_seconds_bucket[5m])) by (le, route))",
+          "legendFormat": "p95 {{ route }}",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "histogram_quantile(0.50, sum(rate(thv_reg_srv_http_request_duration_seconds_bucket[5m])) by (le, route))",
+          "legendFormat": "p50 {{ route }}",
+          "refId": "B"
+        }
+      ],
+      "title": "Request Latency (p50/p95)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 10 },
+              { "color": "red", "value": 50 }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 9 },
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum(thv_reg_srv_http_active_requests)",
+          "legendFormat": "Active Requests",
+          "refId": "A"
+        }
+      ],
+      "title": "Active Requests",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byRegexp", "options": "5.." },
+            "properties": [{ "id": "color", "value": { "fixedColor": "red", "mode": "fixed" } }]
+          },
+          {
+            "matcher": { "id": "byRegexp", "options": "4.." },
+            "properties": [{ "id": "color", "value": { "fixedColor": "yellow", "mode": "fixed" } }]
+          }
+        ]
+      },
+      "gridPos": { "h": 4, "w": 18, "x": 6, "y": 9 },
+      "id": 5,
+      "options": {
+        "legend": { "calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum(rate(thv_reg_srv_http_requests_total[5m])) by (status_code)",
+          "legendFormat": "{{ status_code }}",
+          "refId": "A"
+        }
+      ],
+      "title": "Request Rate by Status Code",
+      "type": "timeseries"
+    },
+    {
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 13 },
+      "id": 6,
+      "title": "Registry Metrics",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 6, "w": 12, "x": 0, "y": 14 },
+      "id": 7,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "thv_reg_srv_servers_total",
+          "legendFormat": "{{ registry }}",
+          "refId": "A"
+        }
+      ],
+      "title": "Servers per Registry",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 6, "w": 12, "x": 12, "y": 14 },
+      "id": 8,
+      "options": {
+        "legend": { "calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "none" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "thv_reg_srv_servers_total",
+          "legendFormat": "{{ registry }}",
+          "refId": "A"
+        }
+      ],
+      "title": "Servers per Registry (over time)",
+      "type": "timeseries"
+    },
+    {
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 20 },
+      "id": 9,
+      "title": "Sync Metrics",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 21 },
+      "id": 10,
+      "options": {
+        "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "histogram_quantile(0.95, sum(rate(thv_reg_srv_sync_duration_seconds_bucket[5m])) by (le, registry))",
+          "legendFormat": "p95 {{ registry }}",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "histogram_quantile(0.50, sum(rate(thv_reg_srv_sync_duration_seconds_bucket[5m])) by (le, registry))",
+          "legendFormat": "p50 {{ registry }}",
+          "refId": "B"
+        }
+      ],
+      "title": "Sync Duration (p50/p95)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "bars",
+            "fillOpacity": 100,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "normal" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byRegexp", "options": ".*false.*" },
+            "properties": [{ "id": "color", "value": { "fixedColor": "red", "mode": "fixed" } }]
+          },
+          {
+            "matcher": { "id": "byRegexp", "options": ".*true.*" },
+            "properties": [{ "id": "color", "value": { "fixedColor": "green", "mode": "fixed" } }]
+          }
+        ]
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 21 },
+      "id": 11,
+      "options": {
+        "legend": { "calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "none" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum(increase(thv_reg_srv_sync_duration_seconds_count[5m])) by (registry, success)",
+          "legendFormat": "{{ registry }} (success={{ success }})",
+          "refId": "A"
+        }
+      ],
+      "title": "Sync Operations (success/failure)",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 39,
+  "tags": ["toolhive", "registry"],
+  "templating": {
+    "list": [
+      {
+        "current": { "selected": false, "text": "Prometheus", "value": "Prometheus" },
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": { "from": "now-1h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "ToolHive Registry Server",
+  "uid": "toolhive-registry",
+  "version": 1,
+  "weekStart": ""
+}

--- a/internal/telemetry/metrics.go
+++ b/internal/telemetry/metrics.go
@@ -1,0 +1,102 @@
+// Package telemetry provides OpenTelemetry instrumentation for the registry server.
+package telemetry
+
+import (
+	"context"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+)
+
+const (
+	// RegistryMetricsMeterName is the name used for the registry metrics meter
+	RegistryMetricsMeterName = "github.com/stacklok/toolhive-registry-server/registry"
+
+	// SyncMetricsMeterName is the name used for the sync metrics meter
+	SyncMetricsMeterName = "github.com/stacklok/toolhive-registry-server/sync"
+)
+
+// RegistryMetrics holds the OpenTelemetry instruments for registry metrics
+type RegistryMetrics struct {
+	serversTotal metric.Int64Gauge
+}
+
+// NewRegistryMetrics creates a new RegistryMetrics instance with the given meter provider.
+// If provider is nil, it returns nil (no-op metrics).
+func NewRegistryMetrics(provider metric.MeterProvider) (*RegistryMetrics, error) {
+	if provider == nil {
+		return nil, nil
+	}
+
+	meter := provider.Meter(RegistryMetricsMeterName)
+
+	serversTotal, err := meter.Int64Gauge(
+		"thv_reg_srv_servers_total",
+		metric.WithDescription("Number of servers in each registry"),
+		metric.WithUnit("{server}"),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &RegistryMetrics{
+		serversTotal: serversTotal,
+	}, nil
+}
+
+// RecordServersTotal records the current number of servers in a registry
+func (m *RegistryMetrics) RecordServersTotal(ctx context.Context, registryName string, count int64) {
+	if m == nil || m.serversTotal == nil {
+		return
+	}
+
+	attrs := []attribute.KeyValue{
+		attribute.String("registry", registryName),
+	}
+
+	m.serversTotal.Record(ctx, count, metric.WithAttributes(attrs...))
+}
+
+// SyncMetrics holds the OpenTelemetry instruments for sync operation metrics
+type SyncMetrics struct {
+	syncDuration metric.Float64Histogram
+}
+
+// NewSyncMetrics creates a new SyncMetrics instance with the given meter provider.
+// If provider is nil, it returns nil (no-op metrics).
+func NewSyncMetrics(provider metric.MeterProvider) (*SyncMetrics, error) {
+	if provider == nil {
+		return nil, nil
+	}
+
+	meter := provider.Meter(SyncMetricsMeterName)
+
+	syncDuration, err := meter.Float64Histogram(
+		"thv_reg_srv_sync_duration_seconds",
+		metric.WithDescription("Duration of sync operations in seconds"),
+		metric.WithUnit("s"),
+		metric.WithExplicitBucketBoundaries(0.1, 0.5, 1, 2.5, 5, 10, 30, 60, 120, 300),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &SyncMetrics{
+		syncDuration: syncDuration,
+	}, nil
+}
+
+// RecordSyncDuration records the duration of a sync operation for a registry
+func (m *SyncMetrics) RecordSyncDuration(ctx context.Context, registryName string, duration time.Duration, success bool) {
+	if m == nil || m.syncDuration == nil {
+		return
+	}
+
+	attrs := []attribute.KeyValue{
+		attribute.String("registry", registryName),
+		attribute.Bool("success", success),
+	}
+
+	m.syncDuration.Record(ctx, duration.Seconds(), metric.WithAttributes(attrs...))
+}

--- a/internal/telemetry/metrics_test.go
+++ b/internal/telemetry/metrics_test.go
@@ -1,0 +1,197 @@
+package telemetry
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+func TestNewRegistryMetrics(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns nil when provider is nil", func(t *testing.T) {
+		t.Parallel()
+
+		metrics, err := NewRegistryMetrics(nil)
+		require.NoError(t, err)
+		assert.Nil(t, metrics)
+	})
+
+	t.Run("creates metrics with SDK provider", func(t *testing.T) {
+		t.Parallel()
+
+		mp := sdkmetric.NewMeterProvider()
+		defer func() { _ = mp.Shutdown(context.Background()) }()
+
+		metrics, err := NewRegistryMetrics(mp)
+		require.NoError(t, err)
+		assert.NotNil(t, metrics)
+		assert.NotNil(t, metrics.serversTotal)
+	})
+}
+
+func TestRegistryMetrics_RecordServersTotal(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no-op when metrics is nil", func(t *testing.T) {
+		t.Parallel()
+
+		var metrics *RegistryMetrics
+		// Should not panic
+		metrics.RecordServersTotal(context.Background(), "test-registry", 10)
+	})
+
+	t.Run("records server count with registry attribute", func(t *testing.T) {
+		t.Parallel()
+
+		reader := sdkmetric.NewManualReader()
+		mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+		defer func() { _ = mp.Shutdown(context.Background()) }()
+
+		metrics, err := NewRegistryMetrics(mp)
+		require.NoError(t, err)
+		require.NotNil(t, metrics)
+
+		// Record some metrics
+		metrics.RecordServersTotal(context.Background(), "prod-registry", 42)
+		metrics.RecordServersTotal(context.Background(), "dev-registry", 10)
+
+		// Collect metrics
+		var rm metricdata.ResourceMetrics
+		err = reader.Collect(context.Background(), &rm)
+		require.NoError(t, err)
+
+		// Verify metrics were recorded
+		require.NotEmpty(t, rm.ScopeMetrics)
+
+		// Find our registry metrics scope
+		var foundScope bool
+		for _, scope := range rm.ScopeMetrics {
+			if scope.Scope.Name == RegistryMetricsMeterName {
+				foundScope = true
+				assert.NotEmpty(t, scope.Metrics)
+			}
+		}
+		assert.True(t, foundScope, "expected to find registry metrics scope")
+	})
+}
+
+func TestNewSyncMetrics(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns nil when provider is nil", func(t *testing.T) {
+		t.Parallel()
+
+		metrics, err := NewSyncMetrics(nil)
+		require.NoError(t, err)
+		assert.Nil(t, metrics)
+	})
+
+	t.Run("creates metrics with SDK provider", func(t *testing.T) {
+		t.Parallel()
+
+		mp := sdkmetric.NewMeterProvider()
+		defer func() { _ = mp.Shutdown(context.Background()) }()
+
+		metrics, err := NewSyncMetrics(mp)
+		require.NoError(t, err)
+		assert.NotNil(t, metrics)
+		assert.NotNil(t, metrics.syncDuration)
+	})
+}
+
+func TestSyncMetrics_RecordSyncDuration(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no-op when metrics is nil", func(t *testing.T) {
+		t.Parallel()
+
+		var metrics *SyncMetrics
+		// Should not panic
+		metrics.RecordSyncDuration(context.Background(), "test-registry", 5*time.Second, true)
+	})
+
+	t.Run("records sync duration with attributes", func(t *testing.T) {
+		t.Parallel()
+
+		reader := sdkmetric.NewManualReader()
+		mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+		defer func() { _ = mp.Shutdown(context.Background()) }()
+
+		metrics, err := NewSyncMetrics(mp)
+		require.NoError(t, err)
+		require.NotNil(t, metrics)
+
+		// Record successful sync
+		metrics.RecordSyncDuration(context.Background(), "prod-registry", 2500*time.Millisecond, true)
+
+		// Record failed sync
+		metrics.RecordSyncDuration(context.Background(), "dev-registry", 500*time.Millisecond, false)
+
+		// Collect metrics
+		var rm metricdata.ResourceMetrics
+		err = reader.Collect(context.Background(), &rm)
+		require.NoError(t, err)
+
+		// Verify metrics were recorded
+		require.NotEmpty(t, rm.ScopeMetrics)
+
+		// Find our sync metrics scope
+		var foundScope bool
+		for _, scope := range rm.ScopeMetrics {
+			if scope.Scope.Name == SyncMetricsMeterName {
+				foundScope = true
+				assert.NotEmpty(t, scope.Metrics)
+
+				// Verify we have the histogram metric
+				for _, m := range scope.Metrics {
+					if m.Name == "thv_reg_srv_sync_duration_seconds" {
+						// Verify it's a histogram
+						_, ok := m.Data.(metricdata.Histogram[float64])
+						assert.True(t, ok, "expected histogram data type")
+					}
+				}
+			}
+		}
+		assert.True(t, foundScope, "expected to find sync metrics scope")
+	})
+
+	t.Run("records duration in seconds", func(t *testing.T) {
+		t.Parallel()
+
+		reader := sdkmetric.NewManualReader()
+		mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+		defer func() { _ = mp.Shutdown(context.Background()) }()
+
+		metrics, err := NewSyncMetrics(mp)
+		require.NoError(t, err)
+
+		// Record a 1.5 second sync
+		metrics.RecordSyncDuration(context.Background(), "test", 1500*time.Millisecond, true)
+
+		// Collect and verify
+		var rm metricdata.ResourceMetrics
+		err = reader.Collect(context.Background(), &rm)
+		require.NoError(t, err)
+
+		// The histogram should have recorded 1.5 seconds
+		for _, scope := range rm.ScopeMetrics {
+			if scope.Scope.Name == SyncMetricsMeterName {
+				for _, m := range scope.Metrics {
+					if m.Name == "thv_reg_srv_sync_duration_seconds" {
+						hist, ok := m.Data.(metricdata.Histogram[float64])
+						require.True(t, ok)
+						require.NotEmpty(t, hist.DataPoints)
+						// Sum should be 1.5 (seconds)
+						assert.InDelta(t, 1.5, hist.DataPoints[0].Sum, 0.001)
+					}
+				}
+			}
+		}
+	})
+}

--- a/internal/telemetry/middleware.go
+++ b/internal/telemetry/middleware.go
@@ -1,0 +1,139 @@
+// Package telemetry provides OpenTelemetry instrumentation for the registry server.
+package telemetry
+
+import (
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/chi/v5/middleware"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+)
+
+const (
+	// HTTPMetricsMeterName is the name used for the HTTP metrics meter
+	HTTPMetricsMeterName = "github.com/stacklok/toolhive-registry-server/http"
+)
+
+// HTTPMetrics holds the OpenTelemetry instruments for HTTP metrics
+type HTTPMetrics struct {
+	requestDuration metric.Float64Histogram
+	requestsTotal   metric.Int64Counter
+	activeRequests  metric.Int64UpDownCounter
+}
+
+// NewHTTPMetrics creates a new HTTPMetrics instance with the given meter provider.
+// If provider is nil, it returns nil (no-op metrics).
+func NewHTTPMetrics(provider metric.MeterProvider) (*HTTPMetrics, error) {
+	if provider == nil {
+		return nil, nil
+	}
+
+	meter := provider.Meter(HTTPMetricsMeterName)
+
+	requestDuration, err := meter.Float64Histogram(
+		"thv_reg_srv_http_request_duration_seconds",
+		metric.WithDescription("Duration of HTTP requests in seconds"),
+		metric.WithUnit("s"),
+		metric.WithExplicitBucketBoundaries(0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	requestsTotal, err := meter.Int64Counter(
+		"thv_reg_srv_http_requests_total",
+		metric.WithDescription("Total number of HTTP requests"),
+		metric.WithUnit("{request}"),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	activeRequests, err := meter.Int64UpDownCounter(
+		"thv_reg_srv_http_active_requests",
+		metric.WithDescription("Number of currently in-flight HTTP requests"),
+		metric.WithUnit("{request}"),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &HTTPMetrics{
+		requestDuration: requestDuration,
+		requestsTotal:   requestsTotal,
+		activeRequests:  activeRequests,
+	}, nil
+}
+
+// Middleware returns an HTTP middleware that records metrics for each request.
+// If HTTPMetrics is nil, it returns a pass-through middleware.
+func (m *HTTPMetrics) Middleware(next http.Handler) http.Handler {
+	if m == nil {
+		return next
+	}
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Capture context at the start - it may be cancelled after ServeHTTP returns
+		ctx := r.Context()
+		start := time.Now()
+
+		// Get route pattern from chi context (will be available after routing)
+		// We need to wrap the response writer to capture the status code
+		ww := middleware.NewWrapResponseWriter(w, r.ProtoMajor)
+
+		// Increment active requests
+		m.activeRequests.Add(ctx, 1)
+
+		// Serve the request
+		next.ServeHTTP(ww, r)
+
+		// Decrement active requests after request completes
+		m.activeRequests.Add(ctx, -1)
+
+		// Get the route pattern from chi - this gives us the pattern like "/registry/v0.1/servers/{name}"
+		// rather than the actual URL like "/registry/v0.1/servers/my-server"
+		routePattern := getRoutePattern(r)
+
+		// Record metrics
+		attrs := []attribute.KeyValue{
+			attribute.String("method", r.Method),
+			attribute.String("route", routePattern),
+			attribute.String("status_code", strconv.Itoa(ww.Status())),
+		}
+
+		duration := time.Since(start).Seconds()
+		m.requestDuration.Record(ctx, duration, metric.WithAttributes(attrs...))
+		m.requestsTotal.Add(ctx, 1, metric.WithAttributes(attrs...))
+	})
+}
+
+// getRoutePattern extracts the route pattern from a chi request context.
+// Returns "unknown_route" if no pattern is found to prevent cardinality explosion.
+func getRoutePattern(r *http.Request) string {
+	rctx := chi.RouteContext(r.Context())
+	if rctx != nil && rctx.RoutePattern() != "" {
+		return rctx.RoutePattern()
+	}
+	// Return a constant to prevent cardinality explosion from unknown routes
+	return "unknown_route"
+}
+
+// MetricsMiddleware creates middleware from a MeterProvider for convenience.
+// This is a helper function that combines NewHTTPMetrics and Middleware.
+func MetricsMiddleware(provider metric.MeterProvider) (func(http.Handler) http.Handler, error) {
+	metrics, err := NewHTTPMetrics(provider)
+	if err != nil {
+		return nil, err
+	}
+
+	// Return the middleware function
+	return func(next http.Handler) http.Handler {
+		if metrics == nil {
+			return next
+		}
+		return metrics.Middleware(next)
+	}, nil
+}

--- a/internal/telemetry/middleware_test.go
+++ b/internal/telemetry/middleware_test.go
@@ -1,0 +1,269 @@
+package telemetry
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/metric/noop"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+func TestNewHTTPMetrics(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns nil when provider is nil", func(t *testing.T) {
+		t.Parallel()
+
+		metrics, err := NewHTTPMetrics(nil)
+		require.NoError(t, err)
+		assert.Nil(t, metrics)
+	})
+
+	t.Run("creates metrics with SDK provider", func(t *testing.T) {
+		t.Parallel()
+
+		mp := sdkmetric.NewMeterProvider()
+		defer func() { _ = mp.Shutdown(context.Background()) }()
+
+		metrics, err := NewHTTPMetrics(mp)
+		require.NoError(t, err)
+		assert.NotNil(t, metrics)
+		assert.NotNil(t, metrics.requestDuration)
+		assert.NotNil(t, metrics.requestsTotal)
+		assert.NotNil(t, metrics.activeRequests)
+	})
+}
+
+func TestHTTPMetrics_Middleware(t *testing.T) {
+	t.Parallel()
+
+	t.Run("passes through when metrics is nil", func(t *testing.T) {
+		t.Parallel()
+
+		var metrics *HTTPMetrics
+		handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})
+
+		wrapped := metrics.Middleware(handler)
+
+		req := httptest.NewRequest(http.MethodGet, "/test", nil)
+		rr := httptest.NewRecorder()
+		wrapped.ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusOK, rr.Code)
+	})
+
+	t.Run("records metrics for successful request", func(t *testing.T) {
+		t.Parallel()
+
+		// Create a test meter provider with a reader to capture metrics
+		reader := sdkmetric.NewManualReader()
+		mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+		defer func() { _ = mp.Shutdown(context.Background()) }()
+
+		metrics, err := NewHTTPMetrics(mp)
+		require.NoError(t, err)
+		require.NotNil(t, metrics)
+
+		// Create a simple handler that returns 200
+		handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})
+
+		// Create chi router to test route pattern extraction
+		r := chi.NewRouter()
+		r.Use(metrics.Middleware)
+		r.Get("/test/{id}", handler)
+
+		// Make request
+		req := httptest.NewRequest(http.MethodGet, "/test/123", nil)
+		rr := httptest.NewRecorder()
+		r.ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusOK, rr.Code)
+
+		// Collect metrics
+		var rm metricdata.ResourceMetrics
+		err = reader.Collect(context.Background(), &rm)
+		require.NoError(t, err)
+
+		// Verify metrics were recorded
+		require.NotEmpty(t, rm.ScopeMetrics, "expected scope metrics to be recorded")
+
+		// Find our HTTP metrics scope
+		var foundScope bool
+		for _, scope := range rm.ScopeMetrics {
+			if scope.Scope.Name == HTTPMetricsMeterName {
+				foundScope = true
+				assert.NotEmpty(t, scope.Metrics, "expected metrics to be recorded")
+			}
+		}
+		assert.True(t, foundScope, "expected to find HTTP metrics scope")
+	})
+
+	t.Run("records metrics for error response", func(t *testing.T) {
+		t.Parallel()
+
+		reader := sdkmetric.NewManualReader()
+		mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+		defer func() { _ = mp.Shutdown(context.Background()) }()
+
+		metrics, err := NewHTTPMetrics(mp)
+		require.NoError(t, err)
+
+		// Create a handler that returns 500
+		handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		})
+
+		r := chi.NewRouter()
+		r.Use(metrics.Middleware)
+		r.Get("/error", handler)
+
+		req := httptest.NewRequest(http.MethodGet, "/error", nil)
+		rr := httptest.NewRecorder()
+		r.ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusInternalServerError, rr.Code)
+
+		// Verify metrics were recorded
+		var rm metricdata.ResourceMetrics
+		err = reader.Collect(context.Background(), &rm)
+		require.NoError(t, err)
+		require.NotEmpty(t, rm.ScopeMetrics)
+	})
+
+	t.Run("extracts route pattern from chi router", func(t *testing.T) {
+		t.Parallel()
+
+		reader := sdkmetric.NewManualReader()
+		mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+		defer func() { _ = mp.Shutdown(context.Background()) }()
+
+		metrics, err := NewHTTPMetrics(mp)
+		require.NoError(t, err)
+
+		handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})
+
+		r := chi.NewRouter()
+		r.Use(metrics.Middleware)
+		r.Get("/users/{userID}/posts/{postID}", handler)
+
+		// Make request with specific IDs
+		req := httptest.NewRequest(http.MethodGet, "/users/42/posts/123", nil)
+		rr := httptest.NewRecorder()
+		r.ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusOK, rr.Code)
+
+		// Verify metrics were recorded (route pattern should be used, not actual URL)
+		var rm metricdata.ResourceMetrics
+		err = reader.Collect(context.Background(), &rm)
+		require.NoError(t, err)
+		require.NotEmpty(t, rm.ScopeMetrics)
+	})
+}
+
+func TestMetricsMiddleware(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns no-op middleware when provider is nil", func(t *testing.T) {
+		t.Parallel()
+
+		mw, err := MetricsMiddleware(nil)
+		require.NoError(t, err)
+		require.NotNil(t, mw)
+
+		// Test that the middleware passes through
+		handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})
+
+		wrapped := mw(handler)
+		req := httptest.NewRequest(http.MethodGet, "/test", nil)
+		rr := httptest.NewRecorder()
+		wrapped.ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusOK, rr.Code)
+	})
+
+	t.Run("returns working middleware with noop provider", func(t *testing.T) {
+		t.Parallel()
+
+		mp := noop.NewMeterProvider()
+		mw, err := MetricsMiddleware(mp)
+		require.NoError(t, err)
+		require.NotNil(t, mw)
+
+		handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusCreated)
+		})
+
+		wrapped := mw(handler)
+		req := httptest.NewRequest(http.MethodPost, "/test", nil)
+		rr := httptest.NewRecorder()
+		wrapped.ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusCreated, rr.Code)
+	})
+
+	t.Run("creates working middleware with SDK provider", func(t *testing.T) {
+		t.Parallel()
+
+		mp := sdkmetric.NewMeterProvider()
+		defer func() { _ = mp.Shutdown(context.Background()) }()
+
+		mw, err := MetricsMiddleware(mp)
+		require.NoError(t, err)
+		require.NotNil(t, mw)
+
+		handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})
+
+		wrapped := mw(handler)
+		req := httptest.NewRequest(http.MethodGet, "/test", nil)
+		rr := httptest.NewRecorder()
+		wrapped.ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusOK, rr.Code)
+	})
+}
+
+func TestGetRoutePattern(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns unknown_route when no chi context", func(t *testing.T) {
+		t.Parallel()
+
+		req := httptest.NewRequest(http.MethodGet, "/test/path", nil)
+		pattern := getRoutePattern(req)
+
+		assert.Equal(t, "unknown_route", pattern)
+	})
+
+	t.Run("returns route pattern from chi context", func(t *testing.T) {
+		t.Parallel()
+
+		handler := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+			pattern := getRoutePattern(r)
+			assert.Equal(t, "/users/{id}", pattern)
+		})
+
+		r := chi.NewRouter()
+		r.Get("/users/{id}", handler)
+
+		req := httptest.NewRequest(http.MethodGet, "/users/123", nil)
+		rr := httptest.NewRecorder()
+		r.ServeHTTP(rr, req)
+	})
+}


### PR DESCRIPTION
## Summary

Add comprehensive metrics collection for the registry server using OpenTelemetry with OTLP export.

### Metrics Added

All metrics are prefixed with `thv_reg_srv_` for easy identification:

| Metric | Type | Description |
|--------|------|-------------|
| `thv_reg_srv_http_request_duration_seconds` | Histogram | HTTP request latency |
| `thv_reg_srv_http_requests_total` | Counter | Total HTTP requests |
| `thv_reg_srv_http_active_requests` | UpDownCounter | In-flight requests |
| `thv_reg_srv_servers_total` | Gauge | Number of servers per registry |
| `thv_reg_srv_sync_duration_seconds` | Histogram | Sync operation duration |

### Implementation

- `internal/telemetry/metrics.go` - RegistryMetrics and SyncMetrics structs
- `internal/telemetry/middleware.go` - HTTP metrics middleware for Chi router
- `internal/app/builder.go` - Integration via `WithMeterProvider` option
- `internal/sync/coordinator/coordinator.go` - Sync metrics recording

### Also Included

- Grafana dashboard (`examples/otel/grafana/dashboards/registry-server.json`)
- Observability documentation (`docs/observability.md`)
- Comprehensive unit tests for all metrics components

<img width="1975" height="1176" alt="image" src="https://github.com/user-attachments/assets/4829aec6-97d4-4142-9d61-5c2fba1d1b8f" />


Ref: https://github.com/stacklok/toolhive-registry-server/issues/259