### PR TITLE
Update OpenAPI docs

### DIFF
--- a/docs/thv-registry-api/docs.go
+++ b/docs/thv-registry-api/docs.go
@@ -1251,6 +1251,7 @@ const docTemplate = `{
         },
         "/registry/v0.1/publish": {
             "post": {
+                "deprecated": true,
                 "description": "Publish a server to the registry. This server does not support publishing via this endpoint.\nUse the registry-specific endpoint /{registryName}/v0.1/publish instead.",
                 "requestBody": {
                     "content": {
@@ -1302,6 +1303,7 @@ const docTemplate = `{
         },
         "/registry/v0.1/servers": {
             "get": {
+                "deprecated": true,
                 "description": "Get a list of available servers from all registries (aggregated view)",
                 "parameters": [
                     {
@@ -1397,6 +1399,7 @@ const docTemplate = `{
         },
         "/registry/v0.1/servers/{serverName}/versions": {
             "get": {
+                "deprecated": true,
                 "description": "Returns all available versions for a specific MCP server from all registries (aggregated view)",
                 "parameters": [
                     {
@@ -1482,6 +1485,7 @@ const docTemplate = `{
         },
         "/registry/v0.1/servers/{serverName}/versions/{version}": {
             "get": {
+                "deprecated": true,
                 "description": "Returns detailed information about a specific version of an MCP server from all registries.\nUse the special version ` + "`" + `latest` + "`" + ` to get the latest version.",
                 "parameters": [
                     {
@@ -1773,6 +1777,126 @@ const docTemplate = `{
             }
         },
         "/registry/{registryName}/v0.1/servers/{serverName}/versions/{version}": {
+            "delete": {
+                "description": "Delete a server version from a specific managed registry",
+                "parameters": [
+                    {
+                        "description": "Registry name",
+                        "in": "path",
+                        "name": "registryName",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Server name (URL-encoded)",
+                        "in": "path",
+                        "name": "serverName",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Version (URL-encoded)",
+                        "in": "path",
+                        "name": "version",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "204": {
+                        "description": "No content"
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "additionalProperties": {
+                                        "type": "string"
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "description": "Bad request"
+                    },
+                    "401": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "additionalProperties": {
+                                        "type": "string"
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "description": "Unauthorized"
+                    },
+                    "403": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "additionalProperties": {
+                                        "type": "string"
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "description": "Not a managed registry"
+                    },
+                    "404": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "additionalProperties": {
+                                        "type": "string"
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "description": "Server version not found"
+                    },
+                    "500": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "additionalProperties": {
+                                        "type": "string"
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "description": "Internal server error"
+                    }
+                },
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "summary": "Delete server version from specific registry",
+                "tags": [
+                    "registry"
+                ]
+            },
             "get": {
                 "description": "Returns detailed information about a specific version of an MCP server from a specific registry.\nUse the special version ` + "`" + `latest` + "`" + ` to get the latest version.",
                 "parameters": [
@@ -2026,128 +2150,6 @@ const docTemplate = `{
                     }
                 ],
                 "summary": "Publish server to specific registry",
-                "tags": [
-                    "registry"
-                ]
-            }
-        },
-        "/{registryName}/v0.1/servers/{serverName}/versions/{version}": {
-            "delete": {
-                "description": "Delete a server version from a specific managed registry",
-                "parameters": [
-                    {
-                        "description": "Registry name",
-                        "in": "path",
-                        "name": "registryName",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "description": "Server name (URL-encoded)",
-                        "in": "path",
-                        "name": "serverName",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "description": "Version (URL-encoded)",
-                        "in": "path",
-                        "name": "version",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "object"
-                            }
-                        }
-                    }
-                },
-                "responses": {
-                    "204": {
-                        "description": "No content"
-                    },
-                    "400": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "additionalProperties": {
-                                        "type": "string"
-                                    },
-                                    "type": "object"
-                                }
-                            }
-                        },
-                        "description": "Bad request"
-                    },
-                    "401": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "additionalProperties": {
-                                        "type": "string"
-                                    },
-                                    "type": "object"
-                                }
-                            }
-                        },
-                        "description": "Unauthorized"
-                    },
-                    "403": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "additionalProperties": {
-                                        "type": "string"
-                                    },
-                                    "type": "object"
-                                }
-                            }
-                        },
-                        "description": "Not a managed registry"
-                    },
-                    "404": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "additionalProperties": {
-                                        "type": "string"
-                                    },
-                                    "type": "object"
-                                }
-                            }
-                        },
-                        "description": "Server version not found"
-                    },
-                    "500": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "additionalProperties": {
-                                        "type": "string"
-                                    },
-                                    "type": "object"
-                                }
-                            }
-                        },
-                        "description": "Internal server error"
-                    }
-                },
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "summary": "Delete server version from specific registry",
                 "tags": [
                     "registry"
                 ]

--- a/docs/thv-registry-api/swagger.json
+++ b/docs/thv-registry-api/swagger.json
@@ -1244,6 +1244,7 @@
         },
         "/registry/v0.1/publish": {
             "post": {
+                "deprecated": true,
                 "description": "Publish a server to the registry. This server does not support publishing via this endpoint.\nUse the registry-specific endpoint /{registryName}/v0.1/publish instead.",
                 "requestBody": {
                     "content": {
@@ -1295,6 +1296,7 @@
         },
         "/registry/v0.1/servers": {
             "get": {
+                "deprecated": true,
                 "description": "Get a list of available servers from all registries (aggregated view)",
                 "parameters": [
                     {
@@ -1390,6 +1392,7 @@
         },
         "/registry/v0.1/servers/{serverName}/versions": {
             "get": {
+                "deprecated": true,
                 "description": "Returns all available versions for a specific MCP server from all registries (aggregated view)",
                 "parameters": [
                     {
@@ -1475,6 +1478,7 @@
         },
         "/registry/v0.1/servers/{serverName}/versions/{version}": {
             "get": {
+                "deprecated": true,
                 "description": "Returns detailed information about a specific version of an MCP server from all registries.\nUse the special version `latest` to get the latest version.",
                 "parameters": [
                     {
@@ -1766,6 +1770,126 @@
             }
         },
         "/registry/{registryName}/v0.1/servers/{serverName}/versions/{version}": {
+            "delete": {
+                "description": "Delete a server version from a specific managed registry",
+                "parameters": [
+                    {
+                        "description": "Registry name",
+                        "in": "path",
+                        "name": "registryName",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Server name (URL-encoded)",
+                        "in": "path",
+                        "name": "serverName",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Version (URL-encoded)",
+                        "in": "path",
+                        "name": "version",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "204": {
+                        "description": "No content"
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "additionalProperties": {
+                                        "type": "string"
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "description": "Bad request"
+                    },
+                    "401": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "additionalProperties": {
+                                        "type": "string"
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "description": "Unauthorized"
+                    },
+                    "403": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "additionalProperties": {
+                                        "type": "string"
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "description": "Not a managed registry"
+                    },
+                    "404": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "additionalProperties": {
+                                        "type": "string"
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "description": "Server version not found"
+                    },
+                    "500": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "additionalProperties": {
+                                        "type": "string"
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "description": "Internal server error"
+                    }
+                },
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "summary": "Delete server version from specific registry",
+                "tags": [
+                    "registry"
+                ]
+            },
             "get": {
                 "description": "Returns detailed information about a specific version of an MCP server from a specific registry.\nUse the special version `latest` to get the latest version.",
                 "parameters": [
@@ -2019,128 +2143,6 @@
                     }
                 ],
                 "summary": "Publish server to specific registry",
-                "tags": [
-                    "registry"
-                ]
-            }
-        },
-        "/{registryName}/v0.1/servers/{serverName}/versions/{version}": {
-            "delete": {
-                "description": "Delete a server version from a specific managed registry",
-                "parameters": [
-                    {
-                        "description": "Registry name",
-                        "in": "path",
-                        "name": "registryName",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "description": "Server name (URL-encoded)",
-                        "in": "path",
-                        "name": "serverName",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "description": "Version (URL-encoded)",
-                        "in": "path",
-                        "name": "version",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "object"
-                            }
-                        }
-                    }
-                },
-                "responses": {
-                    "204": {
-                        "description": "No content"
-                    },
-                    "400": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "additionalProperties": {
-                                        "type": "string"
-                                    },
-                                    "type": "object"
-                                }
-                            }
-                        },
-                        "description": "Bad request"
-                    },
-                    "401": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "additionalProperties": {
-                                        "type": "string"
-                                    },
-                                    "type": "object"
-                                }
-                            }
-                        },
-                        "description": "Unauthorized"
-                    },
-                    "403": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "additionalProperties": {
-                                        "type": "string"
-                                    },
-                                    "type": "object"
-                                }
-                            }
-                        },
-                        "description": "Not a managed registry"
-                    },
-                    "404": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "additionalProperties": {
-                                        "type": "string"
-                                    },
-                                    "type": "object"
-                                }
-                            }
-                        },
-                        "description": "Server version not found"
-                    },
-                    "500": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "additionalProperties": {
-                                        "type": "string"
-                                    },
-                                    "type": "object"
-                                }
-                            }
-                        },
-                        "description": "Internal server error"
-                    }
-                },
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "summary": "Delete server version from specific registry",
                 "tags": [
                     "registry"
                 ]

--- a/docs/thv-registry-api/swagger.yaml
+++ b/docs/thv-registry-api/swagger.yaml
@@ -647,81 +647,6 @@ paths:
       summary: Publish server to specific registry
       tags:
       - registry
-  /{registryName}/v0.1/servers/{serverName}/versions/{version}:
-    delete:
-      description: Delete a server version from a specific managed registry
-      parameters:
-      - description: Registry name
-        in: path
-        name: registryName
-        required: true
-        schema:
-          type: string
-      - description: Server name (URL-encoded)
-        in: path
-        name: serverName
-        required: true
-        schema:
-          type: string
-      - description: Version (URL-encoded)
-        in: path
-        name: version
-        required: true
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-      responses:
-        "204":
-          description: No content
-        "400":
-          content:
-            application/json:
-              schema:
-                additionalProperties:
-                  type: string
-                type: object
-          description: Bad request
-        "401":
-          content:
-            application/json:
-              schema:
-                additionalProperties:
-                  type: string
-                type: object
-          description: Unauthorized
-        "403":
-          content:
-            application/json:
-              schema:
-                additionalProperties:
-                  type: string
-                type: object
-          description: Not a managed registry
-        "404":
-          content:
-            application/json:
-              schema:
-                additionalProperties:
-                  type: string
-                type: object
-          description: Server version not found
-        "500":
-          content:
-            application/json:
-              schema:
-                additionalProperties:
-                  type: string
-                type: object
-          description: Internal server error
-      security:
-      - BearerAuth: []
-      summary: Delete server version from specific registry
-      tags:
-      - registry
   /extension/v0/registries:
     get:
       description: List all registries
@@ -1153,6 +1078,80 @@ paths:
       tags:
       - registry
   /registry/{registryName}/v0.1/servers/{serverName}/versions/{version}:
+    delete:
+      description: Delete a server version from a specific managed registry
+      parameters:
+      - description: Registry name
+        in: path
+        name: registryName
+        required: true
+        schema:
+          type: string
+      - description: Server name (URL-encoded)
+        in: path
+        name: serverName
+        required: true
+        schema:
+          type: string
+      - description: Version (URL-encoded)
+        in: path
+        name: version
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        "204":
+          description: No content
+        "400":
+          content:
+            application/json:
+              schema:
+                additionalProperties:
+                  type: string
+                type: object
+          description: Bad request
+        "401":
+          content:
+            application/json:
+              schema:
+                additionalProperties:
+                  type: string
+                type: object
+          description: Unauthorized
+        "403":
+          content:
+            application/json:
+              schema:
+                additionalProperties:
+                  type: string
+                type: object
+          description: Not a managed registry
+        "404":
+          content:
+            application/json:
+              schema:
+                additionalProperties:
+                  type: string
+                type: object
+          description: Server version not found
+        "500":
+          content:
+            application/json:
+              schema:
+                additionalProperties:
+                  type: string
+                type: object
+          description: Internal server error
+      security:
+      - BearerAuth: []
+      summary: Delete server version from specific registry
+      tags:
+      - registry
     get:
       description: |-
         Returns detailed information about a specific version of an MCP server from a specific registry.
@@ -1219,6 +1218,7 @@ paths:
       - registry
   /registry/v0.1/publish:
     post:
+      deprecated: true
       description: |-
         Publish a server to the registry. This server does not support publishing via this endpoint.
         Use the registry-specific endpoint /{registryName}/v0.1/publish instead.
@@ -1251,6 +1251,7 @@ paths:
       - registry-aggregated
   /registry/v0.1/servers:
     get:
+      deprecated: true
       description: Get a list of available servers from all registries (aggregated
         view)
       parameters:
@@ -1310,6 +1311,7 @@ paths:
       - registry-aggregated
   /registry/v0.1/servers/{serverName}/versions:
     get:
+      deprecated: true
       description: Returns all available versions for a specific MCP server from all
         registries (aggregated view)
       parameters:
@@ -1362,6 +1364,7 @@ paths:
       - registry-aggregated
   /registry/v0.1/servers/{serverName}/versions/{version}:
     get:
+      deprecated: true
       description: |-
         Returns detailed information about a specific version of an MCP server from all registries.
         Use the special version `latest` to get the latest version.

--- a/internal/api/registry/v01/routes.go
+++ b/internal/api/registry/v01/routes.go
@@ -158,6 +158,7 @@ func (routes *Routes) handleListServers(w http.ResponseWriter, r *http.Request, 
 // @Failure		401		{object}	map[string]string	"Unauthorized"
 // @Security	BearerAuth
 // @Router		/registry/v0.1/servers [get]
+// @Deprecated	true
 func (routes *Routes) listServers(w http.ResponseWriter, r *http.Request) {
 	routes.handleListServers(w, r, "")
 }
@@ -249,6 +250,7 @@ func (routes *Routes) handleListVersions(w http.ResponseWriter, r *http.Request,
 // @Failure		404		{object}	map[string]string	"Server not found"
 // @Security	BearerAuth
 // @Router		/registry/v0.1/servers/{serverName}/versions [get]
+// @Deprecated	true
 func (routes *Routes) listVersions(w http.ResponseWriter, r *http.Request) {
 	routes.handleListVersions(w, r, "")
 }
@@ -336,6 +338,7 @@ func (routes *Routes) handleGetVersion(w http.ResponseWriter, r *http.Request, r
 // @Failure		404		{object}	map[string]string	"Server or version not found"
 // @Security	BearerAuth
 // @Router		/registry/v0.1/servers/{serverName}/versions/{version} [get]
+// @Deprecated	true
 func (routes *Routes) getVersion(w http.ResponseWriter, r *http.Request) {
 	routes.handleGetVersion(w, r, "")
 }
@@ -384,7 +387,7 @@ func (routes *Routes) getVersionWithRegistryName(w http.ResponseWriter, r *http.
 // @Failure      404  {object}  map[string]string  "Server version not found"
 // @Failure      500  {object}  map[string]string  "Internal server error"
 // @Security     BearerAuth
-// @Router       /{registryName}/v0.1/servers/{serverName}/versions/{version} [delete]
+// @Router       /registry/{registryName}/v0.1/servers/{serverName}/versions/{version} [delete]
 func (routes *Routes) deleteVersionWithRegistryName(w http.ResponseWriter, r *http.Request) {
 	registryName, err := common.GetAndValidateURLParam(r, "registryName")
 	if err != nil {
@@ -521,6 +524,7 @@ func (routes *Routes) publishWithRegistryName(w http.ResponseWriter, r *http.Req
 // @Failure		501	{object}	map[string]string	"Not implemented"
 // @Security	BearerAuth
 // @Router		/registry/v0.1/publish [post]
+// @Deprecated	true
 func (*Routes) publish(w http.ResponseWriter, _ *http.Request) {
 	common.WriteErrorResponse(
 		w,


### PR DESCRIPTION
This change marks as deprecated all endpoints directly under `/registry/v0.1` in favor of "namespaced" ones under `/registry/{registryName}/v0.1`.