### PR TITLE
feat(chart): add RBAC templates for Kubernetes controller

### DIFF
--- a/deploy/charts/toolhive-registry-server/templates/rbac.yaml
+++ b/deploy/charts/toolhive-registry-server/templates/rbac.yaml
@@ -1,0 +1,87 @@
+{{- if .Values.rbac.create -}}
+---
+# Role for leader election (required for Kubernetes controller)
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "toolhive-registry-server.fullname" . }}-leader-election
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "toolhive-registry-server.labels" . | nindent 4 }}
+rules:
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+---
+# RoleBinding for leader election
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "toolhive-registry-server.fullname" . }}-leader-election
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "toolhive-registry-server.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "toolhive-registry-server.fullname" . }}-leader-election
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "toolhive-registry-server.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- if .Values.rbac.watchMCPServers }}
+---
+# Role for watching MCPServer resources
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "toolhive-registry-server.fullname" . }}-mcpserver-reader
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "toolhive-registry-server.labels" . | nindent 4 }}
+rules:
+  - apiGroups:
+      - toolhive.stacklok.dev
+    resources:
+      - mcpservers
+      - virtualmcpservers
+      - mcpremoteproxies
+    verbs:
+      - get
+      - list
+      - watch
+---
+# RoleBinding for MCPServer reader
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "toolhive-registry-server.fullname" . }}-mcpserver-reader
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "toolhive-registry-server.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "toolhive-registry-server.fullname" . }}-mcpserver-reader
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "toolhive-registry-server.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}
+{{- end }}

--- a/deploy/charts/toolhive-registry-server/values.yaml
+++ b/deploy/charts/toolhive-registry-server/values.yaml
@@ -27,6 +27,14 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
+rbac:
+  # -- Specifies whether RBAC resources should be created
+  # Required for Kubernetes registry sources (leader election and watching MCPServer resources)
+  create: true
+  # -- Whether to create RBAC for watching MCPServer/VirtualMCPServer/MCPRemoteProxy resources
+  # Set to true when using kubernetes registry sources
+  watchMCPServers: false
+
 # -- Annotations to add to the pod
 podAnnotations: {}
 


### PR DESCRIPTION
## Summary
- Add Role and RoleBinding templates for leader election and MCPServer watching
- New helm values: `rbac.create` and `rbac.watchMCPServers`

## Details
The registry server's Kubernetes controller requires RBAC permissions for:
1. **Leader election** - access to leases in `coordination.k8s.io`
2. **MCPServer watching** - read access to MCPServer/VirtualMCPServer/MCPRemoteProxy resources

Without these permissions, the Kubernetes registry source cannot sync MCPServer resources to the registry.
