### PR TITLE
Add leader election role to Helm chart

### DIFF
--- a/deploy/charts/toolhive-registry-server/README.md
+++ b/deploy/charts/toolhive-registry-server/README.md
@@ -72,6 +72,8 @@ The command removes all the Kubernetes components associated with the chart and 
 | image.registryServerUrl | string | `"ghcr.io/stacklok/thv-registry-api:v0.5.0"` | URL of the registry server image |
 | imagePullSecrets | list | `[]` | Image pull secrets for private registries |
 | initContainers | list | `[]` | Init containers to run before the main container Use this for setup tasks like preparing pgpass files, waiting for dependencies, etc. Init containers share the same volumes as the main container (extraVolumes) |
+| leaderElectionRole | object | `{"binding":{"name":""},"name":"","rules":[{"apiGroups":["toolhive.stacklok.dev"],"resources":["mcpservers","mcpremoteproxies","virtualmcpservers"],"verbs":["get","list","watch"]},{"apiGroups":[""],"resources":["services"],"verbs":["get","list","watch"]},{"apiGroups":[""],"resources":["configmaps"],"verbs":["get","list","watch","create","update","patch","delete"]},{"apiGroups":["coordination.k8s.io"],"resources":["leases"],"verbs":["get","list","watch","create","update","patch","delete"]},{"apiGroups":[""],"resources":["events"],"verbs":["create","patch"]}]}` | Leader election role configuration |
+| leaderElectionRole.binding.name | string | `""` | Name of the role binding for leader election |
 | livenessProbe | object | `{"httpGet":{"path":"/health","port":"http"},"initialDelaySeconds":30,"periodSeconds":10}` | Liveness probe configuration |
 | nameOverride | string | `""` | Override the name of the chart |
 | nodeSelector | object | `{}` | Node selector for pod scheduling |

--- a/deploy/charts/toolhive-registry-server/templates/_helpers.tpl
+++ b/deploy/charts/toolhive-registry-server/templates/_helpers.tpl
@@ -63,6 +63,20 @@ Create the name of the service account to use
 {{- end }}
 
 {{/*
+Create the name of the leader election role to use
+*/}}
+{{- define "toolhive-registry-server.leaderElectionRoleName" -}}
+{{- default (include "toolhive-registry-server.fullname" .) .Values.leaderElectionRole.name }}
+{{- end }}
+
+{{/*
+Create the name of the leader election role binding to use
+*/}}
+{{- define "toolhive-registry-server.leaderElectionRoleBindingName" -}}
+{{- default (include "toolhive-registry-server.fullname" .) .Values.leaderElectionRole.binding.name }}
+{{- end }}
+
+{{/*
 Create the name of the configmap for the registry server config
 */}}
 {{- define "toolhive-registry-server.configMapName" -}}

--- a/deploy/charts/toolhive-registry-server/templates/role.yaml
+++ b/deploy/charts/toolhive-registry-server/templates/role.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "toolhive-registry-server.leaderElectionRoleName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "toolhive-registry-server.labels" . | nindent 4 }}
+rules:
+  {{- toYaml .Values.leaderElectionRole.rules | nindent 2 }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "toolhive-registry-server.leaderElectionRoleBindingName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "toolhive-registry-server.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "toolhive-registry-server.leaderElectionRoleName" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "toolhive-registry-server.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}

--- a/deploy/charts/toolhive-registry-server/values.yaml
+++ b/deploy/charts/toolhive-registry-server/values.yaml
@@ -235,3 +235,66 @@ extraVolumeMounts: []
   #   readOnly: true
   # - name: registry-data
   #   mountPath: /data
+
+# -- Leader election role configuration
+leaderElectionRole:
+  name: ""
+  binding:
+    # -- Name of the role binding for leader election
+    name: ""
+  rules:
+  # Permissions required to watch MCP servers, virtual MCP servers,
+  # and remote proxies
+  - apiGroups:
+      - toolhive.stacklok.dev
+    resources:
+      - mcpservers
+      - mcpremoteproxies
+      - virtualmcpservers
+    verbs:
+      - get
+      - list
+      - watch
+  # Permissions required to watch Services
+  - apiGroups:
+      - ''
+    resources:
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+  # Permissions required to manipulate ConfigMaps
+  - apiGroups:
+      - ''
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  # Permissions required to use Kubernetes leases for leader election
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  # Permissions required to receive events for the watched resources
+  - apiGroups:
+      - ''
+    resources:
+      - events
+    verbs:
+      - create
+      - patch


### PR DESCRIPTION
This change adds a the necessary template and defaults in `values.yaml` to provision a Kubernetes `Role`. Such a role is configured with the necessary permissions to watch for `MCPServer`, `VirtualMCPServer`, `RemoteProxy`, and `Service` resources (as well as events), allowing the internal Kubernetes controller to scan for MCP workloads.

Fixes #469