### PR TITLE
Pass config throughout the factory layer

### DIFF
--- a/internal/app/builder.go
+++ b/internal/app/builder.go
@@ -285,7 +285,7 @@ func buildSyncComponents(
 
 	// Build registry handler factory (storage-agnostic)
 	if b.registryHandlerFactory == nil {
-		b.registryHandlerFactory = sources.NewRegistryHandlerFactory()
+		b.registryHandlerFactory = sources.NewRegistryHandlerFactory(b.config)
 	}
 
 	// Create state service using storage factory

--- a/internal/sources/api.go
+++ b/internal/sources/api.go
@@ -15,16 +15,18 @@ type apiRegistryHandler struct {
 	httpClient      httpclient.Client
 	validator       RegistryDataValidator
 	upstreamHandler *upstreamAPIHandler
+	cfg             *config.Config
 }
 
 // NewAPIRegistryHandler creates a new API registry handler
-func NewAPIRegistryHandler() RegistryHandler {
+func NewAPIRegistryHandler(cfg *config.Config) RegistryHandler {
 	httpClient := httpclient.NewDefaultClient(0) // Use default timeout
 
 	return &apiRegistryHandler{
 		httpClient:      httpClient,
 		validator:       NewRegistryDataValidator(),
-		upstreamHandler: NewUpstreamAPIHandler(httpClient),
+		upstreamHandler: NewUpstreamAPIHandler(httpClient, cfg),
+		cfg:             cfg,
 	}
 }
 

--- a/internal/sources/api_test.go
+++ b/internal/sources/api_test.go
@@ -131,7 +131,7 @@ openapi: 3.1.0
 			mockServer := tt.setupServer()
 			defer mockServer.Close()
 
-			handler := sources.NewAPIRegistryHandler()
+			handler := sources.NewAPIRegistryHandler(nil)
 			ctx := context.Background()
 
 			// Set the endpoint from the mock server
@@ -164,7 +164,7 @@ openapi: 3.1.0
 func TestNewAPIRegistryHandler(t *testing.T) {
 	t.Parallel()
 
-	handler := sources.NewAPIRegistryHandler()
+	handler := sources.NewAPIRegistryHandler(nil)
 
 	require.NotNil(t, handler, "NewAPIRegistryHandler should return a non-nil handler")
 }
@@ -225,7 +225,7 @@ openapi: 3.1.0
 	}))
 	defer mockServer.Close()
 
-	handler := sources.NewAPIRegistryHandler()
+	handler := sources.NewAPIRegistryHandler(nil)
 	ctx := context.Background()
 
 	registryConfig := &config.RegistryConfig{
@@ -250,7 +250,7 @@ openapi: 3.1.0
 func TestAPIRegistryHandler_NilConfig(t *testing.T) {
 	t.Parallel()
 
-	handler := sources.NewAPIRegistryHandler()
+	handler := sources.NewAPIRegistryHandler(nil)
 	ctx := context.Background()
 
 	_, err := handler.FetchRegistry(ctx, nil)
@@ -261,7 +261,7 @@ func TestAPIRegistryHandler_NilConfig(t *testing.T) {
 func TestAPIRegistryHandler_NilAPIConfig(t *testing.T) {
 	t.Parallel()
 
-	handler := sources.NewAPIRegistryHandler()
+	handler := sources.NewAPIRegistryHandler(nil)
 	ctx := context.Background()
 
 	registryConfig := &config.RegistryConfig{

--- a/internal/sources/api_upstream.go
+++ b/internal/sources/api_upstream.go
@@ -42,13 +42,15 @@ const (
 type upstreamAPIHandler struct {
 	httpClient httpclient.Client
 	validator  RegistryDataValidator
+	cfg        *config.Config
 }
 
 // NewUpstreamAPIHandler creates a new upstream MCP Registry API handler
-func NewUpstreamAPIHandler(httpClient httpclient.Client) *upstreamAPIHandler {
+func NewUpstreamAPIHandler(httpClient httpclient.Client, cfg *config.Config) *upstreamAPIHandler {
 	return &upstreamAPIHandler{
 		httpClient: httpClient,
 		validator:  NewRegistryDataValidator(),
+		cfg:        cfg,
 	}
 }
 

--- a/internal/sources/api_upstream_test.go
+++ b/internal/sources/api_upstream_test.go
@@ -207,7 +207,7 @@ info:
 			defer mockServer.Close()
 
 			httpClient := httpclient.NewDefaultClient(0)
-			handler := NewUpstreamAPIHandler(httpClient)
+			handler := NewUpstreamAPIHandler(httpClient, nil)
 			ctx := context.Background()
 
 			err := handler.Validate(ctx, mockServer.URL)
@@ -302,7 +302,7 @@ func TestUpstreamAPIHandler_FetchRegistry(t *testing.T) {
 			defer mockServer.Close()
 
 			httpClient := httpclient.NewDefaultClient(0)
-			handler := NewUpstreamAPIHandler(httpClient)
+			handler := NewUpstreamAPIHandler(httpClient, nil)
 			ctx := context.Background()
 
 			registryConfig := &config.RegistryConfig{
@@ -394,7 +394,7 @@ func TestUpstreamAPIHandler_FetchRegistry_Pagination(t *testing.T) {
 	defer mockServer.Close()
 
 	httpClient := httpclient.NewDefaultClient(0)
-	handler := NewUpstreamAPIHandler(httpClient)
+	handler := NewUpstreamAPIHandler(httpClient, nil)
 	ctx := context.Background()
 
 	registryConfig := &config.RegistryConfig{
@@ -478,7 +478,7 @@ func TestUpstreamAPIHandler_CurrentHash(t *testing.T) {
 			defer mockServer.Close()
 
 			httpClient := httpclient.NewDefaultClient(0)
-			handler := NewUpstreamAPIHandler(httpClient)
+			handler := NewUpstreamAPIHandler(httpClient, nil)
 			ctx := context.Background()
 
 			registryConfig := &config.RegistryConfig{
@@ -538,7 +538,7 @@ func TestUpstreamAPIHandler_HashConsistency(t *testing.T) {
 	defer mockServer.Close()
 
 	httpClient := httpclient.NewDefaultClient(0)
-	handler := NewUpstreamAPIHandler(httpClient)
+	handler := NewUpstreamAPIHandler(httpClient, nil)
 	ctx := context.Background()
 
 	registryConfig := &config.RegistryConfig{
@@ -582,7 +582,7 @@ func TestUpstreamAPIHandler_EmptyServers(t *testing.T) {
 	defer mockServer.Close()
 
 	httpClient := httpclient.NewDefaultClient(0)
-	handler := NewUpstreamAPIHandler(httpClient)
+	handler := NewUpstreamAPIHandler(httpClient, nil)
 	ctx := context.Background()
 
 	registryConfig := &config.RegistryConfig{
@@ -642,7 +642,7 @@ func TestUpstreamAPIHandler_MultiplePages(t *testing.T) {
 	defer mockServer.Close()
 
 	httpClient := httpclient.NewDefaultClient(0)
-	handler := NewUpstreamAPIHandler(httpClient)
+	handler := NewUpstreamAPIHandler(httpClient, nil)
 	ctx := context.Background()
 
 	registryConfig := &config.RegistryConfig{
@@ -670,7 +670,7 @@ func TestNewUpstreamAPIHandler(t *testing.T) {
 	t.Parallel()
 
 	httpClient := httpclient.NewDefaultClient(0)
-	handler := NewUpstreamAPIHandler(httpClient)
+	handler := NewUpstreamAPIHandler(httpClient, nil)
 
 	require.NotNil(t, handler, "NewUpstreamAPIHandler should return a non-nil handler")
 }
@@ -701,7 +701,7 @@ func TestUpstreamAPIHandler_HTTPErrorCodes(t *testing.T) {
 			defer mockServer.Close()
 
 			httpClient := httpclient.NewDefaultClient(0)
-			handler := NewUpstreamAPIHandler(httpClient)
+			handler := NewUpstreamAPIHandler(httpClient, nil)
 			ctx := context.Background()
 
 			registryConfig := &config.RegistryConfig{

--- a/internal/sources/factory.go
+++ b/internal/sources/factory.go
@@ -7,18 +7,22 @@ import (
 )
 
 // defaultRegistryHandlerFactory is the default implementation of RegistryHandlerFactory
-type defaultRegistryHandlerFactory struct{}
+type defaultRegistryHandlerFactory struct {
+	cfg *config.Config
+}
 
 var _ RegistryHandlerFactory = (*defaultRegistryHandlerFactory)(nil)
 
 // NewRegistryHandlerFactory creates a new registry handler factory
-func NewRegistryHandlerFactory() RegistryHandlerFactory {
-	return &defaultRegistryHandlerFactory{}
+func NewRegistryHandlerFactory(cfg *config.Config) RegistryHandlerFactory {
+	return &defaultRegistryHandlerFactory{
+		cfg: cfg,
+	}
 }
 
 // CreateHandler creates a registry handler for the given registry configuration
 // The source type is inferred from which field is present (Git/API/File)
-func (*defaultRegistryHandlerFactory) CreateHandler(regCfg *config.RegistryConfig) (RegistryHandler, error) {
+func (f *defaultRegistryHandlerFactory) CreateHandler(regCfg *config.RegistryConfig) (RegistryHandler, error) {
 	if regCfg == nil {
 		return nil, fmt.Errorf("registry configuration cannot be nil")
 	}
@@ -30,11 +34,11 @@ func (*defaultRegistryHandlerFactory) CreateHandler(regCfg *config.RegistryConfi
 
 	switch sourceType {
 	case config.SourceTypeGit:
-		return NewGitRegistryHandler(), nil
+		return NewGitRegistryHandler(f.cfg), nil
 	case config.SourceTypeAPI:
-		return NewAPIRegistryHandler(), nil
+		return NewAPIRegistryHandler(f.cfg), nil
 	case config.SourceTypeFile:
-		return NewFileRegistryHandler(), nil
+		return NewFileRegistryHandler(f.cfg), nil
 	case config.SourceTypeKubernetes:
 		return nil, fmt.Errorf("kubernetes source type is not yet implemented")
 	case config.SourceTypeManaged:

--- a/internal/sources/factory_test.go
+++ b/internal/sources/factory_test.go
@@ -11,14 +11,14 @@ import (
 func TestNewRegistryHandlerFactory(t *testing.T) {
 	t.Parallel()
 
-	factory := NewRegistryHandlerFactory()
+	factory := NewRegistryHandlerFactory(nil)
 	assert.NotNil(t, factory)
 }
 
 func TestDefaultRegistryHandlerFactory_CreateHandler(t *testing.T) {
 	t.Parallel()
 
-	factory := NewRegistryHandlerFactory()
+	factory := NewRegistryHandlerFactory(nil)
 
 	tests := []struct {
 		name           string

--- a/internal/sources/file.go
+++ b/internal/sources/file.go
@@ -20,22 +20,25 @@ const (
 type fileRegistryHandler struct {
 	validator  RegistryDataValidator
 	httpClient httpclient.Client
+	cfg        *config.Config
 }
 
 // NewFileRegistryHandler creates a new file registry handler
-func NewFileRegistryHandler() RegistryHandler {
+func NewFileRegistryHandler(cfg *config.Config) RegistryHandler {
 	return &fileRegistryHandler{
 		validator:  NewRegistryDataValidator(),
 		httpClient: httpclient.NewDefaultClient(DefaultURLTimeout),
+		cfg:        cfg,
 	}
 }
 
 // NewFileRegistryHandlerWithClient creates a new file registry handler with a custom HTTP client
 // This is useful for testing
-func NewFileRegistryHandlerWithClient(client httpclient.Client) RegistryHandler {
+func NewFileRegistryHandlerWithClient(client httpclient.Client, cfg *config.Config) RegistryHandler {
 	return &fileRegistryHandler{
 		validator:  NewRegistryDataValidator(),
 		httpClient: client,
+		cfg:        cfg,
 	}
 }
 

--- a/internal/sources/file_test.go
+++ b/internal/sources/file_test.go
@@ -61,7 +61,7 @@ const testUpstreamRegistryData = `{
 func TestNewFileRegistryHandler(t *testing.T) {
 	t.Parallel()
 
-	handler := NewFileRegistryHandler()
+	handler := NewFileRegistryHandler(nil)
 	assert.NotNil(t, handler)
 	// Cast to concrete type to access fields in tests (same package)
 	concreteHandler := handler.(*fileRegistryHandler)
@@ -129,7 +129,7 @@ func TestFileRegistryHandler_Validate(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			handler := NewFileRegistryHandler()
+			handler := NewFileRegistryHandler(nil)
 			err := handler.Validate(tt.registryConfig)
 
 			if tt.expectError {
@@ -274,7 +274,7 @@ func TestFileRegistryHandler_FetchRegistry(t *testing.T) {
 			filePath := tt.setupFile(t)
 			regCfg := tt.registryConfig(filePath)
 
-			handler := NewFileRegistryHandler()
+			handler := NewFileRegistryHandler(nil)
 			result, err := handler.FetchRegistry(context.Background(), regCfg)
 
 			if tt.expectError {
@@ -309,7 +309,7 @@ func TestFileRegistryHandler_CurrentHash(t *testing.T) {
 		},
 	}
 
-	handler := NewFileRegistryHandler()
+	handler := NewFileRegistryHandler(nil)
 	hash, err := handler.CurrentHash(context.Background(), regCfg)
 
 	require.NoError(t, err)
@@ -332,7 +332,7 @@ func TestFileRegistryHandler_CurrentHash_FileNotFound(t *testing.T) {
 		},
 	}
 
-	handler := NewFileRegistryHandler()
+	handler := NewFileRegistryHandler(nil)
 	hash, err := handler.CurrentHash(context.Background(), regCfg)
 
 	require.Error(t, err)
@@ -351,7 +351,7 @@ func TestFileRegistryHandler_CurrentHash_ValidationFailure(t *testing.T) {
 		},
 	}
 
-	handler := NewFileRegistryHandler()
+	handler := NewFileRegistryHandler(nil)
 	hash, err := handler.CurrentHash(context.Background(), regCfg)
 
 	require.Error(t, err)
@@ -416,7 +416,7 @@ func TestFileRegistryHandler_Validate_URL(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			handler := NewFileRegistryHandler()
+			handler := NewFileRegistryHandler(nil)
 			err := handler.Validate(tt.registryConfig)
 
 			if tt.expectError {
@@ -516,7 +516,7 @@ func TestFileRegistryHandler_FetchRegistry_URL(t *testing.T) {
 
 			// Create handler with custom HTTP client
 			client := httpclient.NewDefaultClient(DefaultURLTimeout)
-			handler := NewFileRegistryHandlerWithClient(client)
+			handler := NewFileRegistryHandlerWithClient(client, nil)
 
 			regCfg := &config.RegistryConfig{
 				Name:   "test-url",
@@ -556,7 +556,7 @@ func TestFileRegistryHandler_CurrentHash_URL(t *testing.T) {
 
 	// Create handler with custom HTTP client
 	client := httpclient.NewDefaultClient(DefaultURLTimeout)
-	handler := NewFileRegistryHandlerWithClient(client)
+	handler := NewFileRegistryHandlerWithClient(client, nil)
 
 	regCfg := &config.RegistryConfig{
 		Name:   "test-url",
@@ -589,7 +589,7 @@ func TestFileRegistryHandler_FetchRegistry_URL_WithTimeout(t *testing.T) {
 
 	// Create handler
 	client := httpclient.NewDefaultClient(DefaultURLTimeout)
-	handler := NewFileRegistryHandlerWithClient(client)
+	handler := NewFileRegistryHandlerWithClient(client, nil)
 
 	regCfg := &config.RegistryConfig{
 		Name:   "test-url",
@@ -612,7 +612,7 @@ func TestNewFileRegistryHandlerWithClient(t *testing.T) {
 	t.Parallel()
 
 	client := httpclient.NewDefaultClient(DefaultURLTimeout)
-	handler := NewFileRegistryHandlerWithClient(client)
+	handler := NewFileRegistryHandlerWithClient(client, nil)
 
 	assert.NotNil(t, handler)
 	concreteHandler := handler.(*fileRegistryHandler)

--- a/internal/sources/git.go
+++ b/internal/sources/git.go
@@ -21,13 +21,15 @@ const (
 type gitRegistryHandler struct {
 	gitClient git2.Client
 	validator RegistryDataValidator
+	cfg       *config.Config
 }
 
 // NewGitRegistryHandler creates a new Git registry handler
-func NewGitRegistryHandler() RegistryHandler {
+func NewGitRegistryHandler(cfg *config.Config) RegistryHandler {
 	return &gitRegistryHandler{
 		gitClient: git2.NewDefaultGitClient(),
 		validator: NewRegistryDataValidator(),
+		cfg:       cfg,
 	}
 }
 

--- a/internal/sources/git_test.go
+++ b/internal/sources/git_test.go
@@ -78,7 +78,7 @@ func (m *MockRegistryDataValidator) ValidateData(data []byte, format string) (*t
 func TestNewGitRegistryHandler(t *testing.T) {
 	t.Parallel()
 
-	handler := NewGitRegistryHandler()
+	handler := NewGitRegistryHandler(nil)
 
 	assert.NotNil(t, handler)
 	// Cast to concrete type to access fields in tests (same package)
@@ -90,7 +90,7 @@ func TestNewGitRegistryHandler(t *testing.T) {
 func TestGitRegistryHandler_Validate(t *testing.T) {
 	t.Parallel()
 
-	handler := NewGitRegistryHandler()
+	handler := NewGitRegistryHandler(nil)
 
 	tests := []struct {
 		name           string
@@ -588,7 +588,7 @@ func TestGitRegistryHandler_DefaultPath(t *testing.T) {
 		},
 	}
 
-	handler := NewGitRegistryHandler()
+	handler := NewGitRegistryHandler(nil)
 	err := handler.Validate(registryConfig)
 
 	require.NoError(t, err)

--- a/internal/sync/detectors_test.go
+++ b/internal/sync/detectors_test.go
@@ -100,7 +100,7 @@ func TestDefaultDataChangeDetector_IsDataChanged(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			registryHandlerFactory := sources.NewRegistryHandlerFactory()
+			registryHandlerFactory := sources.NewRegistryHandlerFactory(nil)
 			detector := &defaultDataChangeDetector{
 				registryHandlerFactory: registryHandlerFactory,
 			}

--- a/internal/sync/manager_test.go
+++ b/internal/sync/manager_test.go
@@ -23,7 +23,7 @@ import (
 func TestNewDefaultSyncManager(t *testing.T) {
 	t.Parallel()
 
-	registryHandlerFactory := sources.NewRegistryHandlerFactory()
+	registryHandlerFactory := sources.NewRegistryHandlerFactory(nil)
 	storageManager := sources.NewFileStorageManager("/tmp/test-storage")
 
 	syncManager := NewDefaultSyncManager(registryHandlerFactory, storageManager)
@@ -121,7 +121,7 @@ func TestDefaultSyncManager_ShouldSync(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			registryHandlerFactory := sources.NewRegistryHandlerFactory()
+			registryHandlerFactory := sources.NewRegistryHandlerFactory(nil)
 			storageManager := sources.NewFileStorageManager("/tmp/test-storage")
 			syncManager := NewDefaultSyncManager(registryHandlerFactory, storageManager)
 
@@ -265,7 +265,7 @@ func TestDefaultSyncManager_PerformSync(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 
-			registryHandlerFactory := sources.NewRegistryHandlerFactory()
+			registryHandlerFactory := sources.NewRegistryHandlerFactory(nil)
 			mockStorageManager := mocks.NewMockStorageManager(ctrl)
 
 			// Setup expectations for successful syncs


### PR DESCRIPTION
The following PR adds support for passing the registry config throughout the factory handlers. This serves as a foundation for the next PR which would be adding a check to enforce the size limit of the publisher provided `_meta` extensions.

Related to #457 