### PR TITLE
Enable parallel runners for golangci-lint

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -124,7 +124,7 @@ tasks:
         silent: true
       - task: deadcode
     cmds:
-      - golangci-lint run ./...
+      - golangci-lint run --allow-parallel-runners ./...
       - go vet ./...
 
   lint-fix:
@@ -138,7 +138,7 @@ tasks:
         silent: true
       - task: deadcode
     cmds:
-      - golangci-lint run --fix ./...
+      - golangci-lint run --allow-parallel-runners --fix ./...
 
   build:
     desc: Build the registry API binary


### PR DESCRIPTION
## Summary
- Add `--allow-parallel-runners` flag to all `golangci-lint run` invocations in the Taskfile
- This allows multiple golangci-lint instances to run simultaneously by preventing the default file lock acquisition at startup

## Test plan
- [ ] Run `task lint` and verify it works as before
- [ ] Run `task lint-fix` and verify it works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)