### PR TITLE
Derive leader election lease ID from Helm release name

### DIFF
--- a/deploy/charts/toolhive-registry-server/templates/deployment.yaml
+++ b/deploy/charts/toolhive-registry-server/templates/deployment.yaml
@@ -64,6 +64,8 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           env:
+            - name: THV_REGISTRY_LEADER_ELECTION_ID
+              value: "{{ include "toolhive-registry-server.fullname" . }}-leader-election"
             {{- if eq .Values.rbac.scope "namespace" }}
             - name: THV_REGISTRY_WATCH_NAMESPACE
               value: "{{ .Values.rbac.allowedNamespaces | join "," }}"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -114,6 +114,11 @@ type Config struct {
 	// Can be set via THV_REGISTRY_WATCH_NAMESPACE environment variable
 	// Not loaded from YAML file - environment variable only
 	WatchNamespace string
+
+	// LeaderElectionID is the unique identifier for the leader election lease.
+	// Can be set via THV_REGISTRY_LEADER_ELECTION_ID environment variable
+	// Not loaded from YAML file - environment variable only
+	LeaderElectionID string
 }
 
 // RegistryConfig defines a single registry data source configuration
@@ -674,6 +679,10 @@ func LoadConfig(opts ...Option) (*Config, error) {
 	// Set watchNamespace from environment variable (THV_REGISTRY_WATCH_NAMESPACE)
 	// This is not loaded from YAML - environment variable only
 	config.WatchNamespace = v.GetString("watch_namespace")
+
+	// Set leaderElectionID from environment variable (THV_REGISTRY_LEADER_ELECTION_ID)
+	// This is not loaded from YAML - environment variable only
+	config.LeaderElectionID = v.GetString("leader_election_id")
 
 	// Validate the config
 	if err := config.validate(); err != nil {

--- a/internal/kubernetes/builder_test.go
+++ b/internal/kubernetes/builder_test.go
@@ -372,6 +372,54 @@ func TestWithRegistryName(t *testing.T) {
 	}
 }
 
+func TestWithLeaderElectionID(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		id      string
+		initial *mcpServerReconcilerOptions
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "valid leader election ID",
+			id:      "my-release-leader-election",
+			initial: &mcpServerReconcilerOptions{},
+			want:    "my-release-leader-election",
+		},
+		{
+			name:    "empty ID should error",
+			id:      "",
+			initial: &mcpServerReconcilerOptions{},
+			wantErr: true,
+		},
+		{
+			name:    "overwrite existing ID",
+			id:      "new-id",
+			initial: &mcpServerReconcilerOptions{leaderElectionID: "old-id"},
+			want:    "new-id",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			opt := WithLeaderElectionID(tt.id)
+			err := opt(tt.initial)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, tt.initial.leaderElectionID)
+		})
+	}
+}
+
 func TestHasRequiredRegistryAnnotations(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
The following PR fixes the leader election lease conflicts between registry deployments in same namespace.

**Details:**
- Adds a configurable `LeaderElectionID` loaded from the `THV_REGISTRY_LEADER_ELECTION_ID` environment variable falling back to the existing hardcoded value when not set.
- The Helm chart sets this automatically using the release `fullname` template so each deployment gets a unique lease

Fixes: #505 