### PR TITLE
Scope leader election RBAC resources to Helm release name

### DIFF
--- a/deploy/charts/toolhive-registry-server/templates/leader-election-role.yaml
+++ b/deploy/charts/toolhive-registry-server/templates/leader-election-role.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: toolhive-registry-server-leader-election-role
+  name: {{ include "toolhive-registry-server.fullname" . }}-leader-election-role
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "toolhive-registry-server.labels" . | nindent 4 }}
@@ -42,14 +42,14 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: toolhive-registry-server-leader-election-rolebinding
+  name: {{ include "toolhive-registry-server.fullname" . }}-leader-election-rolebinding
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "toolhive-registry-server.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: toolhive-registry-server-leader-election-role
+  name: {{ include "toolhive-registry-server.fullname" . }}-leader-election-role
 subjects:
 - kind: ServiceAccount
   name: {{ .Values.serviceAccount.name }}


### PR DESCRIPTION
The following PR fixes an issue where the leader election Role and RoleBinding use hardcoded names causing collisions when multiple releases are deployed in the same namespace.

The solution is to use the `fullname` template for Role and RoleBinding names matching the pattern already used by Deployment, ConfigMap and Service resources.

Related to #508 