### PR TITLE
adds releaseo renovate rule

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -47,6 +47,15 @@
       "depNameTemplate": "golang",
       "datasourceTemplate": "golang-version",
       "versioningTemplate": "loose"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": ["^\\.github/workflows/create-release-pr\\.yml$"],
+      "matchStrings": [
+        "releaseo_version:\\s*(?<currentValue>v[\\d.]+)"
+      ],
+      "depNameTemplate": "stacklok/releaseo",
+      "datasourceTemplate": "github-tags"
     }
   ]
 }


### PR DESCRIPTION
renovate forgets to bump the releaseo version that is passed as an arg. this pr adds the renovate config to ensure that it bumps the action tag as well as the version passed through.