### PR TITLE
Fix metadata serialization

### DIFF
--- a/internal/service/db/impl.go
+++ b/internal/service/db/impl.go
@@ -972,11 +972,14 @@ func (s *dbService) sharedListServersWithCursor(
 
 	result := make([]*upstreamv0.ServerJSON, 0, len(servers))
 	for _, dbServer := range servers {
-		server := helperToServer(
+		server, err := helperToServer(
 			dbServer,
 			packagesMap[dbServer.ID],
 			remotesMap[dbServer.ID],
 		)
+		if err != nil {
+			return nil, nil, err
+		}
 		result = append(result, &server)
 	}
 

--- a/internal/service/db/types_test.go
+++ b/internal/service/db/types_test.go
@@ -3,10 +3,162 @@ package database
 import (
 	"testing"
 
+	"github.com/aws/smithy-go/ptr"
+	"github.com/google/uuid"
 	upstreamv0 "github.com/modelcontextprotocol/registry/pkg/api/v0"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/stacklok/toolhive-registry-server/internal/db/sqlc"
 )
+
+func TestHelperToServer(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		dbServer    helper
+		packages    []sqlc.ListServerPackagesRow
+		remotes     []sqlc.McpServerRemote
+		wantName    string
+		wantVersion string
+		wantDesc    string
+		wantRepo    bool
+		wantMetaVal map[string]any
+		wantErr     bool
+	}{
+		{
+			name: "minimal server with no optional fields",
+			dbServer: helper{
+				ID:      uuid.New(),
+				Name:    "test-server",
+				Version: "1.0.0",
+			},
+			wantName:    "test-server",
+			wantVersion: "1.0.0",
+		},
+		{
+			name: "server with all optional fields",
+			dbServer: helper{
+				ID:          uuid.New(),
+				Name:        "full-server",
+				Version:     "2.0.0",
+				Description: ptr.String("A full server"),
+				Title:       ptr.String("Full Server"),
+				Website:     ptr.String("https://example.com"),
+			},
+			wantName:    "full-server",
+			wantVersion: "2.0.0",
+			wantDesc:    "A full server",
+		},
+		{
+			name: "server with repository",
+			dbServer: helper{
+				ID:                  uuid.New(),
+				Name:                "repo-server",
+				Version:             "1.0.0",
+				RepositoryUrl:       ptr.String("https://github.com/example/repo"),
+				RepositoryType:      ptr.String("github"),
+				RepositoryID:        ptr.String("example/repo"),
+				RepositorySubfolder: ptr.String("src"),
+			},
+			wantName:    "repo-server",
+			wantVersion: "1.0.0",
+			wantRepo:    true,
+		},
+		{
+			name: "server with valid meta JSON",
+			dbServer: helper{
+				ID:         uuid.New(),
+				Name:       "meta-server",
+				Version:    "1.0.0",
+				ServerMeta: []byte(`{"category":"tools"}`),
+			},
+			wantName:    "meta-server",
+			wantVersion: "1.0.0",
+			wantMetaVal: map[string]any{"category": "tools"},
+		},
+		{
+			name: "server with invalid meta JSON returns error",
+			dbServer: helper{
+				ID:         uuid.New(),
+				Name:       "bad-meta",
+				Version:    "1.0.0",
+				ServerMeta: []byte(`{invalid json`),
+			},
+			wantErr: true,
+		},
+		{
+			name: "server with packages and remotes",
+			dbServer: helper{
+				ID:      uuid.New(),
+				Name:    "pkg-server",
+				Version: "1.0.0",
+			},
+			packages: []sqlc.ListServerPackagesRow{
+				{
+					EntryID:        uuid.New(),
+					RegistryType:   "npm",
+					PkgRegistryUrl: "https://registry.npmjs.org",
+					PkgIdentifier:  "@example/mcp",
+					PkgVersion:     "1.0.0",
+					Transport:      "stdio",
+				},
+			},
+			remotes: []sqlc.McpServerRemote{
+				{
+					EntryID:      uuid.New(),
+					Transport:    "sse",
+					TransportUrl: "https://example.com/sse",
+				},
+			},
+			wantName:    "pkg-server",
+			wantVersion: "1.0.0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := helperToServer(tt.dbServer, tt.packages, tt.remotes)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.wantName, got.Name)
+			assert.Equal(t, tt.wantVersion, got.Version)
+			assert.Equal(t, "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json", got.Schema)
+			assert.NotNil(t, got.Meta)
+
+			if tt.wantDesc != "" {
+				assert.Equal(t, tt.wantDesc, got.Description)
+			}
+
+			if tt.wantRepo {
+				require.NotNil(t, got.Repository)
+				assert.Equal(t, ptr.ToString(tt.dbServer.RepositoryUrl), got.Repository.URL)
+				assert.Equal(t, ptr.ToString(tt.dbServer.RepositoryType), got.Repository.Source)
+			} else {
+				assert.Nil(t, got.Repository)
+			}
+
+			if tt.wantMetaVal != nil {
+				assert.Equal(t, tt.wantMetaVal, got.Meta.PublisherProvided)
+			}
+
+			if tt.packages != nil {
+				assert.Len(t, got.Packages, len(tt.packages))
+			}
+			if tt.remotes != nil {
+				assert.Len(t, got.Remotes, len(tt.remotes))
+			}
+		})
+	}
+}
 
 func TestSerializePublisherProvidedMeta(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
This change puts the content of the column `server_meta` under the right field in the API struct. This also adds code to deserialize `server_meta` from base64 to `map[string]any`.

Fixes #516