### PR TITLE
Fix `mcp_server_package` primary key

### DIFF
--- a/database/migrations/000011_add_registry_type_to_package_pk.down.sql
+++ b/database/migrations/000011_add_registry_type_to_package_pk.down.sql
@@ -1,0 +1,7 @@
+-- Revert: remove registry_type from the mcp_server_package primary key.
+
+-- Drop the existing primary key constraint.
+ALTER TABLE mcp_server_package DROP CONSTRAINT mcp_server_package_pkey;
+
+-- Restore the previous primary key without registry_type.
+ALTER TABLE mcp_server_package ADD PRIMARY KEY (entry_id, pkg_identifier, transport);

--- a/database/migrations/000011_add_registry_type_to_package_pk.up.sql
+++ b/database/migrations/000011_add_registry_type_to_package_pk.up.sql
@@ -1,0 +1,15 @@
+-- Add registry_type back to the mcp_server_package primary key.
+-- The previous PK (entry_id, pkg_identifier, transport) allowed only one
+-- registry_type per (entry_id, pkg_identifier, transport) triple.  In
+-- practice the same package identifier can legitimately appear in different
+-- registries (e.g. npm vs pypi), causing duplicate-key failures during
+-- sync.  Re-introducing registry_type into the PK fixes this.
+--
+-- The new PK is strictly more granular than the old one, so existing data
+-- that satisfied the old constraint will always satisfy the new one.
+
+-- Step 1: Drop the existing primary key constraint.
+ALTER TABLE mcp_server_package DROP CONSTRAINT mcp_server_package_pkey;
+
+-- Step 2: Add the new composite primary key with registry_type.
+ALTER TABLE mcp_server_package ADD PRIMARY KEY (entry_id, registry_type, pkg_identifier, transport);

--- a/database/queries/temp_tables.sql
+++ b/database/queries/temp_tables.sql
@@ -78,9 +78,8 @@ SELECT
     runtime_hint, runtime_arguments, package_arguments, env_vars, sha256_hash,
     transport, transport_url, transport_headers
 FROM temp_mcp_server_package
-ON CONFLICT (entry_id, pkg_identifier, transport)
+ON CONFLICT (entry_id, registry_type, pkg_identifier, transport)
 DO UPDATE SET
-    registry_type = EXCLUDED.registry_type,
     pkg_registry_url = EXCLUDED.pkg_registry_url,
     pkg_version = EXCLUDED.pkg_version,
     runtime_hint = EXCLUDED.runtime_hint,

--- a/internal/db/sqlc/temp_tables.sql.go
+++ b/internal/db/sqlc/temp_tables.sql.go
@@ -141,9 +141,8 @@ SELECT
     runtime_hint, runtime_arguments, package_arguments, env_vars, sha256_hash,
     transport, transport_url, transport_headers
 FROM temp_mcp_server_package
-ON CONFLICT (entry_id, pkg_identifier, transport)
+ON CONFLICT (entry_id, registry_type, pkg_identifier, transport)
 DO UPDATE SET
-    registry_type = EXCLUDED.registry_type,
     pkg_registry_url = EXCLUDED.pkg_registry_url,
     pkg_version = EXCLUDED.pkg_version,
     runtime_hint = EXCLUDED.runtime_hint,

--- a/internal/sync/writer/db_test.go
+++ b/internal/sync/writer/db_test.go
@@ -2184,6 +2184,20 @@ func TestDbSyncWriter_Store_ServerWithMultiplePackages(t *testing.T) {
 			Version:         "",
 			Transport:       model.Transport{Type: "stdio"},
 		},
+		{
+			RegistryType:    "pypi",
+			RegistryBaseURL: "fubar",
+			Identifier:      "test-package",
+			Version:         "2.0.0",
+			Transport:       model.Transport{Type: "stdio"},
+		},
+		{
+			RegistryType:    "npm",
+			RegistryBaseURL: "fubar",
+			Identifier:      "test-package",
+			Version:         "2.0.0",
+			Transport:       model.Transport{Type: "stdio"},
+		},
 	}
 
 	registry := createTestUpstreamRegistry([]upstreamv0.ServerJSON{server})
@@ -2199,7 +2213,7 @@ func TestDbSyncWriter_Store_ServerWithMultiplePackages(t *testing.T) {
 
 	packages, err := queries.ListServerPackages(ctx, []uuid.UUID{servers[0].ID})
 	require.NoError(t, err)
-	require.Len(t, packages, 3, "Server should have 3 packages")
+	require.Len(t, packages, 5, "Server should have 5 packages")
 
 	// Verify each package
 	pkgIdentifiers := make(map[string]bool)


### PR DESCRIPTION
The old primary key wasn't allowing insertions of packages having the same identifier and version but different registry type. The fix simply adds `registry_type` to the primary key and extends a test, pinning the expected behavior.

Fixes #520