### PR TITLE
Refactor service interface

### DIFF
--- a/internal/api/registry/v01/routes.go
+++ b/internal/api/registry/v01/routes.go
@@ -96,12 +96,12 @@ func (routes *Routes) handleListServers(w http.ResponseWriter, r *http.Request, 
 	// Parse version (optional string)
 	version := query.Get("version")
 
-	opts := []service.Option[service.ListServersOptions]{}
+	opts := []service.Option{}
 	if cursor != "" {
 		opts = append(opts, service.WithCursor(cursor))
 	}
 	if limit != nil {
-		opts = append(opts, service.WithLimit[service.ListServersOptions](*limit))
+		opts = append(opts, service.WithLimit(*limit))
 	}
 	if search != "" {
 		opts = append(opts, service.WithSearch(search))
@@ -110,10 +110,10 @@ func (routes *Routes) handleListServers(w http.ResponseWriter, r *http.Request, 
 		opts = append(opts, service.WithUpdatedSince(*updatedSince))
 	}
 	if version != "" {
-		opts = append(opts, service.WithVersion[service.ListServersOptions](version))
+		opts = append(opts, service.WithVersion(version))
 	}
 	if registryName != "" {
-		opts = append(opts, service.WithRegistryName[service.ListServersOptions](registryName))
+		opts = append(opts, service.WithRegistryName(registryName))
 	}
 
 	listResult, err := routes.service.ListServers(r.Context(), opts...)
@@ -204,16 +204,16 @@ func (routes *Routes) handleListVersions(w http.ResponseWriter, r *http.Request,
 		return
 	}
 
-	opts := []service.Option[service.ListServerVersionsOptions]{
+	opts := []service.Option{
 		// Note: Upstream API does not support pagination for versions,
 		// so we return an arbitrary large number of records.
-		service.WithLimit[service.ListServerVersionsOptions](1000),
+		service.WithLimit(1000),
 	}
 	if registryName != "" {
-		opts = append(opts, service.WithRegistryName[service.ListServerVersionsOptions](registryName))
+		opts = append(opts, service.WithRegistryName(registryName))
 	}
 	if serverName != "" {
-		opts = append(opts, service.WithName[service.ListServerVersionsOptions](serverName))
+		opts = append(opts, service.WithName(serverName))
 	}
 
 	versions, err := routes.service.ListServerVersions(r.Context(), opts...)
@@ -303,15 +303,15 @@ func (routes *Routes) handleGetVersion(w http.ResponseWriter, r *http.Request, r
 		return
 	}
 
-	opts := []service.Option[service.GetServerVersionOptions]{}
+	opts := []service.Option{}
 	if registryName != "" {
-		opts = append(opts, service.WithRegistryName[service.GetServerVersionOptions](registryName))
+		opts = append(opts, service.WithRegistryName(registryName))
 	}
 	if serverName != "" {
-		opts = append(opts, service.WithName[service.GetServerVersionOptions](serverName))
+		opts = append(opts, service.WithName(serverName))
 	}
 	if version != "" {
-		opts = append(opts, service.WithVersion[service.GetServerVersionOptions](version))
+		opts = append(opts, service.WithVersion(version))
 	}
 
 	server, err := routes.service.GetServerVersion(r.Context(), opts...)
@@ -423,9 +423,9 @@ func (routes *Routes) deleteVersionWithRegistryName(w http.ResponseWriter, r *ht
 	// Call service layer
 	err = routes.service.DeleteServerVersion(
 		r.Context(),
-		service.WithRegistryName[service.DeleteServerVersionOptions](registryName),
-		service.WithName[service.DeleteServerVersionOptions](serverName),
-		service.WithVersion[service.DeleteServerVersionOptions](version),
+		service.WithRegistryName(registryName),
+		service.WithName(serverName),
+		service.WithVersion(version),
 	)
 
 	if err != nil {
@@ -493,7 +493,7 @@ func (routes *Routes) publishWithRegistryName(w http.ResponseWriter, r *http.Req
 	// Call service layer
 	result, err := routes.service.PublishServerVersion(
 		r.Context(),
-		service.WithRegistryName[service.PublishServerVersionOptions](registryName),
+		service.WithRegistryName(registryName),
 		service.WithServerData(&serverData),
 	)
 

--- a/internal/service/db/impl.go
+++ b/internal/service/db/impl.go
@@ -138,7 +138,7 @@ func (*dbService) GetRegistry(
 //nolint:gocyclo
 func (s *dbService) ListServers(
 	ctx context.Context,
-	opts ...service.Option[service.ListServersOptions],
+	opts ...service.Option,
 ) (*service.ListServersResult, error) {
 	ctx, span := s.startSpan(ctx, "dbService.ListServers")
 	defer span.End()
@@ -252,7 +252,7 @@ func (s *dbService) ListServers(
 // ListServerVersions implements RegistryService.ListServerVersions
 func (s *dbService) ListServerVersions(
 	ctx context.Context,
-	opts ...service.Option[service.ListServerVersionsOptions],
+	opts ...service.Option,
 ) ([]*upstreamv0.ServerJSON, error) {
 	ctx, span := s.startSpan(ctx, "dbService.ListServerVersions")
 	defer span.End()
@@ -335,7 +335,7 @@ func (s *dbService) ListServerVersions(
 // GetServer returns a specific server by name
 func (s *dbService) GetServerVersion(
 	ctx context.Context,
-	opts ...service.Option[service.GetServerVersionOptions],
+	opts ...service.Option,
 ) (*upstreamv0.ServerJSON, error) {
 	ctx, span := s.startSpan(ctx, "dbService.GetServerVersion")
 	defer span.End()
@@ -626,7 +626,7 @@ func validateManagedRegistry(
 // PublishServerVersion publishes a server version to a managed registry
 func (s *dbService) PublishServerVersion(
 	ctx context.Context,
-	opts ...service.Option[service.PublishServerVersionOptions],
+	opts ...service.Option,
 ) (*upstreamv0.ServerJSON, error) {
 	ctx, span := s.startSpan(ctx, "dbService.PublishServerVersion")
 	defer span.End()
@@ -676,9 +676,9 @@ func (s *dbService) PublishServerVersion(
 
 	// Fetch the inserted server to return it
 	result, err := s.GetServerVersion(ctx,
-		service.WithRegistryName[service.GetServerVersionOptions](options.RegistryName),
-		service.WithName[service.GetServerVersionOptions](serverData.Name),
-		service.WithVersion[service.GetServerVersionOptions](serverData.Version),
+		service.WithRegistryName(options.RegistryName),
+		service.WithName(serverData.Name),
+		service.WithVersion(serverData.Version),
 	)
 	if err != nil {
 		otel.RecordError(span, err)
@@ -775,7 +775,7 @@ func (s *dbService) insertServerData(
 // DeleteServerVersion removes a server version from a managed registry
 func (s *dbService) DeleteServerVersion(
 	ctx context.Context,
-	opts ...service.Option[service.DeleteServerVersionOptions],
+	opts ...service.Option,
 ) error {
 	ctx, span := s.startSpan(ctx, "dbService.DeleteServerVersion")
 	defer span.End()

--- a/internal/service/db/impl_test.go
+++ b/internal/service/db/impl_test.go
@@ -154,7 +154,7 @@ func TestListServers(t *testing.T) {
 	tests := []struct {
 		name          string
 		setupFunc     func(*testing.T, *pgxpool.Pool)
-		options       []service.Option[service.ListServersOptions]
+		options       []service.Option
 		expectedCount int
 		validateFunc  func(*testing.T, *service.ListServersResult)
 	}{
@@ -164,8 +164,8 @@ func TestListServers(t *testing.T) {
 			setupFunc: func(t *testing.T, pool *pgxpool.Pool) {
 				setupTestData(t, pool)
 			},
-			options: []service.Option[service.ListServersOptions]{
-				service.WithLimit[service.ListServersOptions](10),
+			options: []service.Option{
+				service.WithLimit(10),
 			},
 			//nolint:thelper // We want to see these lines in the test output
 			validateFunc: func(t *testing.T, result *service.ListServersResult) {
@@ -183,8 +183,8 @@ func TestListServers(t *testing.T) {
 			setupFunc: func(t *testing.T, pool *pgxpool.Pool) {
 				setupTestData(t, pool)
 			},
-			options: []service.Option[service.ListServersOptions]{
-				service.WithLimit[service.ListServersOptions](2),
+			options: []service.Option{
+				service.WithLimit(2),
 			},
 			//nolint:thelper // We want to see these lines in the test output
 			validateFunc: func(t *testing.T, result *service.ListServersResult) {
@@ -197,9 +197,9 @@ func TestListServers(t *testing.T) {
 			setupFunc: func(t *testing.T, pool *pgxpool.Pool) {
 				setupTestData(t, pool)
 			},
-			options: []service.Option[service.ListServersOptions]{
+			options: []service.Option{
 				service.WithCursor("invalid-base64"),
-				service.WithLimit[service.ListServersOptions](10),
+				service.WithLimit(10),
 			},
 		},
 		{
@@ -208,10 +208,10 @@ func TestListServers(t *testing.T) {
 			setupFunc: func(t *testing.T, pool *pgxpool.Pool) {
 				setupTestData(t, pool)
 			},
-			options: []service.Option[service.ListServersOptions]{
+			options: []service.Option{
 				// "YWJj" is base64("abc"), which has no comma separator
 				service.WithCursor("YWJj"),
-				service.WithLimit[service.ListServersOptions](10),
+				service.WithLimit(10),
 			},
 		},
 		{
@@ -220,8 +220,8 @@ func TestListServers(t *testing.T) {
 			setupFunc: func(_ *testing.T, _ *pgxpool.Pool) {
 				// Don't set up any data
 			},
-			options: []service.Option[service.ListServersOptions]{
-				service.WithLimit[service.ListServersOptions](10),
+			options: []service.Option{
+				service.WithLimit(10),
 			},
 			//nolint:thelper // We want to see these lines in the test output
 			validateFunc: func(t *testing.T, result *service.ListServersResult) {
@@ -234,9 +234,9 @@ func TestListServers(t *testing.T) {
 			setupFunc: func(t *testing.T, pool *pgxpool.Pool) {
 				setupTestData(t, pool)
 			},
-			options: []service.Option[service.ListServersOptions]{
-				service.WithRegistryName[service.ListServersOptions]("test-registry"),
-				service.WithLimit[service.ListServersOptions](10),
+			options: []service.Option{
+				service.WithRegistryName("test-registry"),
+				service.WithLimit(10),
 			},
 			//nolint:thelper // We want to see these lines in the test output
 			validateFunc: func(t *testing.T, result *service.ListServersResult) {
@@ -254,9 +254,9 @@ func TestListServers(t *testing.T) {
 			setupFunc: func(t *testing.T, pool *pgxpool.Pool) {
 				setupTestData(t, pool)
 			},
-			options: []service.Option[service.ListServersOptions]{
-				service.WithRegistryName[service.ListServersOptions]("non-existent-registry"),
-				service.WithLimit[service.ListServersOptions](10),
+			options: []service.Option{
+				service.WithRegistryName("non-existent-registry"),
+				service.WithLimit(10),
 			},
 		},
 		{
@@ -265,9 +265,9 @@ func TestListServers(t *testing.T) {
 			setupFunc: func(t *testing.T, pool *pgxpool.Pool) {
 				setupTestData(t, pool)
 			},
-			options: []service.Option[service.ListServersOptions]{
+			options: []service.Option{
 				service.WithSearch("server-1"),
-				service.WithLimit[service.ListServersOptions](10),
+				service.WithLimit(10),
 			},
 			//nolint:thelper // We want to see these lines in the test output
 			validateFunc: func(t *testing.T, result *service.ListServersResult) {
@@ -283,9 +283,9 @@ func TestListServers(t *testing.T) {
 			setupFunc: func(t *testing.T, pool *pgxpool.Pool) {
 				setupTestData(t, pool)
 			},
-			options: []service.Option[service.ListServersOptions]{
+			options: []service.Option{
 				service.WithSearch("Test Server 2"),
-				service.WithLimit[service.ListServersOptions](10),
+				service.WithLimit(10),
 			},
 			//nolint:thelper // We want to see these lines in the test output
 			validateFunc: func(t *testing.T, result *service.ListServersResult) {
@@ -299,9 +299,9 @@ func TestListServers(t *testing.T) {
 			setupFunc: func(t *testing.T, pool *pgxpool.Pool) {
 				setupTestData(t, pool)
 			},
-			options: []service.Option[service.ListServersOptions]{
+			options: []service.Option{
 				service.WithSearch("server 2 description"),
-				service.WithLimit[service.ListServersOptions](10),
+				service.WithLimit(10),
 			},
 			//nolint:thelper // We want to see these lines in the test output
 			validateFunc: func(t *testing.T, result *service.ListServersResult) {
@@ -315,9 +315,9 @@ func TestListServers(t *testing.T) {
 			setupFunc: func(t *testing.T, pool *pgxpool.Pool) {
 				setupTestData(t, pool)
 			},
-			options: []service.Option[service.ListServersOptions]{
+			options: []service.Option{
 				service.WithSearch("SERVER-1"), // Uppercase
-				service.WithLimit[service.ListServersOptions](10),
+				service.WithLimit(10),
 			},
 			//nolint:thelper // We want to see these lines in the test output
 			validateFunc: func(t *testing.T, result *service.ListServersResult) {
@@ -333,9 +333,9 @@ func TestListServers(t *testing.T) {
 			setupFunc: func(t *testing.T, pool *pgxpool.Pool) {
 				setupTestData(t, pool)
 			},
-			options: []service.Option[service.ListServersOptions]{
+			options: []service.Option{
 				service.WithSearch("server"), // Partial match
-				service.WithLimit[service.ListServersOptions](10),
+				service.WithLimit(10),
 			},
 			//nolint:thelper // We want to see these lines in the test output
 			validateFunc: func(t *testing.T, result *service.ListServersResult) {
@@ -348,9 +348,9 @@ func TestListServers(t *testing.T) {
 			setupFunc: func(t *testing.T, pool *pgxpool.Pool) {
 				setupTestData(t, pool)
 			},
-			options: []service.Option[service.ListServersOptions]{
+			options: []service.Option{
 				service.WithSearch("nonexistent"),
-				service.WithLimit[service.ListServersOptions](10),
+				service.WithLimit(10),
 			},
 			//nolint:thelper // We want to see these lines in the test output
 			validateFunc: func(t *testing.T, result *service.ListServersResult) {
@@ -363,10 +363,10 @@ func TestListServers(t *testing.T) {
 			setupFunc: func(t *testing.T, pool *pgxpool.Pool) {
 				setupTestData(t, pool)
 			},
-			options: []service.Option[service.ListServersOptions]{
+			options: []service.Option{
 				service.WithSearch("server-1"),
-				service.WithRegistryName[service.ListServersOptions]("test-registry"),
-				service.WithLimit[service.ListServersOptions](10),
+				service.WithRegistryName("test-registry"),
+				service.WithLimit(10),
 			},
 			//nolint:thelper // We want to see these lines in the test output
 			validateFunc: func(t *testing.T, result *service.ListServersResult) {
@@ -382,9 +382,9 @@ func TestListServers(t *testing.T) {
 			setupFunc: func(t *testing.T, pool *pgxpool.Pool) {
 				setupTestData(t, pool)
 			},
-			options: []service.Option[service.ListServersOptions]{
-				service.WithVersion[service.ListServersOptions]("latest"),
-				service.WithLimit[service.ListServersOptions](10),
+			options: []service.Option{
+				service.WithVersion("latest"),
+				service.WithLimit(10),
 			},
 			//nolint:thelper // We want to see these lines in the test output
 			validateFunc: func(t *testing.T, result *service.ListServersResult) {
@@ -425,7 +425,7 @@ func TestListServerVersions(t *testing.T) {
 	tests := []struct {
 		name         string
 		setupFunc    func(*testing.T, *pgxpool.Pool)
-		options      []service.Option[service.ListServerVersionsOptions]
+		options      []service.Option
 		validateFunc func(*testing.T, []*upstreamv0.ServerJSON)
 	}{
 		{
@@ -434,9 +434,9 @@ func TestListServerVersions(t *testing.T) {
 			setupFunc: func(t *testing.T, pool *pgxpool.Pool) {
 				setupTestData(t, pool)
 			},
-			options: []service.Option[service.ListServerVersionsOptions]{
-				service.WithName[service.ListServerVersionsOptions]("com.example/test-server-1"),
-				service.WithLimit[service.ListServerVersionsOptions](10),
+			options: []service.Option{
+				service.WithName("com.example/test-server-1"),
+				service.WithLimit(10),
 			},
 			//nolint:thelper // We want to see these lines in the test output
 			validateFunc: func(t *testing.T, servers []*upstreamv0.ServerJSON) {
@@ -461,9 +461,9 @@ func TestListServerVersions(t *testing.T) {
 			setupFunc: func(t *testing.T, pool *pgxpool.Pool) {
 				setupTestData(t, pool)
 			},
-			options: []service.Option[service.ListServerVersionsOptions]{
-				service.WithName[service.ListServerVersionsOptions]("com.example/test-server-1"),
-				service.WithLimit[service.ListServerVersionsOptions](2),
+			options: []service.Option{
+				service.WithName("com.example/test-server-1"),
+				service.WithLimit(2),
 			},
 			//nolint:thelper // We want to see these lines in the test output
 			validateFunc: func(t *testing.T, servers []*upstreamv0.ServerJSON) {
@@ -476,9 +476,9 @@ func TestListServerVersions(t *testing.T) {
 			setupFunc: func(t *testing.T, pool *pgxpool.Pool) {
 				setupTestData(t, pool)
 			},
-			options: []service.Option[service.ListServerVersionsOptions]{
-				service.WithName[service.ListServerVersionsOptions]("com.example/non-existent-server"),
-				service.WithLimit[service.ListServerVersionsOptions](10),
+			options: []service.Option{
+				service.WithName("com.example/non-existent-server"),
+				service.WithLimit(10),
 			},
 			//nolint:thelper // We want to see these lines in the test output
 			validateFunc: func(t *testing.T, servers []*upstreamv0.ServerJSON) {
@@ -491,9 +491,10 @@ func TestListServerVersions(t *testing.T) {
 			setupFunc: func(t *testing.T, pool *pgxpool.Pool) {
 				setupTestData(t, pool)
 			},
-			options: []service.Option[service.ListServerVersionsOptions]{
-				service.WithName[service.ListServerVersionsOptions]("com.example/test-server-1"),
-				func(opts *service.ListServerVersionsOptions) error {
+			options: []service.Option{
+				service.WithName("com.example/test-server-1"),
+				func(o any) error {
+					opts := o.(*service.ListServerVersionsOptions)
 					// Set nextTime to 30 minutes from now, so only versions created at +1h and +2h are returned
 					nextTime := time.Now().Add(30 * time.Minute).UTC()
 					opts.Next = &nextTime
@@ -512,9 +513,10 @@ func TestListServerVersions(t *testing.T) {
 			setupFunc: func(t *testing.T, pool *pgxpool.Pool) {
 				setupTestData(t, pool)
 			},
-			options: []service.Option[service.ListServerVersionsOptions]{
-				service.WithName[service.ListServerVersionsOptions]("com.example/test-server-1"),
-				func(opts *service.ListServerVersionsOptions) error {
+			options: []service.Option{
+				service.WithName("com.example/test-server-1"),
+				func(o any) error {
+					opts := o.(*service.ListServerVersionsOptions)
 					prevTime := time.Now().Add(1 * time.Hour).UTC()
 					opts.Prev = &prevTime
 					opts.Limit = 10
@@ -532,9 +534,9 @@ func TestListServerVersions(t *testing.T) {
 			setupFunc: func(t *testing.T, pool *pgxpool.Pool) {
 				setupTestData(t, pool)
 			},
-			options: []service.Option[service.ListServerVersionsOptions]{
-				service.WithName[service.ListServerVersionsOptions](""), // Empty name should error
-				service.WithLimit[service.ListServerVersionsOptions](10),
+			options: []service.Option{
+				service.WithName(""), // Empty name should error
+				service.WithLimit(10),
 			},
 		},
 		{
@@ -543,10 +545,10 @@ func TestListServerVersions(t *testing.T) {
 			setupFunc: func(t *testing.T, pool *pgxpool.Pool) {
 				setupTestData(t, pool)
 			},
-			options: []service.Option[service.ListServerVersionsOptions]{
-				service.WithName[service.ListServerVersionsOptions]("com.example/test-server-1"),
-				service.WithRegistryName[service.ListServerVersionsOptions]("test-registry"),
-				service.WithLimit[service.ListServerVersionsOptions](10),
+			options: []service.Option{
+				service.WithName("com.example/test-server-1"),
+				service.WithRegistryName("test-registry"),
+				service.WithLimit(10),
 			},
 			//nolint:thelper // We want to see these lines in the test output
 			validateFunc: func(t *testing.T, servers []*upstreamv0.ServerJSON) {
@@ -571,10 +573,10 @@ func TestListServerVersions(t *testing.T) {
 			setupFunc: func(t *testing.T, pool *pgxpool.Pool) {
 				setupTestData(t, pool)
 			},
-			options: []service.Option[service.ListServerVersionsOptions]{
-				service.WithName[service.ListServerVersionsOptions]("com.example/test-server-1"),
-				service.WithRegistryName[service.ListServerVersionsOptions]("non-existent-registry"),
-				service.WithLimit[service.ListServerVersionsOptions](10),
+			options: []service.Option{
+				service.WithName("com.example/test-server-1"),
+				service.WithRegistryName("non-existent-registry"),
+				service.WithLimit(10),
 			},
 		},
 	}
@@ -608,7 +610,7 @@ func TestGetServerVersion(t *testing.T) {
 	tests := []struct {
 		name         string
 		setupFunc    func(*testing.T, *pgxpool.Pool)
-		options      []service.Option[service.GetServerVersionOptions]
+		options      []service.Option
 		validateFunc func(*testing.T, *upstreamv0.ServerJSON)
 	}{
 		{
@@ -617,9 +619,9 @@ func TestGetServerVersion(t *testing.T) {
 			setupFunc: func(t *testing.T, pool *pgxpool.Pool) {
 				setupTestData(t, pool)
 			},
-			options: []service.Option[service.GetServerVersionOptions]{
-				service.WithName[service.GetServerVersionOptions]("com.example/test-server-1"),
-				service.WithVersion[service.GetServerVersionOptions]("1.0.0"),
+			options: []service.Option{
+				service.WithName("com.example/test-server-1"),
+				service.WithVersion("1.0.0"),
 			},
 			//nolint:thelper // We want to see these lines in the test output
 			validateFunc: func(t *testing.T, server *upstreamv0.ServerJSON) {
@@ -638,9 +640,9 @@ func TestGetServerVersion(t *testing.T) {
 			setupFunc: func(t *testing.T, pool *pgxpool.Pool) {
 				setupTestData(t, pool)
 			},
-			options: []service.Option[service.GetServerVersionOptions]{
-				service.WithName[service.GetServerVersionOptions]("com.example/test-server-1"),
-				service.WithVersion[service.GetServerVersionOptions]("2.0.0"),
+			options: []service.Option{
+				service.WithName("com.example/test-server-1"),
+				service.WithVersion("2.0.0"),
 			},
 			//nolint:thelper // We want to see these lines in the test output
 			validateFunc: func(t *testing.T, server *upstreamv0.ServerJSON) {
@@ -655,9 +657,9 @@ func TestGetServerVersion(t *testing.T) {
 			setupFunc: func(t *testing.T, pool *pgxpool.Pool) {
 				setupTestData(t, pool)
 			},
-			options: []service.Option[service.GetServerVersionOptions]{
-				service.WithName[service.GetServerVersionOptions]("com.example/non-existent-server"),
-				service.WithVersion[service.GetServerVersionOptions]("1.0.0"),
+			options: []service.Option{
+				service.WithName("com.example/non-existent-server"),
+				service.WithVersion("1.0.0"),
 			},
 		},
 		{
@@ -666,9 +668,9 @@ func TestGetServerVersion(t *testing.T) {
 			setupFunc: func(t *testing.T, pool *pgxpool.Pool) {
 				setupTestData(t, pool)
 			},
-			options: []service.Option[service.GetServerVersionOptions]{
-				service.WithName[service.GetServerVersionOptions]("com.example/test-server-1"),
-				service.WithVersion[service.GetServerVersionOptions]("999.999.999"),
+			options: []service.Option{
+				service.WithName("com.example/test-server-1"),
+				service.WithVersion("999.999.999"),
 			},
 		},
 		{
@@ -677,9 +679,9 @@ func TestGetServerVersion(t *testing.T) {
 			setupFunc: func(t *testing.T, pool *pgxpool.Pool) {
 				setupTestData(t, pool)
 			},
-			options: []service.Option[service.GetServerVersionOptions]{
-				service.WithName[service.GetServerVersionOptions](""), // Empty name should error
-				service.WithVersion[service.GetServerVersionOptions]("1.0.0"),
+			options: []service.Option{
+				service.WithName(""), // Empty name should error
+				service.WithVersion("1.0.0"),
 			},
 		},
 		{
@@ -688,9 +690,9 @@ func TestGetServerVersion(t *testing.T) {
 			setupFunc: func(t *testing.T, pool *pgxpool.Pool) {
 				setupTestData(t, pool)
 			},
-			options: []service.Option[service.GetServerVersionOptions]{
-				service.WithName[service.GetServerVersionOptions]("com.example/test-server-1"),
-				service.WithVersion[service.GetServerVersionOptions](""), // Empty version should error
+			options: []service.Option{
+				service.WithName("com.example/test-server-1"),
+				service.WithVersion(""), // Empty version should error
 			},
 		},
 		{
@@ -699,9 +701,9 @@ func TestGetServerVersion(t *testing.T) {
 			setupFunc: func(t *testing.T, pool *pgxpool.Pool) {
 				setupTestData(t, pool)
 			},
-			options: []service.Option[service.GetServerVersionOptions]{
-				service.WithName[service.GetServerVersionOptions]("com.example/test-server-2"),
-				service.WithVersion[service.GetServerVersionOptions]("1.0.0"),
+			options: []service.Option{
+				service.WithName("com.example/test-server-2"),
+				service.WithVersion("1.0.0"),
 			},
 			//nolint:thelper // We want to see these lines in the test output
 			validateFunc: func(t *testing.T, server *upstreamv0.ServerJSON) {
@@ -795,9 +797,9 @@ func TestGetServerVersion(t *testing.T) {
 				)
 				require.NoError(t, err)
 			},
-			options: []service.Option[service.GetServerVersionOptions]{
-				service.WithName[service.GetServerVersionOptions]("com.test/server-with-packages"),
-				service.WithVersion[service.GetServerVersionOptions]("1.0.0"),
+			options: []service.Option{
+				service.WithName("com.test/server-with-packages"),
+				service.WithVersion("1.0.0"),
 			},
 			//nolint:thelper // We want to see these lines in the test output
 			validateFunc: func(t *testing.T, server *upstreamv0.ServerJSON) {
@@ -831,10 +833,10 @@ func TestGetServerVersion(t *testing.T) {
 			setupFunc: func(t *testing.T, pool *pgxpool.Pool) {
 				setupTestData(t, pool)
 			},
-			options: []service.Option[service.GetServerVersionOptions]{
-				service.WithName[service.GetServerVersionOptions]("com.example/test-server-1"),
-				service.WithVersion[service.GetServerVersionOptions]("1.0.0"),
-				service.WithRegistryName[service.GetServerVersionOptions]("test-registry"),
+			options: []service.Option{
+				service.WithName("com.example/test-server-1"),
+				service.WithVersion("1.0.0"),
+				service.WithRegistryName("test-registry"),
 			},
 			//nolint:thelper // We want to see these lines in the test output
 			validateFunc: func(t *testing.T, server *upstreamv0.ServerJSON) {
@@ -851,10 +853,10 @@ func TestGetServerVersion(t *testing.T) {
 			setupFunc: func(t *testing.T, pool *pgxpool.Pool) {
 				setupTestData(t, pool)
 			},
-			options: []service.Option[service.GetServerVersionOptions]{
-				service.WithName[service.GetServerVersionOptions]("com.example/test-server-1"),
-				service.WithVersion[service.GetServerVersionOptions]("1.0.0"),
-				service.WithRegistryName[service.GetServerVersionOptions]("non-existent-registry"),
+			options: []service.Option{
+				service.WithName("com.example/test-server-1"),
+				service.WithVersion("1.0.0"),
+				service.WithRegistryName("non-existent-registry"),
 			},
 		},
 	}
@@ -1381,7 +1383,7 @@ func TestPublishServerVersion(t *testing.T) {
 			// Call PublishServerVersion
 			result, err := svc.PublishServerVersion(
 				context.Background(),
-				service.WithRegistryName[service.PublishServerVersionOptions](tt.registryName),
+				service.WithRegistryName(tt.registryName),
 				service.WithServerData(tt.serverData),
 			)
 

--- a/internal/service/mocks/mock_service.go
+++ b/internal/service/mocks/mock_service.go
@@ -87,7 +87,7 @@ func (mr *MockRegistryServiceMockRecorder) DeleteRegistry(ctx, name any) *gomock
 }
 
 // DeleteServerVersion mocks base method.
-func (m *MockRegistryService) DeleteServerVersion(ctx context.Context, opts ...service.Option[service.DeleteServerVersionOptions]) error {
+func (m *MockRegistryService) DeleteServerVersion(ctx context.Context, opts ...service.Option) error {
 	m.ctrl.T.Helper()
 	varargs := []any{ctx}
 	for _, a := range opts {
@@ -137,7 +137,7 @@ func (mr *MockRegistryServiceMockRecorder) GetRegistryByName(ctx, name any) *gom
 }
 
 // GetServerVersion mocks base method.
-func (m *MockRegistryService) GetServerVersion(ctx context.Context, opts ...service.Option[service.GetServerVersionOptions]) (*v0.ServerJSON, error) {
+func (m *MockRegistryService) GetServerVersion(ctx context.Context, opts ...service.Option) (*v0.ServerJSON, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{ctx}
 	for _, a := range opts {
@@ -172,7 +172,7 @@ func (mr *MockRegistryServiceMockRecorder) ListRegistries(ctx any) *gomock.Call 
 }
 
 // ListServerVersions mocks base method.
-func (m *MockRegistryService) ListServerVersions(ctx context.Context, opts ...service.Option[service.ListServerVersionsOptions]) ([]*v0.ServerJSON, error) {
+func (m *MockRegistryService) ListServerVersions(ctx context.Context, opts ...service.Option) ([]*v0.ServerJSON, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{ctx}
 	for _, a := range opts {
@@ -192,7 +192,7 @@ func (mr *MockRegistryServiceMockRecorder) ListServerVersions(ctx any, opts ...a
 }
 
 // ListServers mocks base method.
-func (m *MockRegistryService) ListServers(ctx context.Context, opts ...service.Option[service.ListServersOptions]) (*service.ListServersResult, error) {
+func (m *MockRegistryService) ListServers(ctx context.Context, opts ...service.Option) (*service.ListServersResult, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{ctx}
 	for _, a := range opts {
@@ -226,7 +226,7 @@ func (mr *MockRegistryServiceMockRecorder) ProcessInlineRegistryData(ctx, name, 
 }
 
 // PublishServerVersion mocks base method.
-func (m *MockRegistryService) PublishServerVersion(ctx context.Context, opts ...service.Option[service.PublishServerVersionOptions]) (*v0.ServerJSON, error) {
+func (m *MockRegistryService) PublishServerVersion(ctx context.Context, opts ...service.Option) (*v0.ServerJSON, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{ctx}
 	for _, a := range opts {

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -174,7 +174,7 @@ func TestWithRegistryNameListServers(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			opt := service.WithRegistryName[service.ListServersOptions](tt.registryName)
+			opt := service.WithRegistryName(tt.registryName)
 			opts := &service.ListServersOptions{}
 			err := opt(opts)
 
@@ -216,7 +216,7 @@ func TestWithRegistryNameListServersVersions(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			opt := service.WithRegistryName[service.ListServerVersionsOptions](tt.registryName)
+			opt := service.WithRegistryName(tt.registryName)
 			opts := &service.ListServerVersionsOptions{}
 			err := opt(opts)
 
@@ -258,7 +258,7 @@ func TestWithRegistryNameGetServerVersion(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			opt := service.WithRegistryName[service.GetServerVersionOptions](tt.registryName)
+			opt := service.WithRegistryName(tt.registryName)
 			opts := &service.GetServerVersionOptions{}
 			err := opt(opts)
 
@@ -392,7 +392,7 @@ func TestWithVersionListServers(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			opt := service.WithVersion[service.ListServersOptions](tt.version)
+			opt := service.WithVersion(tt.version)
 			opts := &service.ListServersOptions{}
 			err := opt(opts)
 
@@ -434,7 +434,7 @@ func TestWithVersionGetServerVersion(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			opt := service.WithVersion[service.GetServerVersionOptions](tt.version)
+			opt := service.WithVersion(tt.version)
 			opts := &service.GetServerVersionOptions{}
 			err := opt(opts)
 
@@ -476,7 +476,7 @@ func TestWithNameListServerVersions(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			opt := service.WithName[service.ListServerVersionsOptions](tt.serverName)
+			opt := service.WithName(tt.serverName)
 			opts := &service.ListServerVersionsOptions{}
 			err := opt(opts)
 
@@ -518,7 +518,7 @@ func TestWithNameGetServerVersion(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			opt := service.WithName[service.GetServerVersionOptions](tt.serverName)
+			opt := service.WithName(tt.serverName)
 			opts := &service.GetServerVersionOptions{}
 			err := opt(opts)
 
@@ -565,7 +565,7 @@ func TestWithLimitListServers(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			opt := service.WithLimit[service.ListServersOptions](tt.limit)
+			opt := service.WithLimit(tt.limit)
 			opts := &service.ListServersOptions{}
 			err := opt(opts)
 
@@ -612,7 +612,7 @@ func TestWithLimitListServerVersions(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			opt := service.WithLimit[service.ListServerVersionsOptions](tt.limit)
+			opt := service.WithLimit(tt.limit)
 			opts := &service.ListServerVersionsOptions{}
 			err := opt(opts)
 


### PR DESCRIPTION
The service interface was using generics to allow the same filter to be applied to multiple service methods. Given it provides very little help in maintaining code, I replaced it with a simple cast.

This is a first of a series of PRs to ease the implementation of skills.

References #441