### PR TITLE
Add service layer for skills

### DIFF
--- a/internal/api/registry/v01/routes.go
+++ b/internal/api/registry/v01/routes.go
@@ -460,7 +460,7 @@ func (routes *Routes) deleteVersionWithRegistryName(w http.ResponseWriter, r *ht
 
 	if err != nil {
 		// Check for specific error types
-		if errors.Is(err, service.ErrRegistryNotFound) || errors.Is(err, service.ErrServerNotFound) {
+		if errors.Is(err, service.ErrRegistryNotFound) || errors.Is(err, service.ErrNotFound) {
 			common.WriteErrorResponse(w, err.Error(), http.StatusNotFound)
 			return
 		}

--- a/internal/api/registry/v01/routes_test.go
+++ b/internal/api/registry/v01/routes_test.go
@@ -1008,7 +1008,7 @@ func TestDeleteVersion(t *testing.T) {
 			path: "/foo/v0.1/servers/com.example%2Fnonexistent/versions/1.0.0",
 			setupMocks: func(m *mocks.MockRegistryService) {
 				m.EXPECT().DeleteServerVersion(gomock.Any(), gomock.Any()).
-					Return(service.ErrServerNotFound)
+					Return(service.ErrNotFound)
 			},
 			setupRouter: func(mockSvc *mocks.MockRegistryService) http.Handler {
 				return Router(mockSvc, false)

--- a/internal/service/db/impl.go
+++ b/internal/service/db/impl.go
@@ -364,13 +364,13 @@ func (s *dbService) GetServerVersion(
 		otel.AttrServerName.String(options.Name),
 		otel.AttrServerVersion.String(options.Version),
 	)
-	if options.RegistryName != nil {
-		span.SetAttributes(otel.AttrRegistryName.String(*options.RegistryName))
+	if options.RegistryName != "" {
+		span.SetAttributes(otel.AttrRegistryName.String(options.RegistryName))
 	}
 
-	if options.RegistryName != nil {
+	if options.RegistryName != "" {
 		querier := sqlc.New(s.pool)
-		if err := validateRegistryExists(ctx, querier, *options.RegistryName); err != nil {
+		if err := validateRegistryExists(ctx, querier, options.RegistryName); err != nil {
 			otel.RecordError(span, err)
 			return nil, err
 		}
@@ -380,8 +380,8 @@ func (s *dbService) GetServerVersion(
 		Name:    options.Name,
 		Version: options.Version,
 	}
-	if options.RegistryName != nil {
-		params.RegistryName = options.RegistryName
+	if options.RegistryName != "" {
+		params.RegistryName = &options.RegistryName
 	}
 
 	// Note: this function fetches a single record given name and version.
@@ -880,7 +880,7 @@ func (s *dbService) DeleteServerVersion(
 	// 5.1. Check if the server version was found and deleted
 	if rowsAffected == 0 {
 		err = fmt.Errorf("%w: %s@%s",
-			service.ErrServerNotFound, options.ServerName, options.Version)
+			service.ErrNotFound, options.ServerName, options.Version)
 		otel.RecordError(span, err)
 		return err
 	}

--- a/internal/service/db/impl_skills.go
+++ b/internal/service/db/impl_skills.go
@@ -1,0 +1,415 @@
+// Package database provides the database-backed implementation of the SkillService interface.
+package database
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+
+	"github.com/stacklok/toolhive-registry-server/internal/db/sqlc"
+	"github.com/stacklok/toolhive-registry-server/internal/otel"
+	"github.com/stacklok/toolhive-registry-server/internal/service"
+	"github.com/stacklok/toolhive-registry-server/internal/versions"
+)
+
+// ListSkills returns skills in the registry with cursor-based pagination.
+//
+//nolint:gocyclo
+func (s *dbService) ListSkills(
+	ctx context.Context,
+	opts ...service.Option,
+) (*service.ListSkillsResult, error) {
+	ctx, span := s.startSpan(ctx, "dbService.ListSkills")
+	defer span.End()
+
+	options := &service.ListSkillsOptions{
+		Limit: service.DefaultPageSize,
+	}
+	for _, opt := range opts {
+		if err := opt(options); err != nil {
+			otel.RecordError(span, err)
+			return nil, err
+		}
+	}
+
+	if options.RegistryName == "" {
+		return nil, fmt.Errorf("registry name is required")
+	}
+
+	if options.Limit > service.MaxPageSize {
+		options.Limit = service.MaxPageSize
+	}
+
+	params := sqlc.ListSkillsParams{
+		RegistryName: &options.RegistryName,
+		Namespace:    &options.Namespace,
+		Size:         int64(options.Limit + 1),
+	}
+	if options.Search != nil {
+		params.Search = options.Search
+	}
+	if options.Cursor != nil {
+		cursorName, cursorVersion, err := service.DecodeCursor(*options.Cursor)
+		if err != nil {
+			otel.RecordError(span, err)
+			return nil, fmt.Errorf("invalid cursor: %w", err)
+		}
+		params.CursorName = &cursorName
+		params.CursorVersion = &cursorVersion
+	}
+
+	querier := sqlc.New(s.pool)
+	listRows, err := querier.ListSkills(ctx, params)
+	if err != nil {
+		otel.RecordError(span, err)
+		return nil, err
+	}
+
+	ids := make([]uuid.UUID, 0)
+	for _, row := range listRows {
+		ids = append(ids, row.EntryID)
+	}
+
+	ociPackages, err := querier.ListSkillOciPackages(ctx, ids)
+	if err != nil {
+		otel.RecordError(span, err)
+		return nil, err
+	}
+	gitPackages, err := querier.ListSkillGitPackages(ctx, ids)
+	if err != nil {
+		otel.RecordError(span, err)
+		return nil, err
+	}
+
+	packages := make(map[uuid.UUID][]service.SkillPackage)
+	for _, pkg := range ociPackages {
+		packages[pkg.SkillEntryID] = append(packages[pkg.SkillEntryID], toServiceSkillOciPackage(pkg))
+	}
+	for _, pkg := range gitPackages {
+		packages[pkg.SkillEntryID] = append(packages[pkg.SkillEntryID], toServiceSkillGitPackage(pkg))
+	}
+
+	nextCursor := ""
+	if len(listRows) > options.Limit {
+		last := listRows[options.Limit-1]
+		nextCursor = service.EncodeCursor(last.Name, last.Version)
+		listRows = listRows[:options.Limit]
+	}
+
+	skills := make([]*service.Skill, len(listRows))
+	for i, row := range listRows {
+		skill := service.ListSkillsRowToSkill(row)
+		skill.Packages = packages[row.EntryID]
+		skills[i] = skill
+	}
+
+	return &service.ListSkillsResult{
+		Skills:     skills,
+		NextCursor: nextCursor,
+	}, nil
+}
+
+// GetSkillVersion returns a specific skill version by name and version.
+func (s *dbService) GetSkillVersion(
+	ctx context.Context,
+	opts ...service.Option,
+) (*service.Skill, error) {
+	ctx, span := s.startSpan(ctx, "dbService.GetSkillVersion")
+	defer span.End()
+
+	options := &service.GetSkillVersionOptions{}
+	for _, opt := range opts {
+		if err := opt(options); err != nil {
+			otel.RecordError(span, err)
+			return nil, err
+		}
+	}
+
+	if options.RegistryName == "" {
+		return nil, fmt.Errorf("registry name is required")
+	}
+	if options.Name == "" || options.Version == "" {
+		return nil, fmt.Errorf("name and version are required")
+	}
+
+	params := sqlc.GetSkillVersionParams{
+		Name:         options.Name,
+		Version:      options.Version,
+		RegistryName: &options.RegistryName,
+	}
+
+	querier := sqlc.New(s.pool)
+	row, err := querier.GetSkillVersion(ctx, params)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, fmt.Errorf("%w: %s %s", service.ErrNotFound, options.Name, options.Version)
+		}
+		otel.RecordError(span, err)
+		return nil, err
+	}
+
+	ociPackages, err := querier.ListSkillOciPackages(ctx, []uuid.UUID{row.SkillEntryID})
+	if err != nil {
+		otel.RecordError(span, err)
+		return nil, err
+	}
+	gitPackages, err := querier.ListSkillGitPackages(ctx, []uuid.UUID{row.SkillEntryID})
+	if err != nil {
+		otel.RecordError(span, err)
+		return nil, err
+	}
+	packages := make([]service.SkillPackage, 0)
+	for _, pkg := range ociPackages {
+		packages = append(packages, toServiceSkillOciPackage(pkg))
+	}
+	for _, pkg := range gitPackages {
+		packages = append(packages, toServiceSkillGitPackage(pkg))
+	}
+
+	res := service.GetSkillVersionRowToSkill(row)
+	res.Packages = packages
+	return res, nil
+}
+
+func toServiceSkillOciPackage(pkg sqlc.SkillOciPackage) service.SkillPackage {
+	digest := ""
+	mediaType := ""
+	if pkg.Digest != nil {
+		digest = *pkg.Digest
+	}
+	if pkg.MediaType != nil {
+		mediaType = *pkg.MediaType
+	}
+	return service.SkillPackage{
+		RegistryType: service.SkillPackageTypeOCI,
+		Identifier:   pkg.Identifier,
+		Digest:       digest,
+		MediaType:    mediaType,
+	}
+}
+
+func toServiceSkillGitPackage(pkg sqlc.SkillGitPackage) service.SkillPackage {
+	return service.SkillPackage{
+		RegistryType: service.SkillPackageTypeGit,
+		URL:          pkg.Url,
+		Ref:          *pkg.Ref,
+		Commit:       *pkg.CommitSha,
+	}
+}
+
+// PublishSkill inserts a new skill version into a managed registry.
+//
+//nolint:gocyclo
+func (s *dbService) PublishSkill(
+	ctx context.Context,
+	skill *service.Skill,
+	opts ...service.Option,
+) (*service.Skill, error) {
+	ctx, span := s.startSpan(ctx, "dbService.PublishSkill")
+	defer span.End()
+
+	options := &service.PublishSkillOptions{}
+	for _, opt := range opts {
+		if err := opt(options); err != nil {
+			otel.RecordError(span, err)
+			return nil, err
+		}
+	}
+	if skill.Namespace == "" || skill.Name == "" || skill.Version == "" {
+		return nil, fmt.Errorf("namespace, name, and version are required")
+	}
+
+	registry, err := validateManagedRegistry(ctx, sqlc.New(s.pool), options.RegistryName)
+	if err != nil {
+		otel.RecordError(span, err)
+		return nil, err
+	}
+
+	now := time.Now().UTC()
+	entryParams := sqlc.InsertRegistryEntryParams{
+		RegID:     registry.ID,
+		EntryType: sqlc.EntryTypeSKILL,
+		Name:      skill.Name,
+		Version:   skill.Version,
+		CreatedAt: &now,
+		UpdatedAt: &now,
+	}
+	if skill.Title != "" {
+		entryParams.Title = &skill.Title
+	}
+	if skill.Description != "" {
+		entryParams.Description = &skill.Description
+	}
+
+	querier := sqlc.New(s.pool)
+	entryID, err := querier.InsertRegistryEntry(ctx, entryParams)
+	if err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+			return nil, fmt.Errorf("%w: %s %s", service.ErrVersionAlreadyExists, skill.Name, skill.Version)
+		}
+		otel.RecordError(span, err)
+		return nil, err
+	}
+
+	skillParams, err := makeInsertSkillVersionParams(entryID, skill)
+	if err != nil {
+		otel.RecordError(span, err)
+		return nil, err
+	}
+
+	_, err = querier.InsertSkillVersion(ctx, *skillParams)
+	if err != nil {
+		otel.RecordError(span, err)
+		return nil, err
+	}
+
+	for _, pkg := range skill.Packages {
+		var err error
+		switch pkg.RegistryType {
+		case service.SkillPackageTypeOCI:
+			err = querier.InsertSkillOciPackage(ctx, sqlc.InsertSkillOciPackageParams{
+				SkillEntryID: entryID,
+				Identifier:   pkg.Identifier,
+				Digest:       &pkg.Digest,
+				MediaType:    &pkg.MediaType,
+			})
+		case service.SkillPackageTypeGit:
+			err = querier.InsertSkillGitPackage(ctx, sqlc.InsertSkillGitPackageParams{
+				SkillEntryID: entryID,
+				Url:          pkg.URL,
+				Ref:          &pkg.Ref,
+				CommitSha:    &pkg.Commit,
+				Subfolder:    &pkg.Subfolder,
+			})
+		}
+		if err != nil {
+			otel.RecordError(span, err)
+			return nil, err
+		}
+	}
+
+	latestSkill, err := querier.GetSkillVersion(ctx, sqlc.GetSkillVersionParams{
+		Name:         skill.Name,
+		RegistryName: &options.RegistryName,
+		Version:      "latest",
+	})
+	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
+		otel.RecordError(span, err)
+		return nil, err
+	}
+
+	if versions.IsNewerVersion(skill.Version, latestSkill.Version) {
+		_, err = querier.UpsertLatestSkillVersion(ctx, sqlc.UpsertLatestSkillVersionParams{
+			RegID:   registry.ID,
+			Name:    skill.Name,
+			Version: skill.Version,
+			EntryID: entryID,
+		})
+		if err != nil {
+			otel.RecordError(span, err)
+			return nil, err
+		}
+	}
+
+	return s.GetSkillVersion(ctx,
+		service.WithRegistryName(options.RegistryName),
+		service.WithName(skill.Name),
+		service.WithVersion(skill.Version),
+	)
+}
+
+func makeInsertSkillVersionParams(
+	entryID uuid.UUID,
+	skill *service.Skill,
+) (*sqlc.InsertSkillVersionParams, error) {
+
+	status := sqlc.NullSkillStatus{}
+	if skill.Status != "" {
+		status = sqlc.NullSkillStatus{
+			SkillStatus: sqlc.SkillStatus(skill.Status),
+			Valid:       true,
+		}
+	}
+
+	repository, err := json.Marshal(skill.Repository)
+	if err != nil {
+		return nil, err
+	}
+	icons, err := json.Marshal(skill.Icons)
+	if err != nil {
+		return nil, err
+	}
+	metadata, err := json.Marshal(skill.Metadata)
+	if err != nil {
+		return nil, err
+	}
+	extensionMeta, err := json.Marshal(skill.Meta)
+	if err != nil {
+		return nil, err
+	}
+
+	skillParams := sqlc.InsertSkillVersionParams{
+		EntryID:       entryID,
+		Namespace:     skill.Namespace,
+		Status:        status,
+		AllowedTools:  skill.AllowedTools,
+		Repository:    repository,
+		Icons:         icons,
+		Metadata:      metadata,
+		ExtensionMeta: extensionMeta,
+	}
+	if skill.License != "" {
+		skillParams.License = &skill.License
+	}
+	if skill.Compatibility != "" {
+		skillParams.Compatibility = &skill.Compatibility
+	}
+
+	return &skillParams, nil
+}
+
+// DeleteSkillVersion removes a skill version from a managed registry.
+func (s *dbService) DeleteSkillVersion(
+	ctx context.Context,
+	opts ...service.Option,
+) error {
+	ctx, span := s.startSpan(ctx, "dbService.DeleteSkillVersion")
+	defer span.End()
+
+	options := &service.DeleteServerVersionOptions{}
+	for _, opt := range opts {
+		if err := opt(options); err != nil {
+			otel.RecordError(span, err)
+			return err
+		}
+	}
+
+	registry, err := validateManagedRegistry(ctx, sqlc.New(s.pool), options.RegistryName)
+	if err != nil {
+		otel.RecordError(span, err)
+		return err
+	}
+
+	querier := sqlc.New(s.pool)
+	affected, err := querier.DeleteRegistryEntry(ctx, sqlc.DeleteRegistryEntryParams{
+		RegID:   registry.ID,
+		Name:    options.ServerName,
+		Version: options.Version,
+	})
+	if err != nil {
+		otel.RecordError(span, err)
+		return err
+	}
+	if affected == 0 {
+		return fmt.Errorf("%w: %s %s", service.ErrNotFound, options.ServerName, options.Version)
+	}
+
+	return nil
+}

--- a/internal/service/db/impl_test.go
+++ b/internal/service/db/impl_test.go
@@ -493,12 +493,14 @@ func TestListServerVersions(t *testing.T) {
 			},
 			options: []service.Option{
 				service.WithName("com.example/test-server-1"),
-				func(o any) error {
-					opts := o.(*service.ListServerVersionsOptions)
+				func(opts any) error {
 					// Set nextTime to 30 minutes from now, so only versions created at +1h and +2h are returned
 					nextTime := time.Now().Add(30 * time.Minute).UTC()
-					opts.Next = &nextTime
-					opts.Limit = 10
+
+					castOpts := opts.(*service.ListServerVersionsOptions)
+					castOpts.Next = &nextTime
+					castOpts.Limit = 10
+
 					return nil
 				},
 			},
@@ -515,11 +517,13 @@ func TestListServerVersions(t *testing.T) {
 			},
 			options: []service.Option{
 				service.WithName("com.example/test-server-1"),
-				func(o any) error {
-					opts := o.(*service.ListServerVersionsOptions)
+				func(opts any) error {
 					prevTime := time.Now().Add(1 * time.Hour).UTC()
-					opts.Prev = &prevTime
-					opts.Limit = 10
+
+					castOpts := opts.(*service.ListServerVersionsOptions)
+					castOpts.Prev = &prevTime
+					castOpts.Limit = 10
+
 					return nil
 				},
 			},

--- a/internal/service/mocks/mock_service.go
+++ b/internal/service/mocks/mock_service.go
@@ -105,6 +105,25 @@ func (mr *MockRegistryServiceMockRecorder) DeleteServerVersion(ctx any, opts ...
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteServerVersion", reflect.TypeOf((*MockRegistryService)(nil).DeleteServerVersion), varargs...)
 }
 
+// DeleteSkillVersion mocks base method.
+func (m *MockRegistryService) DeleteSkillVersion(ctx context.Context, opts ...service.Option) error {
+	m.ctrl.T.Helper()
+	varargs := []any{ctx}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "DeleteSkillVersion", varargs...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteSkillVersion indicates an expected call of DeleteSkillVersion.
+func (mr *MockRegistryServiceMockRecorder) DeleteSkillVersion(ctx any, opts ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{ctx}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteSkillVersion", reflect.TypeOf((*MockRegistryService)(nil).DeleteSkillVersion), varargs...)
+}
+
 // GetRegistry mocks base method.
 func (m *MockRegistryService) GetRegistry(ctx context.Context) (*registry.UpstreamRegistry, string, error) {
 	m.ctrl.T.Helper()
@@ -154,6 +173,26 @@ func (mr *MockRegistryServiceMockRecorder) GetServerVersion(ctx any, opts ...any
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]any{ctx}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetServerVersion", reflect.TypeOf((*MockRegistryService)(nil).GetServerVersion), varargs...)
+}
+
+// GetSkillVersion mocks base method.
+func (m *MockRegistryService) GetSkillVersion(ctx context.Context, opts ...service.Option) (*service.Skill, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{ctx}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "GetSkillVersion", varargs...)
+	ret0, _ := ret[0].(*service.Skill)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetSkillVersion indicates an expected call of GetSkillVersion.
+func (mr *MockRegistryServiceMockRecorder) GetSkillVersion(ctx any, opts ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{ctx}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSkillVersion", reflect.TypeOf((*MockRegistryService)(nil).GetSkillVersion), varargs...)
 }
 
 // ListRegistries mocks base method.
@@ -211,6 +250,26 @@ func (mr *MockRegistryServiceMockRecorder) ListServers(ctx any, opts ...any) *go
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListServers", reflect.TypeOf((*MockRegistryService)(nil).ListServers), varargs...)
 }
 
+// ListSkills mocks base method.
+func (m *MockRegistryService) ListSkills(ctx context.Context, opts ...service.Option) (*service.ListSkillsResult, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{ctx}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ListSkills", varargs...)
+	ret0, _ := ret[0].(*service.ListSkillsResult)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListSkills indicates an expected call of ListSkills.
+func (mr *MockRegistryServiceMockRecorder) ListSkills(ctx any, opts ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{ctx}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSkills", reflect.TypeOf((*MockRegistryService)(nil).ListSkills), varargs...)
+}
+
 // ProcessInlineRegistryData mocks base method.
 func (m *MockRegistryService) ProcessInlineRegistryData(ctx context.Context, name, data, format string) error {
 	m.ctrl.T.Helper()
@@ -243,6 +302,26 @@ func (mr *MockRegistryServiceMockRecorder) PublishServerVersion(ctx any, opts ..
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]any{ctx}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PublishServerVersion", reflect.TypeOf((*MockRegistryService)(nil).PublishServerVersion), varargs...)
+}
+
+// PublishSkill mocks base method.
+func (m *MockRegistryService) PublishSkill(ctx context.Context, skill *service.Skill, opts ...service.Option) (*service.Skill, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{ctx, skill}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "PublishSkill", varargs...)
+	ret0, _ := ret[0].(*service.Skill)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// PublishSkill indicates an expected call of PublishSkill.
+func (mr *MockRegistryServiceMockRecorder) PublishSkill(ctx, skill any, opts ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{ctx, skill}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PublishSkill", reflect.TypeOf((*MockRegistryService)(nil).PublishSkill), varargs...)
 }
 
 // UpdateRegistry mocks base method.

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -268,7 +268,7 @@ func TestWithRegistryNameGetServerVersion(t *testing.T) {
 			}
 
 			require.NoError(t, err)
-			assert.Equal(t, tt.expectedValue, *opts.RegistryName)
+			assert.Equal(t, tt.expectedValue, opts.RegistryName)
 		})
 	}
 }

--- a/internal/service/skill_types.go
+++ b/internal/service/skill_types.go
@@ -1,0 +1,220 @@
+// Package service defines skill-related types returned by the service layer
+// and mapping from sqlc (database) row types.
+package service
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/stacklok/toolhive-registry-server/internal/db/sqlc"
+)
+
+// SkillRepository represents source repository metadata at the service layer.
+type SkillRepository struct {
+	URL  string `json:"url,omitempty"`
+	Type string `json:"type,omitempty"`
+}
+
+// SkillPackage represents a package for a skill at the service layer.
+type SkillPackage struct {
+	RegistryType string `json:"registryType"`
+	Identifier   string `json:"identifier,omitempty"`
+	Digest       string `json:"digest,omitempty"`
+	MediaType    string `json:"mediaType,omitempty"`
+	URL          string `json:"url,omitempty"`
+	Ref          string `json:"ref,omitempty"`
+	Commit       string `json:"commit,omitempty"`
+	Subfolder    string `json:"subfolder,omitempty"`
+}
+
+// SkillIcon represents a display icon for a skill at the service layer.
+type SkillIcon struct {
+	Src   string `json:"src"`
+	Size  string `json:"size,omitempty"`
+	Type  string `json:"type,omitempty"`
+	Label string `json:"label,omitempty"`
+}
+
+// Skill is a single skill returned by ListSkills, ListSkillVersions,
+// GetSkillVersion, GetLatestSkillVersion, and PublishSkill.
+type Skill struct {
+	ID            string           `json:"id,omitempty"`
+	Namespace     string           `json:"namespace"`
+	Name          string           `json:"name"`
+	Description   string           `json:"description"`
+	Version       string           `json:"version"`
+	Status        string           `json:"status,omitempty"`
+	Title         string           `json:"title,omitempty"`
+	License       string           `json:"license,omitempty"`
+	Compatibility string           `json:"compatibility,omitempty"`
+	AllowedTools  []string         `json:"allowedTools,omitempty"`
+	Repository    *SkillRepository `json:"repository,omitempty"`
+	Icons         []SkillIcon      `json:"icons,omitempty"`
+	Packages      []SkillPackage   `json:"packages,omitempty"`
+	Metadata      map[string]any   `json:"metadata,omitempty"`
+	Meta          map[string]any   `json:"_meta,omitempty"`
+	IsLatest      bool             `json:"isLatest,omitempty"`
+	CreatedAt     time.Time        `json:"createdAt,omitempty"`
+	UpdatedAt     time.Time        `json:"updatedAt,omitempty"`
+}
+
+// ListSkillsResult contains the result of a ListSkills operation with pagination.
+type ListSkillsResult struct {
+	Skills     []*Skill `json:"skills"`
+	NextCursor string   `json:"-"`
+}
+
+// skillRow holds the common shape of sqlc skill list/get rows for mapping.
+type skillRow struct {
+	ID            uuid.UUID
+	Name          string
+	Version       string
+	IsLatest      bool
+	CreatedAt     *time.Time
+	UpdatedAt     *time.Time
+	Description   *string
+	Title         *string
+	SkillEntryID  uuid.UUID
+	Namespace     string
+	Status        sqlc.SkillStatus
+	License       *string
+	Compatibility *string
+	AllowedTools  []string
+	Repository    []byte
+	Icons         []byte
+	Metadata      []byte
+	ExtensionMeta []byte
+}
+
+func rowToSkill(r skillRow) *Skill {
+	resp := &Skill{
+		ID:           r.ID.String(),
+		Namespace:    r.Namespace,
+		Name:         r.Name,
+		Version:      r.Version,
+		IsLatest:     r.IsLatest,
+		Status:       string(r.Status),
+		AllowedTools: r.AllowedTools,
+	}
+	if r.Description != nil {
+		resp.Description = *r.Description
+	}
+	if r.Title != nil {
+		resp.Title = *r.Title
+	}
+	if r.License != nil {
+		resp.License = *r.License
+	}
+	if r.Compatibility != nil {
+		resp.Compatibility = *r.Compatibility
+	}
+	if r.CreatedAt != nil {
+		resp.CreatedAt = *r.CreatedAt
+	}
+	if r.UpdatedAt != nil {
+		resp.UpdatedAt = *r.UpdatedAt
+	}
+	if len(r.Repository) > 0 {
+		var repo SkillRepository
+		if err := json.Unmarshal(r.Repository, &repo); err == nil {
+			resp.Repository = &repo
+		}
+	}
+	if len(r.Icons) > 0 {
+		var icons []SkillIcon
+		if err := json.Unmarshal(r.Icons, &icons); err == nil {
+			resp.Icons = icons
+		}
+	}
+	if len(r.Metadata) > 0 {
+		resp.Metadata = make(map[string]any)
+		_ = json.Unmarshal(r.Metadata, &resp.Metadata)
+	}
+	if len(r.ExtensionMeta) > 0 {
+		resp.Meta = make(map[string]any)
+		_ = json.Unmarshal(r.ExtensionMeta, &resp.Meta)
+	}
+	return resp
+}
+
+// ListSkillsRowToSkill maps a sqlc ListSkillsRow to a service Skill.
+func ListSkillsRowToSkill(row sqlc.ListSkillsRow) *Skill {
+	return rowToSkill(skillRow{
+		ID:            row.EntryID,
+		Name:          row.Name,
+		Version:       row.Version,
+		IsLatest:      row.IsLatest,
+		CreatedAt:     row.CreatedAt,
+		UpdatedAt:     row.UpdatedAt,
+		Description:   row.Description,
+		Title:         row.Title,
+		Namespace:     row.Namespace,
+		Status:        row.Status,
+		License:       row.License,
+		Compatibility: row.Compatibility,
+		AllowedTools:  row.AllowedTools,
+		Repository:    row.Repository,
+		Icons:         row.Icons,
+		Metadata:      row.Metadata,
+		ExtensionMeta: row.ExtensionMeta,
+	})
+}
+
+// GetSkillVersionRowToSkill maps a sqlc GetSkillVersionRow to a service Skill.
+func GetSkillVersionRowToSkill(row sqlc.GetSkillVersionRow) *Skill {
+	return rowToSkill(skillRow{
+		ID:            row.ID,
+		Name:          row.Name,
+		Version:       row.Version,
+		IsLatest:      row.IsLatest,
+		CreatedAt:     row.CreatedAt,
+		UpdatedAt:     row.UpdatedAt,
+		Description:   row.Description,
+		Title:         row.Title,
+		SkillEntryID:  row.SkillEntryID,
+		Namespace:     row.Namespace,
+		Status:        row.Status,
+		License:       row.License,
+		Compatibility: row.Compatibility,
+		AllowedTools:  row.AllowedTools,
+		Repository:    row.Repository,
+		Icons:         row.Icons,
+		Metadata:      row.Metadata,
+		ExtensionMeta: row.ExtensionMeta,
+	})
+}
+
+// PublishSkillOptions is the options for the PublishSkill operation
+type PublishSkillOptions struct {
+	RegistryName string
+}
+
+// ListSkillsOptions is the options for the ListSkills and ListSkillVersions
+// operations.
+type ListSkillsOptions struct {
+	RegistryName string
+	Namespace    string
+	Name         *string
+	Version      *string
+	Search       *string
+	Limit        int
+	Cursor       *string
+}
+
+// GetSkillVersionOptions is the options for the GetSkillVersion operation.
+type GetSkillVersionOptions struct {
+	RegistryName string
+	Namespace    string
+	Name         string
+	Version      string
+}
+
+// DeleteSkillVersionOptions is the options for the DeleteSkillVersion operation
+type DeleteSkillVersionOptions struct {
+	RegistryName string
+	Namespace    string
+	Name         string
+	Version      string
+}


### PR DESCRIPTION
This change adds service layer implementation for skills. Four new routines are added

* `ListSkills` to list skills, optionally filtered by namespace and name
* `GetSkillVersion` to get individual records, either a specific version or the latest version
* `PublishSkill` to create new skills, and
* `DeleteSkillVersion` to delete skills.

A lot of code is just new types and converters, but a non-trivial amount of logic is implemented in `internal/service/db/impl_skills.go`.

References #441