### PR TITLE
Add API layer for skills

### DIFF
--- a/docs/thv-registry-api/docs.go
+++ b/docs/thv-registry-api/docs.go
@@ -2186,7 +2186,7 @@ const docTemplate = `{
         },
         "/registry/{registryName}/v0.1/x/dev.toolhive/skills": {
             "get": {
-                "description": "List skills in a registry (paginated, latest versions). Not implemented.",
+                "description": "List skills in a registry (paginated, latest versions).",
                 "parameters": [
                     {
                         "description": "Registry name",
@@ -2271,7 +2271,7 @@ const docTemplate = `{
                         },
                         "description": "Bad request"
                     },
-                    "501": {
+                    "500": {
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -2282,7 +2282,7 @@ const docTemplate = `{
                                 }
                             }
                         },
-                        "description": "Not implemented"
+                        "description": "Internal server error"
                     }
                 },
                 "security": [
@@ -2296,7 +2296,7 @@ const docTemplate = `{
                 ]
             },
             "post": {
-                "description": "Publish a skill version to the registry. Not implemented.",
+                "description": "Publish a skill version to the registry.",
                 "parameters": [
                     {
                         "description": "Registry name",
@@ -2378,7 +2378,7 @@ const docTemplate = `{
                         },
                         "description": "Not a managed registry"
                     },
-                    "501": {
+                    "409": {
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -2389,7 +2389,20 @@ const docTemplate = `{
                                 }
                             }
                         },
-                        "description": "Not implemented"
+                        "description": "Version already exists"
+                    },
+                    "500": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "additionalProperties": {
+                                        "type": "string"
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "description": "Internal server error"
                     }
                 },
                 "security": [
@@ -2405,7 +2418,7 @@ const docTemplate = `{
         },
         "/registry/{registryName}/v0.1/x/dev.toolhive/skills/{namespace}/{name}": {
             "get": {
-                "description": "Get the latest version of a skill by namespace and name. Not implemented.",
+                "description": "Get the latest version of a skill by namespace and name.",
                 "parameters": [
                     {
                         "description": "Registry name",
@@ -2481,7 +2494,7 @@ const docTemplate = `{
                         },
                         "description": "Skill not found"
                     },
-                    "501": {
+                    "500": {
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -2492,7 +2505,7 @@ const docTemplate = `{
                                 }
                             }
                         },
-                        "description": "Not implemented"
+                        "description": "Internal server error"
                     }
                 },
                 "security": [
@@ -2508,7 +2521,7 @@ const docTemplate = `{
         },
         "/registry/{registryName}/v0.1/x/dev.toolhive/skills/{namespace}/{name}/versions": {
             "get": {
-                "description": "List all versions of a skill. Not implemented.",
+                "description": "List all versions of a skill.",
                 "parameters": [
                     {
                         "description": "Registry name",
@@ -2584,7 +2597,7 @@ const docTemplate = `{
                         },
                         "description": "Skill not found"
                     },
-                    "501": {
+                    "500": {
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -2595,7 +2608,7 @@ const docTemplate = `{
                                 }
                             }
                         },
-                        "description": "Not implemented"
+                        "description": "Internal server error"
                     }
                 },
                 "security": [
@@ -2611,7 +2624,7 @@ const docTemplate = `{
         },
         "/registry/{registryName}/v0.1/x/dev.toolhive/skills/{namespace}/{name}/versions/{version}": {
             "delete": {
-                "description": "Delete a specific version of a skill from the registry. Not implemented.",
+                "description": "Delete a specific version of a skill from the registry.",
                 "parameters": [
                     {
                         "description": "Registry name",
@@ -2715,7 +2728,7 @@ const docTemplate = `{
                         },
                         "description": "Skill version not found"
                     },
-                    "501": {
+                    "500": {
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -2726,7 +2739,7 @@ const docTemplate = `{
                                 }
                             }
                         },
-                        "description": "Not implemented"
+                        "description": "Internal server error"
                     }
                 },
                 "security": [
@@ -2740,7 +2753,7 @@ const docTemplate = `{
                 ]
             },
             "get": {
-                "description": "Get a specific version of a skill. Not implemented.",
+                "description": "Get a specific version of a skill.",
                 "parameters": [
                     {
                         "description": "Registry name",
@@ -2825,7 +2838,7 @@ const docTemplate = `{
                         },
                         "description": "Skill or version not found"
                     },
-                    "501": {
+                    "500": {
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -2836,7 +2849,7 @@ const docTemplate = `{
                                 }
                             }
                         },
-                        "description": "Not implemented"
+                        "description": "Internal server error"
                     }
                 },
                 "security": [

--- a/docs/thv-registry-api/swagger.json
+++ b/docs/thv-registry-api/swagger.json
@@ -2179,7 +2179,7 @@
         },
         "/registry/{registryName}/v0.1/x/dev.toolhive/skills": {
             "get": {
-                "description": "List skills in a registry (paginated, latest versions). Not implemented.",
+                "description": "List skills in a registry (paginated, latest versions).",
                 "parameters": [
                     {
                         "description": "Registry name",
@@ -2264,7 +2264,7 @@
                         },
                         "description": "Bad request"
                     },
-                    "501": {
+                    "500": {
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -2275,7 +2275,7 @@
                                 }
                             }
                         },
-                        "description": "Not implemented"
+                        "description": "Internal server error"
                     }
                 },
                 "security": [
@@ -2289,7 +2289,7 @@
                 ]
             },
             "post": {
-                "description": "Publish a skill version to the registry. Not implemented.",
+                "description": "Publish a skill version to the registry.",
                 "parameters": [
                     {
                         "description": "Registry name",
@@ -2371,7 +2371,7 @@
                         },
                         "description": "Not a managed registry"
                     },
-                    "501": {
+                    "409": {
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -2382,7 +2382,20 @@
                                 }
                             }
                         },
-                        "description": "Not implemented"
+                        "description": "Version already exists"
+                    },
+                    "500": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "additionalProperties": {
+                                        "type": "string"
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "description": "Internal server error"
                     }
                 },
                 "security": [
@@ -2398,7 +2411,7 @@
         },
         "/registry/{registryName}/v0.1/x/dev.toolhive/skills/{namespace}/{name}": {
             "get": {
-                "description": "Get the latest version of a skill by namespace and name. Not implemented.",
+                "description": "Get the latest version of a skill by namespace and name.",
                 "parameters": [
                     {
                         "description": "Registry name",
@@ -2474,7 +2487,7 @@
                         },
                         "description": "Skill not found"
                     },
-                    "501": {
+                    "500": {
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -2485,7 +2498,7 @@
                                 }
                             }
                         },
-                        "description": "Not implemented"
+                        "description": "Internal server error"
                     }
                 },
                 "security": [
@@ -2501,7 +2514,7 @@
         },
         "/registry/{registryName}/v0.1/x/dev.toolhive/skills/{namespace}/{name}/versions": {
             "get": {
-                "description": "List all versions of a skill. Not implemented.",
+                "description": "List all versions of a skill.",
                 "parameters": [
                     {
                         "description": "Registry name",
@@ -2577,7 +2590,7 @@
                         },
                         "description": "Skill not found"
                     },
-                    "501": {
+                    "500": {
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -2588,7 +2601,7 @@
                                 }
                             }
                         },
-                        "description": "Not implemented"
+                        "description": "Internal server error"
                     }
                 },
                 "security": [
@@ -2604,7 +2617,7 @@
         },
         "/registry/{registryName}/v0.1/x/dev.toolhive/skills/{namespace}/{name}/versions/{version}": {
             "delete": {
-                "description": "Delete a specific version of a skill from the registry. Not implemented.",
+                "description": "Delete a specific version of a skill from the registry.",
                 "parameters": [
                     {
                         "description": "Registry name",
@@ -2708,7 +2721,7 @@
                         },
                         "description": "Skill version not found"
                     },
-                    "501": {
+                    "500": {
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -2719,7 +2732,7 @@
                                 }
                             }
                         },
-                        "description": "Not implemented"
+                        "description": "Internal server error"
                     }
                 },
                 "security": [
@@ -2733,7 +2746,7 @@
                 ]
             },
             "get": {
-                "description": "Get a specific version of a skill. Not implemented.",
+                "description": "Get a specific version of a skill.",
                 "parameters": [
                     {
                         "description": "Registry name",
@@ -2818,7 +2831,7 @@
                         },
                         "description": "Skill or version not found"
                     },
-                    "501": {
+                    "500": {
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -2829,7 +2842,7 @@
                                 }
                             }
                         },
-                        "description": "Not implemented"
+                        "description": "Internal server error"
                     }
                 },
                 "security": [

--- a/docs/thv-registry-api/swagger.yaml
+++ b/docs/thv-registry-api/swagger.yaml
@@ -1368,7 +1368,7 @@ paths:
       - registry
   /registry/{registryName}/v0.1/x/dev.toolhive/skills:
     get:
-      description: List skills in a registry (paginated, latest versions). Not implemented.
+      description: List skills in a registry (paginated, latest versions).
       parameters:
       - description: Registry name
         in: path
@@ -1421,21 +1421,21 @@ paths:
                   type: string
                 type: object
           description: Bad request
-        "501":
+        "500":
           content:
             application/json:
               schema:
                 additionalProperties:
                   type: string
                 type: object
-          description: Not implemented
+          description: Internal server error
       security:
       - BearerAuth: []
       summary: List skills in registry
       tags:
       - skills
     post:
-      description: Publish a skill version to the registry. Not implemented.
+      description: Publish a skill version to the registry.
       parameters:
       - description: Registry name
         in: path
@@ -1485,14 +1485,22 @@ paths:
                   type: string
                 type: object
           description: Not a managed registry
-        "501":
+        "409":
           content:
             application/json:
               schema:
                 additionalProperties:
                   type: string
                 type: object
-          description: Not implemented
+          description: Version already exists
+        "500":
+          content:
+            application/json:
+              schema:
+                additionalProperties:
+                  type: string
+                type: object
+          description: Internal server error
       security:
       - BearerAuth: []
       summary: Publish skill
@@ -1500,7 +1508,7 @@ paths:
       - skills
   /registry/{registryName}/v0.1/x/dev.toolhive/skills/{namespace}/{name}:
     get:
-      description: Get the latest version of a skill by namespace and name. Not implemented.
+      description: Get the latest version of a skill by namespace and name.
       parameters:
       - description: Registry name
         in: path
@@ -1548,14 +1556,14 @@ paths:
                   type: string
                 type: object
           description: Skill not found
-        "501":
+        "500":
           content:
             application/json:
               schema:
                 additionalProperties:
                   type: string
                 type: object
-          description: Not implemented
+          description: Internal server error
       security:
       - BearerAuth: []
       summary: Get latest skill version
@@ -1563,7 +1571,7 @@ paths:
       - skills
   /registry/{registryName}/v0.1/x/dev.toolhive/skills/{namespace}/{name}/versions:
     get:
-      description: List all versions of a skill. Not implemented.
+      description: List all versions of a skill.
       parameters:
       - description: Registry name
         in: path
@@ -1611,14 +1619,14 @@ paths:
                   type: string
                 type: object
           description: Skill not found
-        "501":
+        "500":
           content:
             application/json:
               schema:
                 additionalProperties:
                   type: string
                 type: object
-          description: Not implemented
+          description: Internal server error
       security:
       - BearerAuth: []
       summary: List skill versions
@@ -1626,7 +1634,7 @@ paths:
       - skills
   /registry/{registryName}/v0.1/x/dev.toolhive/skills/{namespace}/{name}/versions/{version}:
     delete:
-      description: Delete a specific version of a skill from the registry. Not implemented.
+      description: Delete a specific version of a skill from the registry.
       parameters:
       - description: Registry name
         in: path
@@ -1692,21 +1700,21 @@ paths:
                   type: string
                 type: object
           description: Skill version not found
-        "501":
+        "500":
           content:
             application/json:
               schema:
                 additionalProperties:
                   type: string
                 type: object
-          description: Not implemented
+          description: Internal server error
       security:
       - BearerAuth: []
       summary: Delete skill version
       tags:
       - skills
     get:
-      description: Get a specific version of a skill. Not implemented.
+      description: Get a specific version of a skill.
       parameters:
       - description: Registry name
         in: path
@@ -1760,14 +1768,14 @@ paths:
                   type: string
                 type: object
           description: Skill or version not found
-        "501":
+        "500":
           content:
             application/json:
               schema:
                 additionalProperties:
                   type: string
                 type: object
-          description: Not implemented
+          description: Internal server error
       security:
       - BearerAuth: []
       summary: Get specific skill version

--- a/internal/api/x/skills/routes_test.go
+++ b/internal/api/x/skills/routes_test.go
@@ -3,6 +3,7 @@ package skills
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -27,22 +28,35 @@ func skillsRouterWithRegistryMount(svc service.RegistryService) http.Handler {
 
 func TestListSkills(t *testing.T) {
 	t.Parallel()
-	ctrl := gomock.NewController(t)
-	t.Cleanup(ctrl.Finish)
-	mockSvc := mocks.NewMockRegistryService(ctrl)
-	router := skillsRouterWithRegistryMount(mockSvc)
 
 	tests := []struct {
 		name       string
 		path       string
+		setupMocks func(m *mocks.MockRegistryService)
 		wantStatus int
 		wantError  string
 	}{
 		{
-			name:       "valid query returns 501",
-			path:       "/myreg/v0.1/x/dev.toolhive/skills",
-			wantStatus: http.StatusNotImplemented,
-			wantError:  "Skills list is not implemented",
+			name: "valid query returns 200",
+			path: "/myreg/v0.1/x/dev.toolhive/skills",
+			setupMocks: func(m *mocks.MockRegistryService) {
+				m.EXPECT().ListSkills(gomock.Any(), gomock.Any()).
+					Return(&service.ListSkillsResult{
+						Skills: []*service.Skill{
+							{Namespace: "io.github.stacklok", Name: "pdf-processor", Version: "1.0.0", Description: "Extract text"},
+						},
+					}, nil)
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name: "service error returns 500",
+			path: "/myreg/v0.1/x/dev.toolhive/skills",
+			setupMocks: func(m *mocks.MockRegistryService) {
+				m.EXPECT().ListSkills(gomock.Any(), gomock.Any()).
+					Return(nil, fmt.Errorf("database error"))
+			},
+			wantStatus: http.StatusInternalServerError,
 		},
 		{
 			name:       "invalid limit returns 400",
@@ -67,6 +81,14 @@ func TestListSkills(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			ctrl := gomock.NewController(t)
+			t.Cleanup(ctrl.Finish)
+			mockSvc := mocks.NewMockRegistryService(ctrl)
+			if tt.setupMocks != nil {
+				tt.setupMocks(mockSvc)
+			}
+			router := skillsRouterWithRegistryMount(mockSvc)
+
 			req := httptest.NewRequest(http.MethodGet, tt.path, nil)
 			rr := httptest.NewRecorder()
 			router.ServeHTTP(rr, req)
@@ -82,22 +104,36 @@ func TestListSkills(t *testing.T) {
 
 func TestGetLatestVersion(t *testing.T) {
 	t.Parallel()
-	ctrl := gomock.NewController(t)
-	t.Cleanup(ctrl.Finish)
-	mockSvc := mocks.NewMockRegistryService(ctrl)
-	router := skillsRouterWithRegistryMount(mockSvc)
 
 	tests := []struct {
 		name       string
 		path       string
+		setupMocks func(m *mocks.MockRegistryService)
 		wantStatus int
 		wantError  string
 	}{
 		{
-			name:       "valid path returns 501",
-			path:       "/myreg/v0.1/x/dev.toolhive/skills/io.github.stacklok/pdf-processor",
-			wantStatus: http.StatusNotImplemented,
-			wantError:  "Get latest skill version is not implemented",
+			name: "valid path returns 200",
+			path: "/myreg/v0.1/x/dev.toolhive/skills/io.github.stacklok/pdf-processor",
+			setupMocks: func(m *mocks.MockRegistryService) {
+				m.EXPECT().GetSkillVersion(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&service.Skill{
+						Namespace:   "io.github.stacklok",
+						Name:        "pdf-processor",
+						Version:     "1.0.0",
+						Description: "Extract text from PDFs",
+					}, nil)
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name: "not found returns 404",
+			path: "/myreg/v0.1/x/dev.toolhive/skills/io.github.stacklok/nonexistent",
+			setupMocks: func(m *mocks.MockRegistryService) {
+				m.EXPECT().GetSkillVersion(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil, fmt.Errorf("%w: nonexistent", service.ErrNotFound))
+			},
+			wantStatus: http.StatusNotFound,
 		},
 		{
 			name:       "empty namespace returns 400",
@@ -116,6 +152,14 @@ func TestGetLatestVersion(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			ctrl := gomock.NewController(t)
+			t.Cleanup(ctrl.Finish)
+			mockSvc := mocks.NewMockRegistryService(ctrl)
+			if tt.setupMocks != nil {
+				tt.setupMocks(mockSvc)
+			}
+			router := skillsRouterWithRegistryMount(mockSvc)
+
 			req := httptest.NewRequest(http.MethodGet, tt.path, nil)
 			rr := httptest.NewRecorder()
 			router.ServeHTTP(rr, req)
@@ -134,35 +178,59 @@ func TestListVersions(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	t.Cleanup(ctrl.Finish)
 	mockSvc := mocks.NewMockRegistryService(ctrl)
+
+	mockSvc.EXPECT().ListSkills(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(&service.ListSkillsResult{
+			Skills: []*service.Skill{
+				{Namespace: "io.github.stacklok", Name: "pdf-processor", Version: "1.0.0"},
+				{Namespace: "io.github.stacklok", Name: "pdf-processor", Version: "0.9.0"},
+			},
+		}, nil)
+
 	router := skillsRouterWithRegistryMount(mockSvc)
 
 	req := httptest.NewRequest(http.MethodGet, "/myreg/v0.1/x/dev.toolhive/skills/io.github.stacklok/pdf-processor/versions", nil)
 	rr := httptest.NewRecorder()
 	router.ServeHTTP(rr, req)
-	assert.Equal(t, http.StatusNotImplemented, rr.Code)
-	var body map[string]string
-	require.NoError(t, json.NewDecoder(rr.Body).Decode(&body))
-	assert.Equal(t, "List skill versions is not implemented", body["error"])
+	assert.Equal(t, http.StatusOK, rr.Code)
+
+	var resp SkillListResponse
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
+	assert.Equal(t, 2, resp.Metadata.Count)
 }
 
 func TestGetVersion(t *testing.T) {
 	t.Parallel()
-	ctrl := gomock.NewController(t)
-	t.Cleanup(ctrl.Finish)
-	mockSvc := mocks.NewMockRegistryService(ctrl)
-	router := skillsRouterWithRegistryMount(mockSvc)
 
 	tests := []struct {
 		name       string
 		path       string
+		setupMocks func(m *mocks.MockRegistryService)
 		wantStatus int
 		wantError  string
 	}{
 		{
-			name:       "valid path returns 501",
-			path:       "/myreg/v0.1/x/dev.toolhive/skills/io.github.stacklok/pdf-processor/versions/1.0.0",
-			wantStatus: http.StatusNotImplemented,
-			wantError:  "Get skill version is not implemented",
+			name: "valid path returns 200",
+			path: "/myreg/v0.1/x/dev.toolhive/skills/io.github.stacklok/pdf-processor/versions/1.0.0",
+			setupMocks: func(m *mocks.MockRegistryService) {
+				m.EXPECT().GetSkillVersion(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&service.Skill{
+						Namespace:   "io.github.stacklok",
+						Name:        "pdf-processor",
+						Version:     "1.0.0",
+						Description: "Extract text from PDFs",
+					}, nil)
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name: "not found returns 404",
+			path: "/myreg/v0.1/x/dev.toolhive/skills/io.github.stacklok/pdf-processor/versions/9.9.9",
+			setupMocks: func(m *mocks.MockRegistryService) {
+				m.EXPECT().GetSkillVersion(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil, fmt.Errorf("%w: pdf-processor@9.9.9", service.ErrNotFound))
+			},
+			wantStatus: http.StatusNotFound,
 		},
 		{
 			name:       "empty version returns 400",
@@ -175,6 +243,14 @@ func TestGetVersion(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			ctrl := gomock.NewController(t)
+			t.Cleanup(ctrl.Finish)
+			mockSvc := mocks.NewMockRegistryService(ctrl)
+			if tt.setupMocks != nil {
+				tt.setupMocks(mockSvc)
+			}
+			router := skillsRouterWithRegistryMount(mockSvc)
+
 			req := httptest.NewRequest(http.MethodGet, tt.path, nil)
 			rr := httptest.NewRecorder()
 			router.ServeHTTP(rr, req)
@@ -190,10 +266,6 @@ func TestGetVersion(t *testing.T) {
 
 func TestPublishSkill(t *testing.T) {
 	t.Parallel()
-	ctrl := gomock.NewController(t)
-	t.Cleanup(ctrl.Finish)
-	mockSvc := mocks.NewMockRegistryService(ctrl)
-	router := skillsRouterWithRegistryMount(mockSvc)
 
 	validBody := thvregistry.Skill{
 		Namespace:   "io.github.stacklok",
@@ -205,14 +277,41 @@ func TestPublishSkill(t *testing.T) {
 	tests := []struct {
 		name       string
 		body       interface{}
+		setupMocks func(m *mocks.MockRegistryService)
 		wantStatus int
 		wantError  string
 	}{
 		{
-			name:       "valid body returns 501",
-			body:       validBody,
-			wantStatus: http.StatusNotImplemented,
-			wantError:  "Publish skill is not implemented",
+			name: "valid body returns 201",
+			body: validBody,
+			setupMocks: func(m *mocks.MockRegistryService) {
+				m.EXPECT().PublishSkill(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&service.Skill{
+						Namespace:   "io.github.stacklok",
+						Name:        "pdf-processor",
+						Description: "Extract text from PDFs",
+						Version:     "1.0.0",
+					}, nil)
+			},
+			wantStatus: http.StatusCreated,
+		},
+		{
+			name: "version conflict returns 409",
+			body: validBody,
+			setupMocks: func(m *mocks.MockRegistryService) {
+				m.EXPECT().PublishSkill(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil, fmt.Errorf("%w: pdf-processor@1.0.0", service.ErrVersionAlreadyExists))
+			},
+			wantStatus: http.StatusConflict,
+		},
+		{
+			name: "not managed returns 403",
+			body: validBody,
+			setupMocks: func(m *mocks.MockRegistryService) {
+				m.EXPECT().PublishSkill(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil, service.ErrNotManagedRegistry)
+			},
+			wantStatus: http.StatusForbidden,
 		},
 		{
 			name:       "missing namespace returns 400",
@@ -255,6 +354,14 @@ func TestPublishSkill(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			ctrl := gomock.NewController(t)
+			t.Cleanup(ctrl.Finish)
+			mockSvc := mocks.NewMockRegistryService(ctrl)
+			if tt.setupMocks != nil {
+				tt.setupMocks(mockSvc)
+			}
+			router := skillsRouterWithRegistryMount(mockSvc)
+
 			var reqBody bytes.Buffer
 			if tt.body != nil {
 				switch b := tt.body.(type) {
@@ -286,22 +393,40 @@ func TestPublishSkill(t *testing.T) {
 
 func TestDeleteVersion(t *testing.T) {
 	t.Parallel()
-	ctrl := gomock.NewController(t)
-	t.Cleanup(ctrl.Finish)
-	mockSvc := mocks.NewMockRegistryService(ctrl)
-	router := skillsRouterWithRegistryMount(mockSvc)
 
 	tests := []struct {
 		name       string
 		path       string
+		setupMocks func(m *mocks.MockRegistryService)
 		wantStatus int
 		wantError  string
 	}{
 		{
-			name:       "valid path returns 501",
-			path:       "/myreg/v0.1/x/dev.toolhive/skills/io.github.stacklok/pdf-processor/versions/1.0.0",
-			wantStatus: http.StatusNotImplemented,
-			wantError:  "Delete skill version is not implemented",
+			name: "valid path returns 204",
+			path: "/myreg/v0.1/x/dev.toolhive/skills/io.github.stacklok/pdf-processor/versions/1.0.0",
+			setupMocks: func(m *mocks.MockRegistryService) {
+				m.EXPECT().DeleteSkillVersion(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil)
+			},
+			wantStatus: http.StatusNoContent,
+		},
+		{
+			name: "not found returns 404",
+			path: "/myreg/v0.1/x/dev.toolhive/skills/io.github.stacklok/pdf-processor/versions/9.9.9",
+			setupMocks: func(m *mocks.MockRegistryService) {
+				m.EXPECT().DeleteSkillVersion(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(fmt.Errorf("%w: pdf-processor@9.9.9", service.ErrNotFound))
+			},
+			wantStatus: http.StatusNotFound,
+		},
+		{
+			name: "not managed returns 403",
+			path: "/myreg/v0.1/x/dev.toolhive/skills/io.github.stacklok/pdf-processor/versions/1.0.0",
+			setupMocks: func(m *mocks.MockRegistryService) {
+				m.EXPECT().DeleteSkillVersion(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(service.ErrNotManagedRegistry)
+			},
+			wantStatus: http.StatusForbidden,
 		},
 		{
 			name:       "empty version returns 400",
@@ -314,6 +439,14 @@ func TestDeleteVersion(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			ctrl := gomock.NewController(t)
+			t.Cleanup(ctrl.Finish)
+			mockSvc := mocks.NewMockRegistryService(ctrl)
+			if tt.setupMocks != nil {
+				tt.setupMocks(mockSvc)
+			}
+			router := skillsRouterWithRegistryMount(mockSvc)
+
 			req := httptest.NewRequest(http.MethodDelete, tt.path, nil)
 			rr := httptest.NewRecorder()
 			router.ServeHTTP(rr, req)


### PR DESCRIPTION
This change adds the following endpoints

* `GET /{regName}/v0.1/x/dev.toolhive/skills` to list skills
* `GET /{regName}/v0.1/x/dev.toolhive/skills/{namespace}/{name}` to retrieve the latest version of a skill by name and namespace
* `GET /{regName}/v0.1/x/dev.toolhive/skills/{namespace}/{name}/versions` to list versions of a skill
* `GET /{regName}/v0.1/x/dev.toolhive/skills/{namespace}/{name}/versions/{version}` to retrieve a specific version
* `POST/{regName}/v0.1/x/dev.toolhive/skills` to create new skills
* `DELETE /{regName}/v0.1/x/dev.toolhive/skills/{namespace}/{name}/versions/{version}` to delete a version of a skill

Fixes #441