### PR TITLE
Support custom display name via registry-title annotation

### DIFF
--- a/internal/kubernetes/builder.go
+++ b/internal/kubernetes/builder.go
@@ -25,6 +25,7 @@ const (
 	defaultRegistryExportAnnotation          = "toolhive.stacklok.dev/registry-export"
 	defaultRegistryURLAnnotation             = "toolhive.stacklok.dev/registry-url"
 	defaultRegistryDescriptionAnnotation     = "toolhive.stacklok.dev/registry-description"
+	defaultRegistryTitleAnnotation           = "toolhive.stacklok.dev/registry-title"
 	defaultRegistryToolDefinitionsAnnotation = "toolhive.stacklok.dev/tool-definitions"
 	defaultRegistryToolsAnnotation           = "toolhive.stacklok.dev/tools"
 

--- a/internal/kubernetes/types.go
+++ b/internal/kubernetes/types.go
@@ -47,6 +47,10 @@ func extractServer(mcpServer *mcpv1alpha1.MCPServer) (*upstreamv0.ServerJSON, er
 	}
 	serverJSON.Description = desc
 
+	if title, ok := annotations[defaultRegistryTitleAnnotation]; ok {
+		serverJSON.Title = title
+	}
+
 	transportURL, ok := annotations[defaultRegistryURLAnnotation]
 	if !ok {
 		return nil, fmt.Errorf("URL not found in annotations")
@@ -131,6 +135,10 @@ func extractVirtualMCPServer(virtualMCPServer *mcpv1alpha1.VirtualMCPServer) (*u
 	}
 	serverJSON.Description = desc
 
+	if title, ok := annotations[defaultRegistryTitleAnnotation]; ok {
+		serverJSON.Title = title
+	}
+
 	transportURL, ok := annotations[defaultRegistryURLAnnotation]
 	if !ok {
 		return nil, fmt.Errorf("URL not found in annotations")
@@ -212,6 +220,10 @@ func extractMCPRemoteProxy(mcpRemoteProxy *mcpv1alpha1.MCPRemoteProxy) (*upstrea
 		return nil, fmt.Errorf("description not found in annotations")
 	}
 	serverJSON.Description = desc
+
+	if title, ok := annotations[defaultRegistryTitleAnnotation]; ok {
+		serverJSON.Title = title
+	}
 
 	transportURL, ok := annotations[defaultRegistryURLAnnotation]
 	if !ok {

--- a/internal/kubernetes/types_test.go
+++ b/internal/kubernetes/types_test.go
@@ -61,6 +61,7 @@ func TestExtractServer(t *testing.T) {
 			wantErr:     false,
 			//nolint:thelper // We want to see these lines in the test output
 			checkMeta: func(t *testing.T, sj *upstreamv0.ServerJSON) {
+				assert.Empty(t, sj.Title, "Title should be empty when title annotation is not set")
 				assert.Equal(t, "A test MCP server", sj.Description)
 				assert.NotNil(t, sj.Meta.PublisherProvided["io.github.stacklok"])
 				ioStacklok := sj.Meta.PublisherProvided["io.github.stacklok"].(map[string]any)
@@ -426,6 +427,33 @@ func TestExtractServer(t *testing.T) {
 			},
 		},
 		{
+			name: "MCPServer with title annotation",
+			mcpServer: createTestMCPServer(
+				"titled-server",
+				"default",
+				map[string]string{
+					defaultRegistryDescriptionAnnotation: "A titled MCP server",
+					defaultRegistryURLAnnotation:         "https://example.com/titled",
+					defaultRegistryTitleAnnotation:       "My Custom Server Title",
+				},
+				mcpv1alpha1.MCPServerSpec{
+					Image:     "test/titled:v1",
+					Transport: "sse",
+				},
+			),
+			wantSchema:  "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+			wantName:    "com.toolhive.k8s.default/titled-server",
+			wantVersion: "1.0.0",
+			wantErr:     false,
+			//nolint:thelper // We want to see these lines in the test output
+			checkMeta: func(t *testing.T, sj *upstreamv0.ServerJSON) {
+				assert.Equal(t, "My Custom Server Title", sj.Title)
+				assert.Equal(t, "A titled MCP server", sj.Description)
+				require.Len(t, sj.Remotes, 1)
+				assert.Equal(t, "https://example.com/titled", sj.Remotes[0].URL)
+			},
+		},
+		{
 			name: "MCPServer with both tool_definitions and tools",
 			mcpServer: createTestMCPServer(
 				"server-with-both",
@@ -690,6 +718,7 @@ func TestExtractVirtualMCPServer(t *testing.T) {
 			wantErr:     false,
 			//nolint:thelper // We want to see these lines in the test output
 			checkMeta: func(t *testing.T, sj *upstreamv0.ServerJSON) {
+				assert.Empty(t, sj.Title, "Title should be empty when title annotation is not set")
 				assert.Equal(t, "A test Virtual MCP server", sj.Description)
 				assert.NotNil(t, sj.Meta.PublisherProvided["io.github.stacklok"])
 				ioStacklok := sj.Meta.PublisherProvided["io.github.stacklok"].(map[string]any)
@@ -879,6 +908,29 @@ func TestExtractVirtualMCPServer(t *testing.T) {
 			},
 		},
 		{
+			name: "VirtualMCPServer with title annotation",
+			vmcpServer: createTestVirtualMCPServer(
+				"titled-vmcp-server",
+				"default",
+				map[string]string{
+					defaultRegistryDescriptionAnnotation: "A titled Virtual MCP server",
+					defaultRegistryURLAnnotation:         "https://example.com/vmcp-titled",
+					defaultRegistryTitleAnnotation:       "My Virtual Server Title",
+				},
+			),
+			wantSchema:  "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+			wantName:    "com.toolhive.k8s.default/titled-vmcp-server",
+			wantVersion: "1.0.0",
+			wantErr:     false,
+			//nolint:thelper // We want to see these lines in the test output
+			checkMeta: func(t *testing.T, sj *upstreamv0.ServerJSON) {
+				assert.Equal(t, "My Virtual Server Title", sj.Title)
+				assert.Equal(t, "A titled Virtual MCP server", sj.Description)
+				require.Len(t, sj.Remotes, 1)
+				assert.Equal(t, "https://example.com/vmcp-titled", sj.Remotes[0].URL)
+			},
+		},
+		{
 			name: "VirtualMCPServer with both tool_definitions and tools",
 			vmcpServer: createTestVirtualMCPServer(
 				"vmcp-with-both",
@@ -980,6 +1032,7 @@ func TestExtractMCPRemoteProxy(t *testing.T) {
 			wantErr:     false,
 			//nolint:thelper // We want to see these lines in the test output
 			checkMeta: func(t *testing.T, sj *upstreamv0.ServerJSON) {
+				assert.Empty(t, sj.Title, "Title should be empty when title annotation is not set")
 				assert.Equal(t, "A test MCP Remote Proxy", sj.Description)
 				assert.NotNil(t, sj.Meta.PublisherProvided["io.github.stacklok"])
 				ioStacklok := sj.Meta.PublisherProvided["io.github.stacklok"].(map[string]any)
@@ -1173,6 +1226,29 @@ func TestExtractMCPRemoteProxy(t *testing.T) {
 				require.Len(t, tools, 2)
 				assert.Equal(t, "query_database", tools[0])
 				assert.Equal(t, "update_table", tools[1])
+			},
+		},
+		{
+			name: "MCPRemoteProxy with title annotation",
+			mcpRemoteProxy: createTestMCPRemoteProxy(
+				"titled-proxy",
+				"default",
+				map[string]string{
+					defaultRegistryDescriptionAnnotation: "A titled MCP Remote Proxy",
+					defaultRegistryURLAnnotation:         "https://example.com/proxy-titled",
+					defaultRegistryTitleAnnotation:       "My Proxy Title",
+				},
+			),
+			wantSchema:  "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+			wantName:    "com.toolhive.k8s.default/titled-proxy",
+			wantVersion: "1.0.0",
+			wantErr:     false,
+			//nolint:thelper // We want to see these lines in the test output
+			checkMeta: func(t *testing.T, sj *upstreamv0.ServerJSON) {
+				assert.Equal(t, "My Proxy Title", sj.Title)
+				assert.Equal(t, "A titled MCP Remote Proxy", sj.Description)
+				require.Len(t, sj.Remotes, 1)
+				assert.Equal(t, "https://example.com/proxy-titled", sj.Remotes[0].URL)
 			},
 		},
 		{


### PR DESCRIPTION
The following PR:
- Add `toolhive.stacklok.dev/registry-title` annotation support for setting a human-friendly display name on registry entries
- When present, populates the `Title` field on `ServerJSON` for `MCPServer`, `VirtualMCPServer`, and `MCPRemoteProxy` resources
- The reverse-DNS `Name` field remains unchanged

Closes #550
