### PR TITLE
Fix `registry_entry` uniqueness constraint

### DIFF
--- a/database/migrations/000013_fix_registry_entry_unique.down.sql
+++ b/database/migrations/000013_fix_registry_entry_unique.down.sql
@@ -1,0 +1,5 @@
+-- Revert to the original unique constraint without entry_type.
+
+ALTER TABLE registry_entry DROP CONSTRAINT registry_entry_reg_id_entry_type_name_version_key;
+ALTER TABLE registry_entry ADD CONSTRAINT registry_entry_reg_id_name_version_key
+    UNIQUE (reg_id, name, version);

--- a/database/migrations/000013_fix_registry_entry_unique.up.sql
+++ b/database/migrations/000013_fix_registry_entry_unique.up.sql
@@ -1,0 +1,7 @@
+-- Fix the unique constraint on registry_entry to include entry_type.
+-- Without entry_type, an MCP server and a skill with the same name and version
+-- under the same registry would conflict.
+
+ALTER TABLE registry_entry DROP CONSTRAINT registry_entry_reg_id_name_version_key;
+ALTER TABLE registry_entry ADD CONSTRAINT registry_entry_reg_id_entry_type_name_version_key
+    UNIQUE (reg_id, entry_type, name, version);

--- a/database/queries/temp_tables.sql
+++ b/database/queries/temp_tables.sql
@@ -23,9 +23,8 @@ SELECT id,
        created_at,
        updated_at
   FROM temp_registry_entry
-    ON CONFLICT (reg_id, name, version)
+    ON CONFLICT (reg_id, entry_type, name, version)
     DO UPDATE SET
-      entry_type = EXCLUDED.entry_type,
       title = EXCLUDED.title,
       description = EXCLUDED.description,
       updated_at = EXCLUDED.updated_at

--- a/internal/db/sqlc/temp_tables.sql.go
+++ b/internal/db/sqlc/temp_tables.sql.go
@@ -173,9 +173,8 @@ SELECT id,
        created_at,
        updated_at
   FROM temp_registry_entry
-    ON CONFLICT (reg_id, name, version)
+    ON CONFLICT (reg_id, entry_type, name, version)
     DO UPDATE SET
-      entry_type = EXCLUDED.entry_type,
       title = EXCLUDED.title,
       description = EXCLUDED.description,
       updated_at = EXCLUDED.updated_at


### PR DESCRIPTION
A registry is supposed to contain both skills and MCP servers, each having its own set of non-conflicting names. This means that it must be possible to have a skill named `github` and an MCP server named `github` in the same registry as separate entries.

This was not possible due to a bug in the data model that only checked `name` and `version` and was not taking `entry_type` into account.

This change replaces the existing uniqueness constraint with one encompassing `entry_type`.