### PR TITLE
Split registry entries from their versions

### DIFF
--- a/database/migrations/000014_split_entry_version.down.sql
+++ b/database/migrations/000014_split_entry_version.down.sql
@@ -1,0 +1,112 @@
+-- Rollback: Merge entry_version back into registry_entry
+
+-- =============================================================================
+-- Step 1: Drop entry_version → registry_entry FK
+-- =============================================================================
+ALTER TABLE entry_version DROP CONSTRAINT entry_version_entry_id_fkey;
+
+-- =============================================================================
+-- Step 2: Drop child table FKs that reference entry_version(id) and
+--         child table FKs that reference mcp_server(version_id)
+-- =============================================================================
+ALTER TABLE mcp_server DROP CONSTRAINT mcp_server_version_id_fkey;
+ALTER TABLE skill DROP CONSTRAINT skill_version_id_fkey;
+ALTER TABLE latest_entry_version DROP CONSTRAINT latest_entry_version_latest_version_id_fkey;
+ALTER TABLE mcp_server_package DROP CONSTRAINT mcp_server_package_server_id_fkey;
+ALTER TABLE mcp_server_remote DROP CONSTRAINT mcp_server_remote_server_id_fkey;
+ALTER TABLE mcp_server_icon DROP CONSTRAINT mcp_server_icon_server_id_fkey;
+ALTER TABLE skill_oci_package DROP CONSTRAINT skill_oci_package_skill_id_fkey;
+ALTER TABLE skill_git_package DROP CONSTRAINT skill_git_package_skill_id_fkey;
+
+-- =============================================================================
+-- Step 3: Rename columns back to original names
+-- =============================================================================
+ALTER TABLE mcp_server RENAME COLUMN version_id TO entry_id;
+ALTER TABLE skill RENAME COLUMN version_id TO entry_id;
+ALTER TABLE mcp_server_package RENAME COLUMN server_id TO entry_id;
+ALTER TABLE mcp_server_remote RENAME COLUMN server_id TO entry_id;
+ALTER TABLE mcp_server_icon RENAME COLUMN server_id TO entry_id;
+ALTER TABLE skill_oci_package RENAME COLUMN skill_id TO skill_entry_id;
+ALTER TABLE skill_git_package RENAME COLUMN skill_id TO skill_entry_id;
+
+-- =============================================================================
+-- Step 4: Restore version-specific columns on registry_entry
+-- =============================================================================
+ALTER TABLE registry_entry DROP CONSTRAINT registry_entry_reg_id_entry_type_name_key;
+ALTER TABLE registry_entry ADD COLUMN version TEXT;
+ALTER TABLE registry_entry ADD COLUMN title TEXT;
+ALTER TABLE registry_entry ADD COLUMN description TEXT;
+
+-- =============================================================================
+-- Step 5: Re-create registry_entry rows for non-canonical versions
+-- (these were deleted during the up migration)
+-- =============================================================================
+INSERT INTO registry_entry (id, reg_id, entry_type, name, version, title, description, created_at, updated_at)
+SELECT ev.id,
+       re.reg_id,
+       re.entry_type,
+       re.name,
+       ev.version,
+       ev.title,
+       ev.description,
+       ev.created_at,
+       ev.updated_at
+  FROM entry_version ev
+  JOIN registry_entry re ON ev.entry_id = re.id
+ WHERE ev.id != re.id;
+
+-- =============================================================================
+-- Step 6: Restore version data on the canonical registry_entry rows
+-- =============================================================================
+UPDATE registry_entry re
+   SET version     = ev.version,
+       title       = ev.title,
+       description = ev.description,
+       created_at  = ev.created_at,
+       updated_at  = ev.updated_at
+  FROM entry_version ev
+ WHERE re.id = ev.id;
+
+-- =============================================================================
+-- Step 7: Restore NOT NULL and unique constraint
+-- =============================================================================
+ALTER TABLE registry_entry ALTER COLUMN version SET NOT NULL;
+ALTER TABLE registry_entry ADD CONSTRAINT registry_entry_reg_id_entry_type_name_version_key
+    UNIQUE (reg_id, entry_type, name, version);
+
+-- =============================================================================
+-- Step 8: Point child table FKs back to registry_entry(id) and
+--         recreate child table FKs to mcp_server(entry_id)
+-- =============================================================================
+ALTER TABLE mcp_server ADD CONSTRAINT mcp_server_entry_id_fkey
+    FOREIGN KEY (entry_id) REFERENCES registry_entry(id) ON DELETE CASCADE;
+
+ALTER TABLE skill ADD CONSTRAINT skill_entry_id_fkey
+    FOREIGN KEY (entry_id) REFERENCES registry_entry(id) ON DELETE CASCADE;
+
+ALTER TABLE latest_entry_version RENAME COLUMN latest_version_id TO latest_entry_id;
+
+ALTER TABLE latest_entry_version ADD CONSTRAINT latest_entry_version_latest_entry_id_fkey
+    FOREIGN KEY (latest_entry_id) REFERENCES registry_entry(id) ON DELETE CASCADE;
+
+ALTER TABLE mcp_server_package ADD CONSTRAINT mcp_server_package_entry_id_fkey
+    FOREIGN KEY (entry_id) REFERENCES mcp_server(entry_id) ON DELETE CASCADE;
+
+ALTER TABLE mcp_server_remote ADD CONSTRAINT mcp_server_remote_entry_id_fkey
+    FOREIGN KEY (entry_id) REFERENCES mcp_server(entry_id) ON DELETE CASCADE;
+
+ALTER TABLE mcp_server_icon ADD CONSTRAINT mcp_server_icon_entry_id_fkey
+    FOREIGN KEY (entry_id) REFERENCES mcp_server(entry_id) ON DELETE CASCADE;
+
+ALTER TABLE skill_oci_package ADD CONSTRAINT skill_oci_package_skill_entry_id_fkey
+    FOREIGN KEY (skill_entry_id) REFERENCES skill(entry_id) ON DELETE CASCADE;
+
+ALTER TABLE skill_git_package ADD CONSTRAINT skill_git_package_skill_entry_id_fkey
+    FOREIGN KEY (skill_entry_id) REFERENCES skill(entry_id) ON DELETE CASCADE;
+
+-- =============================================================================
+-- Step 9: Drop entry_version table and its indexes
+-- =============================================================================
+DROP INDEX IF EXISTS entry_version_version_idx;
+DROP INDEX IF EXISTS entry_version_entry_id_idx;
+DROP TABLE entry_version;

--- a/database/migrations/000014_split_entry_version.up.sql
+++ b/database/migrations/000014_split_entry_version.up.sql
@@ -1,0 +1,154 @@
+-- Migration: Split registry_entry into registry_entry (name + non-version metadata)
+-- and entry_version (version-specific details).
+--
+-- Currently each registry_entry row represents a (name, version) pair.
+-- After this migration:
+--   registry_entry  = one row per unique (reg_id, entry_type, name)
+--   entry_version   = one row per (entry, version), carrying title/description
+--
+-- entry_version.id reuses the old registry_entry.id values so that existing
+-- FK references from mcp_server, skill, and latest_entry_version remain valid
+-- — only the constraint targets change.
+
+-- =============================================================================
+-- Step 1: Create entry_version table
+-- =============================================================================
+CREATE TABLE entry_version (
+    id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    entry_id    UUID NOT NULL,
+    version     TEXT NOT NULL,
+    title       TEXT,
+    description TEXT,
+    created_at  TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    updated_at  TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+-- =============================================================================
+-- Step 2: Pick one canonical registry_entry row per (reg_id, entry_type, name)
+-- =============================================================================
+CREATE TEMP TABLE _canonical AS
+SELECT DISTINCT ON (reg_id, entry_type, name)
+       id AS canonical_id,
+       reg_id,
+       entry_type,
+       name
+  FROM registry_entry
+ ORDER BY reg_id, entry_type, name, id;
+
+-- =============================================================================
+-- Step 3: Populate entry_version from existing registry_entry rows
+--   entry_version.id       = old registry_entry.id  (preserves child FK values)
+--   entry_version.entry_id = canonical id for this (reg_id, entry_type, name)
+-- =============================================================================
+INSERT INTO entry_version (id, entry_id, version, title, description, created_at, updated_at)
+SELECT re.id,
+       c.canonical_id,
+       re.version,
+       re.title,
+       re.description,
+       re.created_at,
+       re.updated_at
+  FROM registry_entry re
+  JOIN _canonical c ON re.reg_id = c.reg_id
+                   AND re.entry_type = c.entry_type
+                   AND re.name = c.name;
+
+-- =============================================================================
+-- Step 4: Drop FK constraints that reference registry_entry(id) and
+--         child table FKs that reference mcp_server(entry_id)
+-- =============================================================================
+ALTER TABLE mcp_server DROP CONSTRAINT mcp_server_entry_id_fkey;
+ALTER TABLE skill DROP CONSTRAINT skill_entry_id_fkey;
+ALTER TABLE latest_entry_version DROP CONSTRAINT latest_entry_version_latest_entry_id_fkey;
+ALTER TABLE mcp_server_package DROP CONSTRAINT mcp_server_package_entry_id_fkey;
+ALTER TABLE mcp_server_remote DROP CONSTRAINT mcp_server_remote_entry_id_fkey;
+ALTER TABLE mcp_server_icon DROP CONSTRAINT mcp_server_icon_entry_id_fkey;
+ALTER TABLE skill_oci_package DROP CONSTRAINT skill_oci_package_skill_entry_id_fkey;
+ALTER TABLE skill_git_package DROP CONSTRAINT skill_git_package_skill_entry_id_fkey;
+
+-- =============================================================================
+-- Step 5: Rename columns
+--   mcp_server.entry_id          → version_id  (now references entry_version)
+--   skill.entry_id               → version_id  (now references entry_version)
+--   mcp_server_{package,remote,icon}.entry_id → server_id
+--   skill_{oci,git}_package.skill_entry_id    → skill_id
+--   latest_entry_version.latest_entry_id      → latest_version_id
+-- =============================================================================
+ALTER TABLE mcp_server RENAME COLUMN entry_id TO version_id;
+ALTER TABLE skill RENAME COLUMN entry_id TO version_id;
+ALTER TABLE mcp_server_package RENAME COLUMN entry_id TO server_id;
+ALTER TABLE mcp_server_remote RENAME COLUMN entry_id TO server_id;
+ALTER TABLE mcp_server_icon RENAME COLUMN entry_id TO server_id;
+ALTER TABLE skill_oci_package RENAME COLUMN skill_entry_id TO skill_id;
+ALTER TABLE skill_git_package RENAME COLUMN skill_entry_id TO skill_id;
+ALTER TABLE latest_entry_version RENAME COLUMN latest_entry_id TO latest_version_id;
+
+-- =============================================================================
+-- Step 6: Recreate FKs with new column names, pointing to entry_version(id)
+-- =============================================================================
+ALTER TABLE mcp_server ADD CONSTRAINT mcp_server_version_id_fkey
+    FOREIGN KEY (version_id) REFERENCES entry_version(id) ON DELETE CASCADE;
+
+ALTER TABLE skill ADD CONSTRAINT skill_version_id_fkey
+    FOREIGN KEY (version_id) REFERENCES entry_version(id) ON DELETE CASCADE;
+
+ALTER TABLE latest_entry_version ADD CONSTRAINT latest_entry_version_latest_version_id_fkey
+    FOREIGN KEY (latest_version_id) REFERENCES entry_version(id) ON DELETE CASCADE;
+
+ALTER TABLE mcp_server_package ADD CONSTRAINT mcp_server_package_server_id_fkey
+    FOREIGN KEY (server_id) REFERENCES mcp_server(version_id) ON DELETE CASCADE;
+
+ALTER TABLE mcp_server_remote ADD CONSTRAINT mcp_server_remote_server_id_fkey
+    FOREIGN KEY (server_id) REFERENCES mcp_server(version_id) ON DELETE CASCADE;
+
+ALTER TABLE mcp_server_icon ADD CONSTRAINT mcp_server_icon_server_id_fkey
+    FOREIGN KEY (server_id) REFERENCES mcp_server(version_id) ON DELETE CASCADE;
+
+ALTER TABLE skill_oci_package ADD CONSTRAINT skill_oci_package_skill_id_fkey
+    FOREIGN KEY (skill_id) REFERENCES skill(version_id) ON DELETE CASCADE;
+
+ALTER TABLE skill_git_package ADD CONSTRAINT skill_git_package_skill_id_fkey
+    FOREIGN KEY (skill_id) REFERENCES skill(version_id) ON DELETE CASCADE;
+
+-- =============================================================================
+-- Step 7: Delete non-canonical registry_entry rows and update timestamps
+-- =============================================================================
+DELETE FROM registry_entry
+ WHERE id NOT IN (SELECT canonical_id FROM _canonical);
+
+UPDATE registry_entry re
+   SET created_at = agg.min_created,
+       updated_at = agg.max_updated
+  FROM (
+    SELECT entry_id,
+           MIN(created_at) AS min_created,
+           MAX(updated_at) AS max_updated
+      FROM entry_version
+     GROUP BY entry_id
+  ) agg
+ WHERE re.id = agg.entry_id;
+
+DROP TABLE _canonical;
+
+-- =============================================================================
+-- Step 8: Remove version-specific columns from registry_entry
+-- =============================================================================
+ALTER TABLE registry_entry DROP CONSTRAINT registry_entry_reg_id_entry_type_name_version_key;
+ALTER TABLE registry_entry DROP COLUMN version;
+ALTER TABLE registry_entry DROP COLUMN title;
+ALTER TABLE registry_entry DROP COLUMN description;
+
+ALTER TABLE registry_entry ADD CONSTRAINT registry_entry_reg_id_entry_type_name_key
+    UNIQUE (reg_id, entry_type, name);
+
+-- =============================================================================
+-- Step 9: Add FK and indexes on entry_version
+-- =============================================================================
+ALTER TABLE entry_version ADD CONSTRAINT entry_version_entry_id_fkey
+    FOREIGN KEY (entry_id) REFERENCES registry_entry(id) ON DELETE CASCADE;
+
+ALTER TABLE entry_version ADD CONSTRAINT entry_version_entry_id_version_key
+    UNIQUE (entry_id, version);
+
+CREATE INDEX entry_version_entry_id_idx ON entry_version(entry_id);
+CREATE INDEX entry_version_version_idx ON entry_version(version);

--- a/database/queries/registry_entries.sql
+++ b/database/queries/registry_entries.sql
@@ -1,20 +1,21 @@
+-- name: GetRegistryEntryByName :one
+SELECT id
+  FROM registry_entry
+ WHERE reg_id = sqlc.arg(reg_id)
+   AND entry_type = sqlc.arg(entry_type)
+   AND name = sqlc.arg(name);
+
 -- name: InsertRegistryEntry :one
 INSERT INTO registry_entry (
     reg_id,
     entry_type,
     name,
-    title,
-    description,
-    version,
     created_at,
     updated_at
 ) VALUES (
     sqlc.arg(reg_id),
     sqlc.arg(entry_type),
     sqlc.arg(name),
-    sqlc.arg(title),
-    sqlc.arg(description),
-    sqlc.arg(version),
     sqlc.arg(created_at),
     sqlc.arg(updated_at)
 ) RETURNING id;
@@ -22,5 +23,35 @@ INSERT INTO registry_entry (
 -- name: DeleteRegistryEntry :execrows
 DELETE FROM registry_entry
 WHERE reg_id = sqlc.arg(reg_id)
-  AND name = sqlc.arg(name)
+  AND entry_type = sqlc.arg(entry_type)
+  AND name = sqlc.arg(name);
+
+-- name: InsertEntryVersion :one
+INSERT INTO entry_version (
+    entry_id,
+    version,
+    title,
+    description,
+    created_at,
+    updated_at
+) VALUES (
+    sqlc.arg(entry_id),
+    sqlc.arg(version),
+    sqlc.arg(title),
+    sqlc.arg(description),
+    sqlc.arg(created_at),
+    sqlc.arg(updated_at)
+) RETURNING id;
+
+-- name: DeleteEntryVersion :execrows
+DELETE FROM entry_version
+WHERE entry_id = sqlc.arg(entry_id)
   AND version = sqlc.arg(version);
+
+-- name: CountEntryVersions :one
+SELECT count(*) FROM entry_version
+WHERE entry_id = sqlc.arg(entry_id);
+
+-- name: DeleteRegistryEntryByID :execrows
+DELETE FROM registry_entry
+WHERE id = sqlc.arg(id);

--- a/database/queries/servers.sql
+++ b/database/queries/servers.sql
@@ -3,14 +3,14 @@
 -- The cursor_name and cursor_version parameters define the starting point.
 -- When cursor is provided, results start AFTER the specified (name, version) tuple.
 SELECT r.reg_type as registry_type,
-       e.id,
+       v.id,
        e.name,
-       e.version,
-       (l.latest_entry_id IS NOT NULL)::boolean AS is_latest,
-       e.created_at,
-       e.updated_at,
-       e.description,
-       e.title,
+       v.version,
+       (l.latest_version_id IS NOT NULL)::boolean AS is_latest,
+       v.created_at,
+       v.updated_at,
+       v.description,
+       v.title,
        s.website,
        s.upstream_meta,
        s.server_meta,
@@ -19,41 +19,42 @@ SELECT r.reg_type as registry_type,
        s.repository_subfolder,
        s.repository_type
   FROM mcp_server s
-  JOIN registry_entry e ON s.entry_id = e.id
+  JOIN entry_version v ON s.version_id = v.id
+  JOIN registry_entry e ON v.entry_id = e.id
   JOIN registry r ON e.reg_id = r.id
-  LEFT JOIN latest_entry_version l ON e.id = l.latest_entry_id
+  LEFT JOIN latest_entry_version l ON v.id = l.latest_version_id
  WHERE (sqlc.narg(registry_name)::text IS NULL OR r.name = sqlc.narg(registry_name)::text)
    AND (sqlc.narg(search)::text IS NULL OR (
        LOWER(e.name) LIKE LOWER('%' || sqlc.narg(search)::text || '%')
-       OR LOWER(e.title) LIKE LOWER('%' || sqlc.narg(search)::text || '%')
-       OR LOWER(e.description) LIKE LOWER('%' || sqlc.narg(search)::text || '%')
+       OR LOWER(v.title) LIKE LOWER('%' || sqlc.narg(search)::text || '%')
+       OR LOWER(v.description) LIKE LOWER('%' || sqlc.narg(search)::text || '%')
    ))
    -- Filter by updated_since if provided
-   AND (sqlc.narg(updated_since)::timestamp with time zone IS NULL OR e.updated_at > sqlc.narg(updated_since)::timestamp with time zone)
+   AND (sqlc.narg(updated_since)::timestamp with time zone IS NULL OR v.updated_at > sqlc.narg(updated_since)::timestamp with time zone)
    -- Compound cursor comparison: (name, version) > (cursor_name, cursor_version)
    -- This ensures deterministic pagination even when timestamps are identical
    AND (
        sqlc.narg(cursor_name)::text IS NULL
-       OR (e.name, e.version) > (sqlc.narg(cursor_name)::text, sqlc.narg(cursor_version)::text)
+       OR (e.name, v.version) > (sqlc.narg(cursor_name)::text, sqlc.narg(cursor_version)::text)
    )
    AND (
        sqlc.narg(version)::text IS NULL OR
-       e.version = sqlc.narg(version)::text OR
-       (sqlc.narg(version)::text = 'latest' AND l.latest_entry_id = e.id)
+       v.version = sqlc.narg(version)::text OR
+       (sqlc.narg(version)::text = 'latest' AND l.latest_version_id = v.id)
    )
- ORDER BY e.name ASC, e.version ASC
+ ORDER BY e.name ASC, v.version ASC
  LIMIT sqlc.arg(size)::bigint;
 
 -- name: ListServerVersions :many
 SELECT r.reg_type as registry_type,
-       e.id,
+       v.id,
        e.name,
-       e.version,
-       (l.latest_entry_id IS NOT NULL)::boolean AS is_latest,
-       e.created_at,
-       e.updated_at,
-       e.description,
-       e.title,
+       v.version,
+       (l.latest_version_id IS NOT NULL)::boolean AS is_latest,
+       v.created_at,
+       v.updated_at,
+       v.description,
+       v.title,
        s.website,
        s.upstream_meta,
        s.server_meta,
@@ -62,28 +63,29 @@ SELECT r.reg_type as registry_type,
        s.repository_subfolder,
        s.repository_type
   FROM mcp_server s
-  JOIN registry_entry e ON s.entry_id = e.id
+  JOIN entry_version v ON s.version_id = v.id
+  JOIN registry_entry e ON v.entry_id = e.id
   JOIN registry r ON e.reg_id = r.id
-  LEFT JOIN latest_entry_version l ON e.id = l.latest_entry_id
+  LEFT JOIN latest_entry_version l ON v.id = l.latest_version_id
  WHERE e.name = sqlc.arg(name)
    AND (sqlc.narg(registry_name)::text IS NULL OR r.name = sqlc.narg(registry_name)::text)
-   AND ((sqlc.narg(next)::timestamp with time zone IS NULL OR e.created_at > sqlc.narg(next))
-    AND (sqlc.narg(prev)::timestamp with time zone IS NULL OR e.created_at < sqlc.narg(prev)))
+   AND ((sqlc.narg(next)::timestamp with time zone IS NULL OR v.created_at > sqlc.narg(next))
+    AND (sqlc.narg(prev)::timestamp with time zone IS NULL OR v.created_at < sqlc.narg(prev)))
  ORDER BY
- CASE WHEN sqlc.narg(next)::timestamp with time zone IS NULL THEN e.created_at END ASC,
- CASE WHEN sqlc.narg(next)::timestamp with time zone IS NULL THEN e.version END DESC -- acts as tie breaker
+ CASE WHEN sqlc.narg(next)::timestamp with time zone IS NULL THEN v.created_at END ASC,
+ CASE WHEN sqlc.narg(next)::timestamp with time zone IS NULL THEN v.version END DESC -- acts as tie breaker
  LIMIT sqlc.arg(size)::bigint;
 
 -- name: GetServerVersion :one
 SELECT r.reg_type as registry_type,
-       e.id,
+       v.id,
        e.name,
-       e.version,
-       (l.latest_entry_id IS NOT NULL)::boolean AS is_latest,
-       e.created_at,
-       e.updated_at,
-       e.description,
-       e.title,
+       v.version,
+       (l.latest_version_id IS NOT NULL)::boolean AS is_latest,
+       v.created_at,
+       v.updated_at,
+       v.description,
+       v.title,
        s.website,
        s.upstream_meta,
        s.server_meta,
@@ -92,13 +94,14 @@ SELECT r.reg_type as registry_type,
        s.repository_subfolder,
        s.repository_type
   FROM mcp_server s
-  JOIN registry_entry e ON s.entry_id = e.id
+  JOIN entry_version v ON s.version_id = v.id
+  JOIN registry_entry e ON v.entry_id = e.id
   JOIN registry r ON e.reg_id = r.id
-  LEFT JOIN latest_entry_version l ON e.id = l.latest_entry_id
+  LEFT JOIN latest_entry_version l ON v.id = l.latest_version_id
  WHERE e.name = sqlc.arg(name)
    AND (
-       e.version = sqlc.arg(version)
-       OR (sqlc.arg(version) = 'latest' AND l.latest_entry_id = e.id)
+       v.version = sqlc.arg(version)
+       OR (sqlc.arg(version) = 'latest' AND l.latest_version_id = v.id)
    )
    AND (sqlc.narg(registry_name)::text IS NULL OR r.name = sqlc.narg(registry_name)::text);
 
@@ -109,7 +112,7 @@ SELECT l.version
    AND l.reg_id = sqlc.arg(reg_id);
 
 -- name: ListServerPackages :many
-SELECT p.entry_id,
+SELECT p.server_id,
        p.registry_type,
        p.pkg_registry_url,
        p.pkg_identifier,
@@ -123,23 +126,23 @@ SELECT p.entry_id,
        p.transport_url,
        p.transport_headers
   FROM mcp_server_package p
-  JOIN mcp_server s ON p.entry_id = s.entry_id
- WHERE s.entry_id = ANY(sqlc.slice(entry_ids)::UUID[])
+  JOIN mcp_server s ON p.server_id = s.version_id
+ WHERE s.version_id = ANY(sqlc.slice(version_ids)::UUID[])
  ORDER BY p.pkg_version DESC;
 
 -- name: ListServerRemotes :many
-SELECT r.entry_id,
+SELECT r.server_id,
        r.transport,
        r.transport_url,
        r.transport_headers
   FROM mcp_server_remote r
-  JOIN mcp_server s ON r.entry_id = s.entry_id
- WHERE s.entry_id = ANY(sqlc.slice(entry_ids)::UUID[])
+  JOIN mcp_server s ON r.server_id = s.version_id
+ WHERE s.version_id = ANY(sqlc.slice(version_ids)::UUID[])
  ORDER BY r.transport, r.transport_url;
 
 -- name: InsertServerVersion :one
 INSERT INTO mcp_server (
-    entry_id,
+    version_id,
     website,
     upstream_meta,
     server_meta,
@@ -148,7 +151,7 @@ INSERT INTO mcp_server (
     repository_subfolder,
     repository_type
 ) VALUES (
-    sqlc.arg(entry_id),
+    sqlc.arg(version_id),
     sqlc.narg(website),
     sqlc.narg(upstream_meta),
     sqlc.narg(server_meta),
@@ -157,29 +160,29 @@ INSERT INTO mcp_server (
     sqlc.narg(repository_subfolder),
     sqlc.narg(repository_type)
 )
-RETURNING entry_id;
+RETURNING version_id;
 
 -- name: UpsertLatestServerVersion :one
 INSERT INTO latest_entry_version (
     reg_id,
     name,
     version,
-    latest_entry_id
+    latest_version_id
 ) VALUES (
     sqlc.arg(reg_id),
     sqlc.arg(name),
     sqlc.arg(version),
-    sqlc.arg(entry_id)
+    sqlc.arg(version_id)
 ) ON CONFLICT (reg_id, name)
   DO UPDATE SET
     version = sqlc.arg(version),
-    latest_entry_id = sqlc.arg(entry_id)
-RETURNING latest_entry_id;
+    latest_version_id = sqlc.arg(version_id)
+RETURNING latest_version_id;
 
 -- name: InsertServerPackage :exec
 -- TODO: this seems unused
 INSERT INTO mcp_server_package (
-    entry_id,
+    server_id,
     registry_type,
     pkg_registry_url,
     pkg_identifier,
@@ -193,7 +196,7 @@ INSERT INTO mcp_server_package (
     transport_url,
     transport_headers
 ) VALUES (
-    sqlc.arg(entry_id),
+    sqlc.arg(server_id),
     sqlc.arg(registry_type),
     sqlc.arg(pkg_registry_url),
     sqlc.arg(pkg_identifier),
@@ -210,12 +213,12 @@ INSERT INTO mcp_server_package (
 
 -- name: InsertServerRemote :exec
 INSERT INTO mcp_server_remote (
-    entry_id,
+    server_id,
     transport,
     transport_url,
     transport_headers
 ) VALUES (
-    sqlc.arg(entry_id),
+    sqlc.arg(server_id),
     sqlc.arg(transport),
     sqlc.arg(transport_url),
     sqlc.narg(transport_headers)
@@ -223,12 +226,12 @@ INSERT INTO mcp_server_remote (
 
 -- name: InsertServerIcon :exec
 INSERT INTO mcp_server_icon (
-    entry_id,
+    server_id,
     source_uri,
     mime_type,
     theme
 ) VALUES (
-    sqlc.arg(entry_id),
+    sqlc.arg(server_id),
     sqlc.arg(source_uri),
     sqlc.arg(mime_type),
     sqlc.arg(theme)
@@ -238,7 +241,8 @@ INSERT INTO mcp_server_icon (
 WITH registry_entries AS (
     SELECT e.id
       FROM registry_entry e
-      JOIN mcp_server s ON e.id = s.entry_id
+      JOIN entry_version v ON v.entry_id = e.id
+      JOIN mcp_server s ON v.id = s.version_id
      WHERE e.reg_id = sqlc.arg(reg_id)
 )
 DELETE FROM registry_entry
@@ -246,7 +250,7 @@ DELETE FROM registry_entry
 
 -- name: InsertServerVersionForSync :one
 INSERT INTO mcp_server (
-    entry_id,
+    version_id,
     website,
     upstream_meta,
     server_meta,
@@ -255,7 +259,7 @@ INSERT INTO mcp_server (
     repository_subfolder,
     repository_type
 ) VALUES (
-    sqlc.arg(entry_id),
+    sqlc.arg(version_id),
     sqlc.narg(website),
     sqlc.narg(upstream_meta),
     sqlc.narg(server_meta),
@@ -264,11 +268,11 @@ INSERT INTO mcp_server (
     sqlc.narg(repository_subfolder),
     sqlc.narg(repository_type)
 )
-RETURNING entry_id;
+RETURNING version_id;
 
 -- name: UpsertServerVersionForSync :one
 INSERT INTO mcp_server (
-    entry_id,
+    version_id,
     website,
     upstream_meta,
     server_meta,
@@ -277,7 +281,7 @@ INSERT INTO mcp_server (
     repository_subfolder,
     repository_type
 ) VALUES (
-    sqlc.arg(entry_id),
+    sqlc.arg(version_id),
     sqlc.narg(website),
     sqlc.narg(upstream_meta),
     sqlc.narg(server_meta),
@@ -286,7 +290,7 @@ INSERT INTO mcp_server (
     sqlc.narg(repository_subfolder),
     sqlc.narg(repository_type)
 )
-ON CONFLICT (entry_id)
+ON CONFLICT (version_id)
 DO UPDATE SET
     website = sqlc.narg(website),
     upstream_meta = sqlc.narg(upstream_meta),
@@ -295,32 +299,34 @@ DO UPDATE SET
     repository_id = sqlc.narg(repository_id),
     repository_subfolder = sqlc.narg(repository_subfolder),
     repository_type = sqlc.narg(repository_type)
-RETURNING entry_id;
+RETURNING version_id;
 
 -- name: DeleteOrphanedServers :exec
 WITH subset AS (
-    SELECT e.id
-      FROM registry_entry e
-     WHERE reg_id = sqlc.arg(reg_id)
-       AND e.id != ALL(sqlc.slice(keep_ids)::UUID[])
+    SELECT v.id
+      FROM entry_version v
+      JOIN registry_entry e ON v.entry_id = e.id
+     WHERE e.reg_id = sqlc.arg(reg_id)
+       AND v.id != ALL(sqlc.slice(keep_ids)::UUID[])
 )
-DELETE FROM mcp_server s
-WHERE s.entry_id IN (SELECT id FROM subset);
+DELETE FROM entry_version v
+WHERE v.id IN (SELECT id FROM subset);
 
 -- name: DeleteServerPackagesByServerId :exec
 DELETE FROM mcp_server_package
-WHERE entry_id = sqlc.arg(entry_id);
+WHERE server_id = sqlc.arg(server_id);
 
 -- name: DeleteServerRemotesByServerId :exec
 DELETE FROM mcp_server_remote
-WHERE entry_id = sqlc.arg(entry_id);
+WHERE server_id = sqlc.arg(server_id);
 
 -- name: DeleteServerIconsByServerId :exec
 DELETE FROM mcp_server_icon
-WHERE entry_id = sqlc.arg(entry_id);
+WHERE server_id = sqlc.arg(server_id);
 
 -- name: GetServerIDsByRegistryNameVersion :many
-SELECT entry_id, name, version
-FROM registry_entry e
-JOIN mcp_server s ON e.id = s.entry_id
-WHERE e.reg_id = sqlc.arg(reg_id);
+SELECT s.version_id, e.name, v.version
+  FROM entry_version v
+  JOIN registry_entry e ON e.id = v.entry_id
+  JOIN mcp_server s ON v.id = s.version_id
+ WHERE e.reg_id = sqlc.arg(reg_id);

--- a/database/queries/skills.sql
+++ b/database/queries/skills.sql
@@ -3,14 +3,14 @@
 -- The cursor_name and cursor_version parameters define the starting point.
 -- When cursor is provided, results start AFTER the specified (name, version) tuple.
 SELECT r.reg_type AS registry_type,
-       s.entry_id,
+       s.version_id,
        e.name,
-       e.version,
-       (l.latest_entry_id IS NOT NULL)::boolean AS is_latest,
-       e.created_at,
-       e.updated_at,
-       e.description,
-       e.title,
+       v.version,
+       (l.latest_version_id IS NOT NULL)::boolean AS is_latest,
+       v.created_at,
+       v.updated_at,
+       v.description,
+       v.title,
        s.namespace,
        s.status,
        s.license,
@@ -21,36 +21,37 @@ SELECT r.reg_type AS registry_type,
        s.metadata,
        s.extension_meta
   FROM skill s
-  JOIN registry_entry e ON s.entry_id = e.id
+  JOIN entry_version v ON s.version_id = v.id
+  JOIN registry_entry e ON v.entry_id = e.id
   JOIN registry r ON e.reg_id = r.id
-  LEFT JOIN latest_entry_version l ON e.id = l.latest_entry_id
+  LEFT JOIN latest_entry_version l ON v.id = l.latest_version_id
  WHERE (sqlc.narg(registry_name)::text IS NULL OR r.name = sqlc.narg(registry_name)::text)
    AND (sqlc.narg(namespace)::text IS NULL OR s.namespace = sqlc.narg(namespace)::text)
    AND (sqlc.narg(name)::text IS NULL OR e.name = sqlc.narg(name)::text)
    AND (sqlc.narg(search)::text IS NULL OR (
        LOWER(e.name) LIKE LOWER('%' || sqlc.narg(search)::text || '%')
-       OR LOWER(e.title) LIKE LOWER('%' || sqlc.narg(search)::text || '%')
-       OR LOWER(e.description) LIKE LOWER('%' || sqlc.narg(search)::text || '%')
+       OR LOWER(v.title) LIKE LOWER('%' || sqlc.narg(search)::text || '%')
+       OR LOWER(v.description) LIKE LOWER('%' || sqlc.narg(search)::text || '%')
    ))
-   AND (sqlc.narg(updated_since)::timestamp with time zone IS NULL OR e.updated_at > sqlc.narg(updated_since)::timestamp with time zone)
+   AND (sqlc.narg(updated_since)::timestamp with time zone IS NULL OR v.updated_at > sqlc.narg(updated_since)::timestamp with time zone)
    AND (
        sqlc.narg(cursor_name)::text IS NULL
-       OR (e.name, e.version) > (sqlc.narg(cursor_name)::text, sqlc.narg(cursor_version)::text)
+       OR (e.name, v.version) > (sqlc.narg(cursor_name)::text, sqlc.narg(cursor_version)::text)
    )
- ORDER BY e.name ASC, e.version ASC
+ ORDER BY e.name ASC, v.version ASC
  LIMIT sqlc.arg(size)::bigint;
 
 -- name: GetSkillVersion :one
 SELECT r.reg_type AS registry_type,
-       e.id,
+       v.id,
        e.name,
-       e.version,
-       (l.latest_entry_id IS NOT NULL)::boolean AS is_latest,
-       e.created_at,
-       e.updated_at,
-       e.description,
-       e.title,
-       s.entry_id AS skill_entry_id,
+       v.version,
+       (l.latest_version_id IS NOT NULL)::boolean AS is_latest,
+       v.created_at,
+       v.updated_at,
+       v.description,
+       v.title,
+       s.version_id AS skill_version_id,
        s.namespace,
        s.status,
        s.license,
@@ -61,40 +62,41 @@ SELECT r.reg_type AS registry_type,
        s.metadata,
        s.extension_meta
   FROM skill s
-  JOIN registry_entry e ON s.entry_id = e.id
+  JOIN entry_version v ON s.version_id = v.id
+  JOIN registry_entry e ON v.entry_id = e.id
   JOIN registry r ON e.reg_id = r.id
-  LEFT JOIN latest_entry_version l ON e.id = l.latest_entry_id
+  LEFT JOIN latest_entry_version l ON v.id = l.latest_version_id
  WHERE e.name = sqlc.arg(name)
-   AND (e.version = sqlc.arg(version)::text
-       OR (sqlc.arg(version)::text = 'latest' AND l.latest_entry_id = e.id)
+   AND (v.version = sqlc.arg(version)::text
+       OR (sqlc.arg(version)::text = 'latest' AND l.latest_version_id = v.id)
    )
    AND (sqlc.narg(registry_name)::text IS NULL OR r.name = sqlc.narg(registry_name)::text)
    AND (sqlc.narg(namespace)::text IS NULL OR s.namespace = sqlc.narg(namespace)::text);
 
 -- name: ListSkillOciPackages :many
 SELECT p.id,
-       p.skill_entry_id,
+       p.skill_id,
        p.identifier,
        p.digest,
        p.media_type
   FROM skill_oci_package p
-  JOIN skill s ON p.skill_entry_id = s.entry_id
- WHERE s.entry_id = ANY(sqlc.slice(entry_ids)::UUID[]);
+  JOIN skill s ON p.skill_id = s.version_id
+ WHERE s.version_id = ANY(sqlc.slice(version_ids)::UUID[]);
 
 -- name: ListSkillGitPackages :many
 SELECT p.id,
-       p.skill_entry_id,
+       p.skill_id,
        p.url,
        p.ref,
        p.commit_sha,
        p.subfolder
   FROM skill_git_package p
-  JOIN skill s ON p.skill_entry_id = s.entry_id
- WHERE s.entry_id = ANY(sqlc.slice(entry_ids)::UUID[]);
+  JOIN skill s ON p.skill_id = s.version_id
+ WHERE s.version_id = ANY(sqlc.slice(version_ids)::UUID[]);
 
 -- name: InsertSkillVersion :one
 INSERT INTO skill (
-    entry_id,
+    version_id,
     namespace,
     status,
     license,
@@ -105,7 +107,7 @@ INSERT INTO skill (
     metadata,
     extension_meta
 ) VALUES (
-    sqlc.arg(entry_id),
+    sqlc.arg(version_id),
     sqlc.arg(namespace),
     COALESCE(sqlc.narg(status)::skill_status, 'ACTIVE'),
     sqlc.narg(license),
@@ -116,33 +118,33 @@ INSERT INTO skill (
     sqlc.narg(metadata),
     sqlc.narg(extension_meta)
 )
-RETURNING entry_id;
+RETURNING version_id;
 
 -- name: UpsertLatestSkillVersion :one
 INSERT INTO latest_entry_version (
     reg_id,
     name,
     version,
-    latest_entry_id
+    latest_version_id
 ) VALUES (
     sqlc.arg(reg_id),
     sqlc.arg(name),
     sqlc.arg(version),
-    sqlc.arg(entry_id)
+    sqlc.arg(version_id)
 ) ON CONFLICT (reg_id, name)
   DO UPDATE SET
     version = sqlc.arg(version),
-    latest_entry_id = sqlc.arg(entry_id)
-RETURNING latest_entry_id;
+    latest_version_id = sqlc.arg(version_id)
+RETURNING latest_version_id;
 
 -- name: InsertSkillOciPackage :exec
 INSERT INTO skill_oci_package (
-    skill_entry_id,
+    skill_id,
     identifier,
     digest,
     media_type
 ) VALUES (
-    sqlc.arg(skill_entry_id),
+    sqlc.arg(skill_id),
     sqlc.arg(identifier),
     sqlc.narg(digest),
     sqlc.narg(media_type)
@@ -150,13 +152,13 @@ INSERT INTO skill_oci_package (
 
 -- name: InsertSkillGitPackage :exec
 INSERT INTO skill_git_package (
-    skill_entry_id,
+    skill_id,
     url,
     ref,
     commit_sha,
     subfolder
 ) VALUES (
-    sqlc.arg(skill_entry_id),
+    sqlc.arg(skill_id),
     sqlc.arg(url),
     sqlc.narg(ref),
     sqlc.narg(commit_sha),
@@ -164,18 +166,19 @@ INSERT INTO skill_git_package (
 );
 
 -- name: DeleteSkillsByRegistry :exec
-WITH registry_entries AS (
-    SELECT e.id
-      FROM registry_entry e
-      JOIN skill s ON e.id = s.entry_id
+WITH skill_entries AS (
+    SELECT DISTINCT v.entry_id
+      FROM entry_version v
+      JOIN registry_entry e ON v.entry_id = e.id
+      JOIN skill s ON v.id = s.version_id
      WHERE e.reg_id = sqlc.arg(reg_id)
 )
 DELETE FROM registry_entry
- WHERE id IN (SELECT id FROM registry_entries);
+ WHERE id IN (SELECT entry_id FROM skill_entries);
 
 -- name: InsertSkillVersionForSync :one
 INSERT INTO skill (
-    entry_id,
+    version_id,
     namespace,
     status,
     license,
@@ -186,7 +189,7 @@ INSERT INTO skill (
     metadata,
     extension_meta
 ) VALUES (
-    sqlc.arg(entry_id),
+    sqlc.arg(version_id),
     sqlc.arg(namespace),
     COALESCE(sqlc.narg(status)::skill_status, 'ACTIVE'),
     sqlc.narg(license),
@@ -197,11 +200,11 @@ INSERT INTO skill (
     sqlc.narg(metadata),
     sqlc.narg(extension_meta)
 )
-RETURNING entry_id;
+RETURNING version_id;
 
 -- name: UpsertSkillVersionForSync :one
 INSERT INTO skill (
-    entry_id,
+    version_id,
     namespace,
     status,
     license,
@@ -212,7 +215,7 @@ INSERT INTO skill (
     metadata,
     extension_meta
 ) VALUES (
-    sqlc.arg(entry_id),
+    sqlc.arg(version_id),
     sqlc.arg(namespace),
     COALESCE(sqlc.narg(status)::skill_status, 'ACTIVE'),
     sqlc.narg(license),
@@ -223,7 +226,7 @@ INSERT INTO skill (
     sqlc.narg(metadata),
     sqlc.narg(extension_meta)
 )
-ON CONFLICT (entry_id)
+ON CONFLICT (version_id)
 DO UPDATE SET
     status = COALESCE(sqlc.narg(status)::skill_status, skill.status),
     license = sqlc.narg(license),
@@ -233,14 +236,15 @@ DO UPDATE SET
     icons = sqlc.narg(icons),
     metadata = sqlc.narg(metadata),
     extension_meta = sqlc.narg(extension_meta)
-RETURNING entry_id;
+RETURNING version_id;
 
 -- name: DeleteOrphanedSkills :exec
 WITH subset AS (
-    SELECT e.id
-      FROM registry_entry e
-     WHERE reg_id = sqlc.arg(reg_id)
-       AND e.id != ALL(sqlc.slice(keep_ids)::UUID[])
+    SELECT v.id
+      FROM entry_version v
+      JOIN registry_entry e ON v.entry_id = e.id
+     WHERE e.reg_id = sqlc.arg(reg_id)
+       AND v.id != ALL(sqlc.slice(keep_ids)::UUID[])
 )
 DELETE FROM skill s
- WHERE s.entry_id IN (SELECT id FROM subset);
+ WHERE s.version_id IN (SELECT id FROM subset);

--- a/database/queries/temp_tables.sql
+++ b/database/queries/temp_tables.sql
@@ -11,24 +11,47 @@ SELECT * FROM registry_entry
 
 -- name: UpsertRegistryEntriesFromTemp :many
 INSERT INTO registry_entry (
-    id, reg_id, entry_type, name, title, description, version, created_at, updated_at
+    id, reg_id, entry_type, name, created_at, updated_at
 )
 SELECT id,
        reg_id,
        entry_type,
        name,
-       title,
-       description,
-       version,
        created_at,
        updated_at
   FROM temp_registry_entry
-    ON CONFLICT (reg_id, entry_type, name, version)
+    ON CONFLICT (reg_id, entry_type, name)
+    DO UPDATE SET
+      updated_at = EXCLUDED.updated_at
+RETURNING id, reg_id, entry_type, name;
+
+-- Temp Entry Version Table Operations
+
+-- name: CreateTempEntryVersionTable :exec
+CREATE TEMP TABLE temp_entry_version ON COMMIT DROP AS
+SELECT * FROM entry_version
+  WITH NO DATA;
+
+-- name: UpsertEntryVersionsFromTemp :many
+INSERT INTO entry_version (
+    id, entry_id, version, title, description, created_at, updated_at
+)
+SELECT id,
+       entry_id,
+       version,
+       title,
+       description,
+       created_at,
+       updated_at
+  FROM temp_entry_version
+    ON CONFLICT (entry_id, version)
     DO UPDATE SET
       title = EXCLUDED.title,
       description = EXCLUDED.description,
       updated_at = EXCLUDED.updated_at
-RETURNING id, reg_id, entry_type, name, version;
+RETURNING id, entry_id, version;
+
+-- Temp Server Table Operations
 
 -- name: CreateTempServerTable :exec
 CREATE TEMP TABLE temp_mcp_server ON COMMIT DROP AS
@@ -37,10 +60,10 @@ SELECT * FROM mcp_server
 
 -- name: UpsertServersFromTemp :exec
 INSERT INTO mcp_server (
-    entry_id, website, upstream_meta, server_meta,
+    version_id, website, upstream_meta, server_meta,
     repository_url, repository_id, repository_subfolder, repository_type
 )
-SELECT entry_id,
+SELECT version_id,
        website,
        upstream_meta,
        server_meta,
@@ -49,7 +72,7 @@ SELECT entry_id,
        repository_subfolder,
        repository_type
 FROM temp_mcp_server
-  ON CONFLICT (entry_id)
+  ON CONFLICT (version_id)
   DO UPDATE SET
     website = EXCLUDED.website,
     upstream_meta = EXCLUDED.upstream_meta,
@@ -68,16 +91,16 @@ SELECT * FROM mcp_server_package
 
 -- name: UpsertPackagesFromTemp :exec
 INSERT INTO mcp_server_package (
-    entry_id, registry_type, pkg_registry_url, pkg_identifier, pkg_version,
+    server_id, registry_type, pkg_registry_url, pkg_identifier, pkg_version,
     runtime_hint, runtime_arguments, package_arguments, env_vars, sha256_hash,
     transport, transport_url, transport_headers
 )
 SELECT
-    entry_id, registry_type, pkg_registry_url, pkg_identifier, pkg_version,
+    server_id, registry_type, pkg_registry_url, pkg_identifier, pkg_version,
     runtime_hint, runtime_arguments, package_arguments, env_vars, sha256_hash,
     transport, transport_url, transport_headers
 FROM temp_mcp_server_package
-ON CONFLICT (entry_id, registry_type, pkg_identifier, transport)
+ON CONFLICT (server_id, registry_type, pkg_identifier, transport)
 DO UPDATE SET
     pkg_registry_url = EXCLUDED.pkg_registry_url,
     pkg_version = EXCLUDED.pkg_version,
@@ -91,9 +114,9 @@ DO UPDATE SET
 
 -- name: DeleteOrphanedPackages :exec
 DELETE FROM mcp_server_package
-WHERE entry_id = ANY(sqlc.slice(entry_ids)::UUID[])
-  AND (entry_id, pkg_identifier, transport) NOT IN (
-    SELECT entry_id, pkg_identifier, transport FROM temp_mcp_server_package
+WHERE server_id = ANY(sqlc.slice(server_ids)::UUID[])
+  AND (server_id, pkg_identifier, transport) NOT IN (
+    SELECT server_id, pkg_identifier, transport FROM temp_mcp_server_package
   );
 
 -- Temp Remote Table Operations
@@ -104,17 +127,17 @@ SELECT * FROM mcp_server_remote
   WITH NO DATA;
 
 -- name: UpsertRemotesFromTemp :exec
-INSERT INTO mcp_server_remote (entry_id, transport, transport_url, transport_headers)
-SELECT entry_id, transport, transport_url, transport_headers
+INSERT INTO mcp_server_remote (server_id, transport, transport_url, transport_headers)
+SELECT server_id, transport, transport_url, transport_headers
 FROM temp_mcp_server_remote
-ON CONFLICT (entry_id, transport, transport_url)
+ON CONFLICT (server_id, transport, transport_url)
 DO UPDATE SET transport_headers = EXCLUDED.transport_headers;
 
 -- name: DeleteOrphanedRemotes :exec
 DELETE FROM mcp_server_remote
-WHERE entry_id = ANY(sqlc.slice(entry_ids)::UUID[])
-  AND (entry_id, transport, transport_url) NOT IN (
-    SELECT entry_id, transport, transport_url FROM temp_mcp_server_remote
+WHERE server_id = ANY(sqlc.slice(server_ids)::UUID[])
+  AND (server_id, transport, transport_url) NOT IN (
+    SELECT server_id, transport, transport_url FROM temp_mcp_server_remote
   );
 
 -- Temp Icon Table Operations
@@ -125,15 +148,15 @@ SELECT * FROM mcp_server_icon
   WITH NO DATA;
 
 -- name: UpsertIconsFromTemp :exec
-INSERT INTO mcp_server_icon (entry_id, source_uri, mime_type, theme)
-SELECT entry_id, source_uri, mime_type, theme::icon_theme
+INSERT INTO mcp_server_icon (server_id, source_uri, mime_type, theme)
+SELECT server_id, source_uri, mime_type, theme::icon_theme
 FROM temp_mcp_server_icon
-ON CONFLICT (entry_id, source_uri, mime_type, theme)
+ON CONFLICT (server_id, source_uri, mime_type, theme)
 DO NOTHING;
 
 -- name: DeleteOrphanedIcons :exec
 DELETE FROM mcp_server_icon
-WHERE entry_id = ANY(sqlc.slice(entry_ids)::UUID[])
-  AND (entry_id, source_uri, mime_type, theme) NOT IN (
-    SELECT entry_id, source_uri, mime_type, theme FROM temp_mcp_server_icon
+WHERE server_id = ANY(sqlc.slice(server_ids)::UUID[])
+  AND (server_id, source_uri, mime_type, theme) NOT IN (
+    SELECT server_id, source_uri, mime_type, theme FROM temp_mcp_server_icon
   );

--- a/database/sqlc-schemas/temp_tables.sql
+++ b/database/sqlc-schemas/temp_tables.sql
@@ -9,15 +9,22 @@ CREATE TABLE temp_registry_entry (
     reg_id UUID NOT NULL,
     entry_type entry_type NOT NULL,
     name TEXT NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE,
+    updated_at TIMESTAMP WITH TIME ZONE
+);
+
+CREATE TABLE temp_entry_version (
+    id UUID PRIMARY KEY,
+    entry_id UUID NOT NULL,
+    version TEXT NOT NULL,
     title TEXT,
     description TEXT,
-    version TEXT NOT NULL,
     created_at TIMESTAMP WITH TIME ZONE,
     updated_at TIMESTAMP WITH TIME ZONE
 );
 
 CREATE TABLE temp_mcp_server (
-    entry_id UUID NOT NULL,
+    version_id UUID NOT NULL,
     website TEXT,
     upstream_meta JSONB,
     server_meta JSONB,

--- a/internal/db/sqlc/models.go
+++ b/internal/db/sqlc/models.go
@@ -269,11 +269,21 @@ func (ns NullSyncStatus) Value() (driver.Value, error) {
 	return string(ns.SyncStatus), nil
 }
 
+type EntryVersion struct {
+	ID          uuid.UUID  `json:"id"`
+	EntryID     uuid.UUID  `json:"entry_id"`
+	Version     string     `json:"version"`
+	Title       *string    `json:"title"`
+	Description *string    `json:"description"`
+	CreatedAt   *time.Time `json:"created_at"`
+	UpdatedAt   *time.Time `json:"updated_at"`
+}
+
 type LatestEntryVersion struct {
-	RegID         uuid.UUID `json:"reg_id"`
-	Name          string    `json:"name"`
-	Version       string    `json:"version"`
-	LatestEntryID uuid.UUID `json:"latest_entry_id"`
+	RegID           uuid.UUID `json:"reg_id"`
+	Name            string    `json:"name"`
+	Version         string    `json:"version"`
+	LatestVersionID uuid.UUID `json:"latest_version_id"`
 }
 
 type McpServer struct {
@@ -284,18 +294,18 @@ type McpServer struct {
 	RepositoryID        *string   `json:"repository_id"`
 	RepositorySubfolder *string   `json:"repository_subfolder"`
 	RepositoryType      *string   `json:"repository_type"`
-	EntryID             uuid.UUID `json:"entry_id"`
+	VersionID           uuid.UUID `json:"version_id"`
 }
 
 type McpServerIcon struct {
-	EntryID   uuid.UUID `json:"entry_id"`
+	ServerID  uuid.UUID `json:"server_id"`
 	SourceUri string    `json:"source_uri"`
 	MimeType  string    `json:"mime_type"`
 	Theme     IconTheme `json:"theme"`
 }
 
 type McpServerPackage struct {
-	EntryID          uuid.UUID `json:"entry_id"`
+	ServerID         uuid.UUID `json:"server_id"`
 	RegistryType     string    `json:"registry_type"`
 	PkgRegistryUrl   string    `json:"pkg_registry_url"`
 	PkgIdentifier    string    `json:"pkg_identifier"`
@@ -311,7 +321,7 @@ type McpServerPackage struct {
 }
 
 type McpServerRemote struct {
-	EntryID          uuid.UUID `json:"entry_id"`
+	ServerID         uuid.UUID `json:"server_id"`
 	Transport        string    `json:"transport"`
 	TransportUrl     string    `json:"transport_url"`
 	TransportHeaders []byte    `json:"transport_headers"`
@@ -333,15 +343,12 @@ type Registry struct {
 }
 
 type RegistryEntry struct {
-	ID          uuid.UUID  `json:"id"`
-	RegID       uuid.UUID  `json:"reg_id"`
-	EntryType   EntryType  `json:"entry_type"`
-	Name        string     `json:"name"`
-	Title       *string    `json:"title"`
-	Description *string    `json:"description"`
-	Version     string     `json:"version"`
-	CreatedAt   *time.Time `json:"created_at"`
-	UpdatedAt   *time.Time `json:"updated_at"`
+	ID        uuid.UUID  `json:"id"`
+	RegID     uuid.UUID  `json:"reg_id"`
+	EntryType EntryType  `json:"entry_type"`
+	Name      string     `json:"name"`
+	CreatedAt *time.Time `json:"created_at"`
+	UpdatedAt *time.Time `json:"updated_at"`
 }
 
 type RegistrySync struct {
@@ -358,7 +365,7 @@ type RegistrySync struct {
 }
 
 type Skill struct {
-	EntryID       uuid.UUID   `json:"entry_id"`
+	VersionID     uuid.UUID   `json:"version_id"`
 	Namespace     string      `json:"namespace"`
 	Status        SkillStatus `json:"status"`
 	License       *string     `json:"license"`
@@ -371,24 +378,34 @@ type Skill struct {
 }
 
 type SkillGitPackage struct {
-	ID           uuid.UUID `json:"id"`
-	SkillEntryID uuid.UUID `json:"skill_entry_id"`
-	Url          string    `json:"url"`
-	Ref          *string   `json:"ref"`
-	CommitSha    *string   `json:"commit_sha"`
-	Subfolder    *string   `json:"subfolder"`
+	ID        uuid.UUID `json:"id"`
+	SkillID   uuid.UUID `json:"skill_id"`
+	Url       string    `json:"url"`
+	Ref       *string   `json:"ref"`
+	CommitSha *string   `json:"commit_sha"`
+	Subfolder *string   `json:"subfolder"`
 }
 
 type SkillOciPackage struct {
-	ID           uuid.UUID `json:"id"`
-	SkillEntryID uuid.UUID `json:"skill_entry_id"`
-	Identifier   string    `json:"identifier"`
-	Digest       *string   `json:"digest"`
-	MediaType    *string   `json:"media_type"`
+	ID         uuid.UUID `json:"id"`
+	SkillID    uuid.UUID `json:"skill_id"`
+	Identifier string    `json:"identifier"`
+	Digest     *string   `json:"digest"`
+	MediaType  *string   `json:"media_type"`
+}
+
+type TempEntryVersion struct {
+	ID          uuid.UUID  `json:"id"`
+	EntryID     uuid.UUID  `json:"entry_id"`
+	Version     string     `json:"version"`
+	Title       *string    `json:"title"`
+	Description *string    `json:"description"`
+	CreatedAt   *time.Time `json:"created_at"`
+	UpdatedAt   *time.Time `json:"updated_at"`
 }
 
 type TempMcpServer struct {
-	EntryID             uuid.UUID `json:"entry_id"`
+	VersionID           uuid.UUID `json:"version_id"`
 	Website             *string   `json:"website"`
 	UpstreamMeta        []byte    `json:"upstream_meta"`
 	ServerMeta          []byte    `json:"server_meta"`
@@ -429,13 +446,10 @@ type TempMcpServerRemote struct {
 }
 
 type TempRegistryEntry struct {
-	ID          uuid.UUID  `json:"id"`
-	RegID       uuid.UUID  `json:"reg_id"`
-	EntryType   EntryType  `json:"entry_type"`
-	Name        string     `json:"name"`
-	Title       *string    `json:"title"`
-	Description *string    `json:"description"`
-	Version     string     `json:"version"`
-	CreatedAt   *time.Time `json:"created_at"`
-	UpdatedAt   *time.Time `json:"updated_at"`
+	ID        uuid.UUID  `json:"id"`
+	RegID     uuid.UUID  `json:"reg_id"`
+	EntryType EntryType  `json:"entry_type"`
+	Name      string     `json:"name"`
+	CreatedAt *time.Time `json:"created_at"`
+	UpdatedAt *time.Time `json:"updated_at"`
 }

--- a/internal/db/sqlc/querier.go
+++ b/internal/db/sqlc/querier.go
@@ -14,6 +14,9 @@ type Querier interface {
 	BulkInitializeRegistrySyncs(ctx context.Context, arg BulkInitializeRegistrySyncsParams) error
 	// Bulk insert or update CONFIG registries (only updates existing CONFIG registries)
 	BulkUpsertConfigRegistries(ctx context.Context, arg BulkUpsertConfigRegistriesParams) ([]BulkUpsertConfigRegistriesRow, error)
+	CountEntryVersions(ctx context.Context, entryID uuid.UUID) (int64, error)
+	// Temp Entry Version Table Operations
+	CreateTempEntryVersionTable(ctx context.Context) error
 	// Temp Icon Table Operations
 	CreateTempIconTable(ctx context.Context) error
 	// Temp Package Table Operations
@@ -25,6 +28,7 @@ type Querier interface {
 	CreateTempRegistryEntryTable(ctx context.Context) error
 	// Temp Remote Table Operations
 	CreateTempRemoteTable(ctx context.Context) error
+	// Temp Server Table Operations
 	CreateTempServerTable(ctx context.Context) error
 	// Delete an API registry by name (returns 0 if not found or is CONFIG type)
 	DeleteAPIRegistry(ctx context.Context, name string) (int64, error)
@@ -32,21 +36,24 @@ type Querier interface {
 	DeleteConfigRegistriesNotInList(ctx context.Context, ids []uuid.UUID) error
 	// Delete a CONFIG registry by name (returns 0 if not found or is API type)
 	DeleteConfigRegistry(ctx context.Context, name string) (int64, error)
-	DeleteOrphanedIcons(ctx context.Context, entryIds []uuid.UUID) error
-	DeleteOrphanedPackages(ctx context.Context, entryIds []uuid.UUID) error
-	DeleteOrphanedRemotes(ctx context.Context, entryIds []uuid.UUID) error
+	DeleteEntryVersion(ctx context.Context, arg DeleteEntryVersionParams) (int64, error)
+	DeleteOrphanedIcons(ctx context.Context, serverIds []uuid.UUID) error
+	DeleteOrphanedPackages(ctx context.Context, serverIds []uuid.UUID) error
+	DeleteOrphanedRemotes(ctx context.Context, serverIds []uuid.UUID) error
 	DeleteOrphanedServers(ctx context.Context, arg DeleteOrphanedServersParams) error
 	DeleteOrphanedSkills(ctx context.Context, arg DeleteOrphanedSkillsParams) error
 	DeleteRegistryEntry(ctx context.Context, arg DeleteRegistryEntryParams) (int64, error)
-	DeleteServerIconsByServerId(ctx context.Context, entryID uuid.UUID) error
-	DeleteServerPackagesByServerId(ctx context.Context, entryID uuid.UUID) error
-	DeleteServerRemotesByServerId(ctx context.Context, entryID uuid.UUID) error
+	DeleteRegistryEntryByID(ctx context.Context, id uuid.UUID) (int64, error)
+	DeleteServerIconsByServerId(ctx context.Context, serverID uuid.UUID) error
+	DeleteServerPackagesByServerId(ctx context.Context, serverID uuid.UUID) error
+	DeleteServerRemotesByServerId(ctx context.Context, serverID uuid.UUID) error
 	DeleteServersByRegistry(ctx context.Context, regID uuid.UUID) error
 	DeleteSkillsByRegistry(ctx context.Context, regID uuid.UUID) error
 	GetAPIRegistriesByNames(ctx context.Context, names []string) ([]GetAPIRegistriesByNamesRow, error)
 	GetLatestVersionForServer(ctx context.Context, arg GetLatestVersionForServerParams) (string, error)
 	GetRegistry(ctx context.Context, id uuid.UUID) (GetRegistryRow, error)
 	GetRegistryByName(ctx context.Context, name string) (GetRegistryByNameRow, error)
+	GetRegistryEntryByName(ctx context.Context, arg GetRegistryEntryByNameParams) (uuid.UUID, error)
 	GetRegistrySync(ctx context.Context, id uuid.UUID) (RegistrySync, error)
 	GetRegistrySyncByName(ctx context.Context, name string) (RegistrySync, error)
 	GetServerIDsByRegistryNameVersion(ctx context.Context, regID uuid.UUID) ([]GetServerIDsByRegistryNameVersionRow, error)
@@ -63,6 +70,7 @@ type Querier interface {
 	// ============================================================================
 	// Insert a new CONFIG registry with full configuration
 	InsertConfigRegistry(ctx context.Context, arg InsertConfigRegistryParams) (uuid.UUID, error)
+	InsertEntryVersion(ctx context.Context, arg InsertEntryVersionParams) (uuid.UUID, error)
 	InsertRegistryEntry(ctx context.Context, arg InsertRegistryEntryParams) (uuid.UUID, error)
 	InsertRegistrySync(ctx context.Context, arg InsertRegistrySyncParams) (uuid.UUID, error)
 	InsertServerIcon(ctx context.Context, arg InsertServerIconParams) error
@@ -79,15 +87,15 @@ type Querier interface {
 	ListRegistries(ctx context.Context, arg ListRegistriesParams) ([]ListRegistriesRow, error)
 	ListRegistrySyncs(ctx context.Context) ([]ListRegistrySyncsRow, error)
 	ListRegistrySyncsByLastUpdate(ctx context.Context) ([]ListRegistrySyncsByLastUpdateRow, error)
-	ListServerPackages(ctx context.Context, entryIds []uuid.UUID) ([]ListServerPackagesRow, error)
-	ListServerRemotes(ctx context.Context, entryIds []uuid.UUID) ([]McpServerRemote, error)
+	ListServerPackages(ctx context.Context, versionIds []uuid.UUID) ([]ListServerPackagesRow, error)
+	ListServerRemotes(ctx context.Context, versionIds []uuid.UUID) ([]McpServerRemote, error)
 	ListServerVersions(ctx context.Context, arg ListServerVersionsParams) ([]ListServerVersionsRow, error)
 	// Cursor-based pagination using (name, version) compound cursor.
 	// The cursor_name and cursor_version parameters define the starting point.
 	// When cursor is provided, results start AFTER the specified (name, version) tuple.
 	ListServers(ctx context.Context, arg ListServersParams) ([]ListServersRow, error)
-	ListSkillGitPackages(ctx context.Context, entryIds []uuid.UUID) ([]SkillGitPackage, error)
-	ListSkillOciPackages(ctx context.Context, entryIds []uuid.UUID) ([]SkillOciPackage, error)
+	ListSkillGitPackages(ctx context.Context, versionIds []uuid.UUID) ([]SkillGitPackage, error)
+	ListSkillOciPackages(ctx context.Context, versionIds []uuid.UUID) ([]SkillOciPackage, error)
 	// Cursor-based pagination using (name, version) compound cursor.
 	// The cursor_name and cursor_version parameters define the starting point.
 	// When cursor is provided, results start AFTER the specified (name, version) tuple.
@@ -98,6 +106,7 @@ type Querier interface {
 	UpdateRegistrySyncStatusByName(ctx context.Context, arg UpdateRegistrySyncStatusByNameParams) error
 	// Insert or update a CONFIG registry (only updates if existing is CONFIG type)
 	UpsertConfigRegistry(ctx context.Context, arg UpsertConfigRegistryParams) (uuid.UUID, error)
+	UpsertEntryVersionsFromTemp(ctx context.Context) ([]UpsertEntryVersionsFromTempRow, error)
 	UpsertIconsFromTemp(ctx context.Context) error
 	UpsertLatestServerVersion(ctx context.Context, arg UpsertLatestServerVersionParams) (uuid.UUID, error)
 	UpsertLatestSkillVersion(ctx context.Context, arg UpsertLatestSkillVersionParams) (uuid.UUID, error)

--- a/internal/db/sqlc/registry_entries.sql.go
+++ b/internal/db/sqlc/registry_entries.sql.go
@@ -12,35 +12,98 @@ import (
 	"github.com/google/uuid"
 )
 
-const deleteRegistryEntry = `-- name: DeleteRegistryEntry :execrows
-DELETE FROM registry_entry
-WHERE reg_id = $1
-  AND name = $2
-  AND version = $3
+const countEntryVersions = `-- name: CountEntryVersions :one
+SELECT count(*) FROM entry_version
+WHERE entry_id = $1
 `
 
-type DeleteRegistryEntryParams struct {
-	RegID   uuid.UUID `json:"reg_id"`
-	Name    string    `json:"name"`
+func (q *Queries) CountEntryVersions(ctx context.Context, entryID uuid.UUID) (int64, error) {
+	row := q.db.QueryRow(ctx, countEntryVersions, entryID)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
+const deleteEntryVersion = `-- name: DeleteEntryVersion :execrows
+DELETE FROM entry_version
+WHERE entry_id = $1
+  AND version = $2
+`
+
+type DeleteEntryVersionParams struct {
+	EntryID uuid.UUID `json:"entry_id"`
 	Version string    `json:"version"`
 }
 
-func (q *Queries) DeleteRegistryEntry(ctx context.Context, arg DeleteRegistryEntryParams) (int64, error) {
-	result, err := q.db.Exec(ctx, deleteRegistryEntry, arg.RegID, arg.Name, arg.Version)
+func (q *Queries) DeleteEntryVersion(ctx context.Context, arg DeleteEntryVersionParams) (int64, error) {
+	result, err := q.db.Exec(ctx, deleteEntryVersion, arg.EntryID, arg.Version)
 	if err != nil {
 		return 0, err
 	}
 	return result.RowsAffected(), nil
 }
 
-const insertRegistryEntry = `-- name: InsertRegistryEntry :one
-INSERT INTO registry_entry (
-    reg_id,
-    entry_type,
-    name,
+const deleteRegistryEntry = `-- name: DeleteRegistryEntry :execrows
+DELETE FROM registry_entry
+WHERE reg_id = $1
+  AND entry_type = $2
+  AND name = $3
+`
+
+type DeleteRegistryEntryParams struct {
+	RegID     uuid.UUID `json:"reg_id"`
+	EntryType EntryType `json:"entry_type"`
+	Name      string    `json:"name"`
+}
+
+func (q *Queries) DeleteRegistryEntry(ctx context.Context, arg DeleteRegistryEntryParams) (int64, error) {
+	result, err := q.db.Exec(ctx, deleteRegistryEntry, arg.RegID, arg.EntryType, arg.Name)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
+const deleteRegistryEntryByID = `-- name: DeleteRegistryEntryByID :execrows
+DELETE FROM registry_entry
+WHERE id = $1
+`
+
+func (q *Queries) DeleteRegistryEntryByID(ctx context.Context, id uuid.UUID) (int64, error) {
+	result, err := q.db.Exec(ctx, deleteRegistryEntryByID, id)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
+const getRegistryEntryByName = `-- name: GetRegistryEntryByName :one
+SELECT id
+  FROM registry_entry
+ WHERE reg_id = $1
+   AND entry_type = $2
+   AND name = $3
+`
+
+type GetRegistryEntryByNameParams struct {
+	RegID     uuid.UUID `json:"reg_id"`
+	EntryType EntryType `json:"entry_type"`
+	Name      string    `json:"name"`
+}
+
+func (q *Queries) GetRegistryEntryByName(ctx context.Context, arg GetRegistryEntryByNameParams) (uuid.UUID, error) {
+	row := q.db.QueryRow(ctx, getRegistryEntryByName, arg.RegID, arg.EntryType, arg.Name)
+	var id uuid.UUID
+	err := row.Scan(&id)
+	return id, err
+}
+
+const insertEntryVersion = `-- name: InsertEntryVersion :one
+INSERT INTO entry_version (
+    entry_id,
+    version,
     title,
     description,
-    version,
     created_at,
     updated_at
 ) VALUES (
@@ -49,21 +112,55 @@ INSERT INTO registry_entry (
     $3,
     $4,
     $5,
-    $6,
-    $7,
-    $8
+    $6
+) RETURNING id
+`
+
+type InsertEntryVersionParams struct {
+	EntryID     uuid.UUID  `json:"entry_id"`
+	Version     string     `json:"version"`
+	Title       *string    `json:"title"`
+	Description *string    `json:"description"`
+	CreatedAt   *time.Time `json:"created_at"`
+	UpdatedAt   *time.Time `json:"updated_at"`
+}
+
+func (q *Queries) InsertEntryVersion(ctx context.Context, arg InsertEntryVersionParams) (uuid.UUID, error) {
+	row := q.db.QueryRow(ctx, insertEntryVersion,
+		arg.EntryID,
+		arg.Version,
+		arg.Title,
+		arg.Description,
+		arg.CreatedAt,
+		arg.UpdatedAt,
+	)
+	var id uuid.UUID
+	err := row.Scan(&id)
+	return id, err
+}
+
+const insertRegistryEntry = `-- name: InsertRegistryEntry :one
+INSERT INTO registry_entry (
+    reg_id,
+    entry_type,
+    name,
+    created_at,
+    updated_at
+) VALUES (
+    $1,
+    $2,
+    $3,
+    $4,
+    $5
 ) RETURNING id
 `
 
 type InsertRegistryEntryParams struct {
-	RegID       uuid.UUID  `json:"reg_id"`
-	EntryType   EntryType  `json:"entry_type"`
-	Name        string     `json:"name"`
-	Title       *string    `json:"title"`
-	Description *string    `json:"description"`
-	Version     string     `json:"version"`
-	CreatedAt   *time.Time `json:"created_at"`
-	UpdatedAt   *time.Time `json:"updated_at"`
+	RegID     uuid.UUID  `json:"reg_id"`
+	EntryType EntryType  `json:"entry_type"`
+	Name      string     `json:"name"`
+	CreatedAt *time.Time `json:"created_at"`
+	UpdatedAt *time.Time `json:"updated_at"`
 }
 
 func (q *Queries) InsertRegistryEntry(ctx context.Context, arg InsertRegistryEntryParams) (uuid.UUID, error) {
@@ -71,9 +168,6 @@ func (q *Queries) InsertRegistryEntry(ctx context.Context, arg InsertRegistryEnt
 		arg.RegID,
 		arg.EntryType,
 		arg.Name,
-		arg.Title,
-		arg.Description,
-		arg.Version,
 		arg.CreatedAt,
 		arg.UpdatedAt,
 	)

--- a/internal/db/sqlc/servers.sql.go
+++ b/internal/db/sqlc/servers.sql.go
@@ -14,13 +14,14 @@ import (
 
 const deleteOrphanedServers = `-- name: DeleteOrphanedServers :exec
 WITH subset AS (
-    SELECT e.id
-      FROM registry_entry e
-     WHERE reg_id = $1
-       AND e.id != ALL($2::UUID[])
+    SELECT v.id
+      FROM entry_version v
+      JOIN registry_entry e ON v.entry_id = e.id
+     WHERE e.reg_id = $1
+       AND v.id != ALL($2::UUID[])
 )
-DELETE FROM mcp_server s
-WHERE s.entry_id IN (SELECT id FROM subset)
+DELETE FROM entry_version v
+WHERE v.id IN (SELECT id FROM subset)
 `
 
 type DeleteOrphanedServersParams struct {
@@ -35,31 +36,31 @@ func (q *Queries) DeleteOrphanedServers(ctx context.Context, arg DeleteOrphanedS
 
 const deleteServerIconsByServerId = `-- name: DeleteServerIconsByServerId :exec
 DELETE FROM mcp_server_icon
-WHERE entry_id = $1
+WHERE server_id = $1
 `
 
-func (q *Queries) DeleteServerIconsByServerId(ctx context.Context, entryID uuid.UUID) error {
-	_, err := q.db.Exec(ctx, deleteServerIconsByServerId, entryID)
+func (q *Queries) DeleteServerIconsByServerId(ctx context.Context, serverID uuid.UUID) error {
+	_, err := q.db.Exec(ctx, deleteServerIconsByServerId, serverID)
 	return err
 }
 
 const deleteServerPackagesByServerId = `-- name: DeleteServerPackagesByServerId :exec
 DELETE FROM mcp_server_package
-WHERE entry_id = $1
+WHERE server_id = $1
 `
 
-func (q *Queries) DeleteServerPackagesByServerId(ctx context.Context, entryID uuid.UUID) error {
-	_, err := q.db.Exec(ctx, deleteServerPackagesByServerId, entryID)
+func (q *Queries) DeleteServerPackagesByServerId(ctx context.Context, serverID uuid.UUID) error {
+	_, err := q.db.Exec(ctx, deleteServerPackagesByServerId, serverID)
 	return err
 }
 
 const deleteServerRemotesByServerId = `-- name: DeleteServerRemotesByServerId :exec
 DELETE FROM mcp_server_remote
-WHERE entry_id = $1
+WHERE server_id = $1
 `
 
-func (q *Queries) DeleteServerRemotesByServerId(ctx context.Context, entryID uuid.UUID) error {
-	_, err := q.db.Exec(ctx, deleteServerRemotesByServerId, entryID)
+func (q *Queries) DeleteServerRemotesByServerId(ctx context.Context, serverID uuid.UUID) error {
+	_, err := q.db.Exec(ctx, deleteServerRemotesByServerId, serverID)
 	return err
 }
 
@@ -67,7 +68,8 @@ const deleteServersByRegistry = `-- name: DeleteServersByRegistry :exec
 WITH registry_entries AS (
     SELECT e.id
       FROM registry_entry e
-      JOIN mcp_server s ON e.id = s.entry_id
+      JOIN entry_version v ON v.entry_id = e.id
+      JOIN mcp_server s ON v.id = s.version_id
      WHERE e.reg_id = $1
 )
 DELETE FROM registry_entry
@@ -99,16 +101,17 @@ func (q *Queries) GetLatestVersionForServer(ctx context.Context, arg GetLatestVe
 }
 
 const getServerIDsByRegistryNameVersion = `-- name: GetServerIDsByRegistryNameVersion :many
-SELECT entry_id, name, version
-FROM registry_entry e
-JOIN mcp_server s ON e.id = s.entry_id
-WHERE e.reg_id = $1
+SELECT s.version_id, e.name, v.version
+  FROM entry_version v
+  JOIN registry_entry e ON e.id = v.entry_id
+  JOIN mcp_server s ON v.id = s.version_id
+ WHERE e.reg_id = $1
 `
 
 type GetServerIDsByRegistryNameVersionRow struct {
-	EntryID uuid.UUID `json:"entry_id"`
-	Name    string    `json:"name"`
-	Version string    `json:"version"`
+	VersionID uuid.UUID `json:"version_id"`
+	Name      string    `json:"name"`
+	Version   string    `json:"version"`
 }
 
 func (q *Queries) GetServerIDsByRegistryNameVersion(ctx context.Context, regID uuid.UUID) ([]GetServerIDsByRegistryNameVersionRow, error) {
@@ -120,7 +123,7 @@ func (q *Queries) GetServerIDsByRegistryNameVersion(ctx context.Context, regID u
 	items := []GetServerIDsByRegistryNameVersionRow{}
 	for rows.Next() {
 		var i GetServerIDsByRegistryNameVersionRow
-		if err := rows.Scan(&i.EntryID, &i.Name, &i.Version); err != nil {
+		if err := rows.Scan(&i.VersionID, &i.Name, &i.Version); err != nil {
 			return nil, err
 		}
 		items = append(items, i)
@@ -133,14 +136,14 @@ func (q *Queries) GetServerIDsByRegistryNameVersion(ctx context.Context, regID u
 
 const getServerVersion = `-- name: GetServerVersion :one
 SELECT r.reg_type as registry_type,
-       e.id,
+       v.id,
        e.name,
-       e.version,
-       (l.latest_entry_id IS NOT NULL)::boolean AS is_latest,
-       e.created_at,
-       e.updated_at,
-       e.description,
-       e.title,
+       v.version,
+       (l.latest_version_id IS NOT NULL)::boolean AS is_latest,
+       v.created_at,
+       v.updated_at,
+       v.description,
+       v.title,
        s.website,
        s.upstream_meta,
        s.server_meta,
@@ -149,13 +152,14 @@ SELECT r.reg_type as registry_type,
        s.repository_subfolder,
        s.repository_type
   FROM mcp_server s
-  JOIN registry_entry e ON s.entry_id = e.id
+  JOIN entry_version v ON s.version_id = v.id
+  JOIN registry_entry e ON v.entry_id = e.id
   JOIN registry r ON e.reg_id = r.id
-  LEFT JOIN latest_entry_version l ON e.id = l.latest_entry_id
+  LEFT JOIN latest_entry_version l ON v.id = l.latest_version_id
  WHERE e.name = $1
    AND (
-       e.version = $2
-       OR ($2 = 'latest' AND l.latest_entry_id = e.id)
+       v.version = $2
+       OR ($2 = 'latest' AND l.latest_version_id = v.id)
    )
    AND ($3::text IS NULL OR r.name = $3::text)
 `
@@ -211,7 +215,7 @@ func (q *Queries) GetServerVersion(ctx context.Context, arg GetServerVersionPara
 
 const insertServerIcon = `-- name: InsertServerIcon :exec
 INSERT INTO mcp_server_icon (
-    entry_id,
+    server_id,
     source_uri,
     mime_type,
     theme
@@ -224,7 +228,7 @@ INSERT INTO mcp_server_icon (
 `
 
 type InsertServerIconParams struct {
-	EntryID   uuid.UUID `json:"entry_id"`
+	ServerID  uuid.UUID `json:"server_id"`
 	SourceUri string    `json:"source_uri"`
 	MimeType  string    `json:"mime_type"`
 	Theme     IconTheme `json:"theme"`
@@ -232,7 +236,7 @@ type InsertServerIconParams struct {
 
 func (q *Queries) InsertServerIcon(ctx context.Context, arg InsertServerIconParams) error {
 	_, err := q.db.Exec(ctx, insertServerIcon,
-		arg.EntryID,
+		arg.ServerID,
 		arg.SourceUri,
 		arg.MimeType,
 		arg.Theme,
@@ -242,7 +246,7 @@ func (q *Queries) InsertServerIcon(ctx context.Context, arg InsertServerIconPara
 
 const insertServerPackage = `-- name: InsertServerPackage :exec
 INSERT INTO mcp_server_package (
-    entry_id,
+    server_id,
     registry_type,
     pkg_registry_url,
     pkg_identifier,
@@ -273,7 +277,7 @@ INSERT INTO mcp_server_package (
 `
 
 type InsertServerPackageParams struct {
-	EntryID          uuid.UUID `json:"entry_id"`
+	ServerID         uuid.UUID `json:"server_id"`
 	RegistryType     string    `json:"registry_type"`
 	PkgRegistryUrl   string    `json:"pkg_registry_url"`
 	PkgIdentifier    string    `json:"pkg_identifier"`
@@ -291,7 +295,7 @@ type InsertServerPackageParams struct {
 // TODO: this seems unused
 func (q *Queries) InsertServerPackage(ctx context.Context, arg InsertServerPackageParams) error {
 	_, err := q.db.Exec(ctx, insertServerPackage,
-		arg.EntryID,
+		arg.ServerID,
 		arg.RegistryType,
 		arg.PkgRegistryUrl,
 		arg.PkgIdentifier,
@@ -310,7 +314,7 @@ func (q *Queries) InsertServerPackage(ctx context.Context, arg InsertServerPacka
 
 const insertServerRemote = `-- name: InsertServerRemote :exec
 INSERT INTO mcp_server_remote (
-    entry_id,
+    server_id,
     transport,
     transport_url,
     transport_headers
@@ -323,7 +327,7 @@ INSERT INTO mcp_server_remote (
 `
 
 type InsertServerRemoteParams struct {
-	EntryID          uuid.UUID `json:"entry_id"`
+	ServerID         uuid.UUID `json:"server_id"`
 	Transport        string    `json:"transport"`
 	TransportUrl     string    `json:"transport_url"`
 	TransportHeaders []byte    `json:"transport_headers"`
@@ -331,7 +335,7 @@ type InsertServerRemoteParams struct {
 
 func (q *Queries) InsertServerRemote(ctx context.Context, arg InsertServerRemoteParams) error {
 	_, err := q.db.Exec(ctx, insertServerRemote,
-		arg.EntryID,
+		arg.ServerID,
 		arg.Transport,
 		arg.TransportUrl,
 		arg.TransportHeaders,
@@ -341,7 +345,7 @@ func (q *Queries) InsertServerRemote(ctx context.Context, arg InsertServerRemote
 
 const insertServerVersion = `-- name: InsertServerVersion :one
 INSERT INTO mcp_server (
-    entry_id,
+    version_id,
     website,
     upstream_meta,
     server_meta,
@@ -359,11 +363,11 @@ INSERT INTO mcp_server (
     $7,
     $8
 )
-RETURNING entry_id
+RETURNING version_id
 `
 
 type InsertServerVersionParams struct {
-	EntryID             uuid.UUID `json:"entry_id"`
+	VersionID           uuid.UUID `json:"version_id"`
 	Website             *string   `json:"website"`
 	UpstreamMeta        []byte    `json:"upstream_meta"`
 	ServerMeta          []byte    `json:"server_meta"`
@@ -375,7 +379,7 @@ type InsertServerVersionParams struct {
 
 func (q *Queries) InsertServerVersion(ctx context.Context, arg InsertServerVersionParams) (uuid.UUID, error) {
 	row := q.db.QueryRow(ctx, insertServerVersion,
-		arg.EntryID,
+		arg.VersionID,
 		arg.Website,
 		arg.UpstreamMeta,
 		arg.ServerMeta,
@@ -384,14 +388,14 @@ func (q *Queries) InsertServerVersion(ctx context.Context, arg InsertServerVersi
 		arg.RepositorySubfolder,
 		arg.RepositoryType,
 	)
-	var entry_id uuid.UUID
-	err := row.Scan(&entry_id)
-	return entry_id, err
+	var version_id uuid.UUID
+	err := row.Scan(&version_id)
+	return version_id, err
 }
 
 const insertServerVersionForSync = `-- name: InsertServerVersionForSync :one
 INSERT INTO mcp_server (
-    entry_id,
+    version_id,
     website,
     upstream_meta,
     server_meta,
@@ -409,11 +413,11 @@ INSERT INTO mcp_server (
     $7,
     $8
 )
-RETURNING entry_id
+RETURNING version_id
 `
 
 type InsertServerVersionForSyncParams struct {
-	EntryID             uuid.UUID `json:"entry_id"`
+	VersionID           uuid.UUID `json:"version_id"`
 	Website             *string   `json:"website"`
 	UpstreamMeta        []byte    `json:"upstream_meta"`
 	ServerMeta          []byte    `json:"server_meta"`
@@ -425,7 +429,7 @@ type InsertServerVersionForSyncParams struct {
 
 func (q *Queries) InsertServerVersionForSync(ctx context.Context, arg InsertServerVersionForSyncParams) (uuid.UUID, error) {
 	row := q.db.QueryRow(ctx, insertServerVersionForSync,
-		arg.EntryID,
+		arg.VersionID,
 		arg.Website,
 		arg.UpstreamMeta,
 		arg.ServerMeta,
@@ -434,13 +438,13 @@ func (q *Queries) InsertServerVersionForSync(ctx context.Context, arg InsertServ
 		arg.RepositorySubfolder,
 		arg.RepositoryType,
 	)
-	var entry_id uuid.UUID
-	err := row.Scan(&entry_id)
-	return entry_id, err
+	var version_id uuid.UUID
+	err := row.Scan(&version_id)
+	return version_id, err
 }
 
 const listServerPackages = `-- name: ListServerPackages :many
-SELECT p.entry_id,
+SELECT p.server_id,
        p.registry_type,
        p.pkg_registry_url,
        p.pkg_identifier,
@@ -454,13 +458,13 @@ SELECT p.entry_id,
        p.transport_url,
        p.transport_headers
   FROM mcp_server_package p
-  JOIN mcp_server s ON p.entry_id = s.entry_id
- WHERE s.entry_id = ANY($1::UUID[])
+  JOIN mcp_server s ON p.server_id = s.version_id
+ WHERE s.version_id = ANY($1::UUID[])
  ORDER BY p.pkg_version DESC
 `
 
 type ListServerPackagesRow struct {
-	EntryID          uuid.UUID `json:"entry_id"`
+	ServerID         uuid.UUID `json:"server_id"`
 	RegistryType     string    `json:"registry_type"`
 	PkgRegistryUrl   string    `json:"pkg_registry_url"`
 	PkgIdentifier    string    `json:"pkg_identifier"`
@@ -475,8 +479,8 @@ type ListServerPackagesRow struct {
 	TransportHeaders []byte    `json:"transport_headers"`
 }
 
-func (q *Queries) ListServerPackages(ctx context.Context, entryIds []uuid.UUID) ([]ListServerPackagesRow, error) {
-	rows, err := q.db.Query(ctx, listServerPackages, entryIds)
+func (q *Queries) ListServerPackages(ctx context.Context, versionIds []uuid.UUID) ([]ListServerPackagesRow, error) {
+	rows, err := q.db.Query(ctx, listServerPackages, versionIds)
 	if err != nil {
 		return nil, err
 	}
@@ -485,7 +489,7 @@ func (q *Queries) ListServerPackages(ctx context.Context, entryIds []uuid.UUID) 
 	for rows.Next() {
 		var i ListServerPackagesRow
 		if err := rows.Scan(
-			&i.EntryID,
+			&i.ServerID,
 			&i.RegistryType,
 			&i.PkgRegistryUrl,
 			&i.PkgIdentifier,
@@ -510,18 +514,18 @@ func (q *Queries) ListServerPackages(ctx context.Context, entryIds []uuid.UUID) 
 }
 
 const listServerRemotes = `-- name: ListServerRemotes :many
-SELECT r.entry_id,
+SELECT r.server_id,
        r.transport,
        r.transport_url,
        r.transport_headers
   FROM mcp_server_remote r
-  JOIN mcp_server s ON r.entry_id = s.entry_id
- WHERE s.entry_id = ANY($1::UUID[])
+  JOIN mcp_server s ON r.server_id = s.version_id
+ WHERE s.version_id = ANY($1::UUID[])
  ORDER BY r.transport, r.transport_url
 `
 
-func (q *Queries) ListServerRemotes(ctx context.Context, entryIds []uuid.UUID) ([]McpServerRemote, error) {
-	rows, err := q.db.Query(ctx, listServerRemotes, entryIds)
+func (q *Queries) ListServerRemotes(ctx context.Context, versionIds []uuid.UUID) ([]McpServerRemote, error) {
+	rows, err := q.db.Query(ctx, listServerRemotes, versionIds)
 	if err != nil {
 		return nil, err
 	}
@@ -530,7 +534,7 @@ func (q *Queries) ListServerRemotes(ctx context.Context, entryIds []uuid.UUID) (
 	for rows.Next() {
 		var i McpServerRemote
 		if err := rows.Scan(
-			&i.EntryID,
+			&i.ServerID,
 			&i.Transport,
 			&i.TransportUrl,
 			&i.TransportHeaders,
@@ -547,14 +551,14 @@ func (q *Queries) ListServerRemotes(ctx context.Context, entryIds []uuid.UUID) (
 
 const listServerVersions = `-- name: ListServerVersions :many
 SELECT r.reg_type as registry_type,
-       e.id,
+       v.id,
        e.name,
-       e.version,
-       (l.latest_entry_id IS NOT NULL)::boolean AS is_latest,
-       e.created_at,
-       e.updated_at,
-       e.description,
-       e.title,
+       v.version,
+       (l.latest_version_id IS NOT NULL)::boolean AS is_latest,
+       v.created_at,
+       v.updated_at,
+       v.description,
+       v.title,
        s.website,
        s.upstream_meta,
        s.server_meta,
@@ -563,16 +567,17 @@ SELECT r.reg_type as registry_type,
        s.repository_subfolder,
        s.repository_type
   FROM mcp_server s
-  JOIN registry_entry e ON s.entry_id = e.id
+  JOIN entry_version v ON s.version_id = v.id
+  JOIN registry_entry e ON v.entry_id = e.id
   JOIN registry r ON e.reg_id = r.id
-  LEFT JOIN latest_entry_version l ON e.id = l.latest_entry_id
+  LEFT JOIN latest_entry_version l ON v.id = l.latest_version_id
  WHERE e.name = $1
    AND ($2::text IS NULL OR r.name = $2::text)
-   AND (($3::timestamp with time zone IS NULL OR e.created_at > $3)
-    AND ($4::timestamp with time zone IS NULL OR e.created_at < $4))
+   AND (($3::timestamp with time zone IS NULL OR v.created_at > $3)
+    AND ($4::timestamp with time zone IS NULL OR v.created_at < $4))
  ORDER BY
- CASE WHEN $3::timestamp with time zone IS NULL THEN e.created_at END ASC,
- CASE WHEN $3::timestamp with time zone IS NULL THEN e.version END DESC -- acts as tie breaker
+ CASE WHEN $3::timestamp with time zone IS NULL THEN v.created_at END ASC,
+ CASE WHEN $3::timestamp with time zone IS NULL THEN v.version END DESC -- acts as tie breaker
  LIMIT $5::bigint
 `
 
@@ -648,14 +653,14 @@ func (q *Queries) ListServerVersions(ctx context.Context, arg ListServerVersions
 
 const listServers = `-- name: ListServers :many
 SELECT r.reg_type as registry_type,
-       e.id,
+       v.id,
        e.name,
-       e.version,
-       (l.latest_entry_id IS NOT NULL)::boolean AS is_latest,
-       e.created_at,
-       e.updated_at,
-       e.description,
-       e.title,
+       v.version,
+       (l.latest_version_id IS NOT NULL)::boolean AS is_latest,
+       v.created_at,
+       v.updated_at,
+       v.description,
+       v.title,
        s.website,
        s.upstream_meta,
        s.server_meta,
@@ -664,29 +669,30 @@ SELECT r.reg_type as registry_type,
        s.repository_subfolder,
        s.repository_type
   FROM mcp_server s
-  JOIN registry_entry e ON s.entry_id = e.id
+  JOIN entry_version v ON s.version_id = v.id
+  JOIN registry_entry e ON v.entry_id = e.id
   JOIN registry r ON e.reg_id = r.id
-  LEFT JOIN latest_entry_version l ON e.id = l.latest_entry_id
+  LEFT JOIN latest_entry_version l ON v.id = l.latest_version_id
  WHERE ($1::text IS NULL OR r.name = $1::text)
    AND ($2::text IS NULL OR (
        LOWER(e.name) LIKE LOWER('%' || $2::text || '%')
-       OR LOWER(e.title) LIKE LOWER('%' || $2::text || '%')
-       OR LOWER(e.description) LIKE LOWER('%' || $2::text || '%')
+       OR LOWER(v.title) LIKE LOWER('%' || $2::text || '%')
+       OR LOWER(v.description) LIKE LOWER('%' || $2::text || '%')
    ))
    -- Filter by updated_since if provided
-   AND ($3::timestamp with time zone IS NULL OR e.updated_at > $3::timestamp with time zone)
+   AND ($3::timestamp with time zone IS NULL OR v.updated_at > $3::timestamp with time zone)
    -- Compound cursor comparison: (name, version) > (cursor_name, cursor_version)
    -- This ensures deterministic pagination even when timestamps are identical
    AND (
        $4::text IS NULL
-       OR (e.name, e.version) > ($4::text, $5::text)
+       OR (e.name, v.version) > ($4::text, $5::text)
    )
    AND (
        $6::text IS NULL OR
-       e.version = $6::text OR
-       ($6::text = 'latest' AND l.latest_entry_id = e.id)
+       v.version = $6::text OR
+       ($6::text = 'latest' AND l.latest_version_id = v.id)
    )
- ORDER BY e.name ASC, e.version ASC
+ ORDER BY e.name ASC, v.version ASC
  LIMIT $7::bigint
 `
 
@@ -772,7 +778,7 @@ INSERT INTO latest_entry_version (
     reg_id,
     name,
     version,
-    latest_entry_id
+    latest_version_id
 ) VALUES (
     $1,
     $2,
@@ -781,15 +787,15 @@ INSERT INTO latest_entry_version (
 ) ON CONFLICT (reg_id, name)
   DO UPDATE SET
     version = $3,
-    latest_entry_id = $4
-RETURNING latest_entry_id
+    latest_version_id = $4
+RETURNING latest_version_id
 `
 
 type UpsertLatestServerVersionParams struct {
-	RegID   uuid.UUID `json:"reg_id"`
-	Name    string    `json:"name"`
-	Version string    `json:"version"`
-	EntryID uuid.UUID `json:"entry_id"`
+	RegID     uuid.UUID `json:"reg_id"`
+	Name      string    `json:"name"`
+	Version   string    `json:"version"`
+	VersionID uuid.UUID `json:"version_id"`
 }
 
 func (q *Queries) UpsertLatestServerVersion(ctx context.Context, arg UpsertLatestServerVersionParams) (uuid.UUID, error) {
@@ -797,16 +803,16 @@ func (q *Queries) UpsertLatestServerVersion(ctx context.Context, arg UpsertLates
 		arg.RegID,
 		arg.Name,
 		arg.Version,
-		arg.EntryID,
+		arg.VersionID,
 	)
-	var latest_entry_id uuid.UUID
-	err := row.Scan(&latest_entry_id)
-	return latest_entry_id, err
+	var latest_version_id uuid.UUID
+	err := row.Scan(&latest_version_id)
+	return latest_version_id, err
 }
 
 const upsertServerVersionForSync = `-- name: UpsertServerVersionForSync :one
 INSERT INTO mcp_server (
-    entry_id,
+    version_id,
     website,
     upstream_meta,
     server_meta,
@@ -824,7 +830,7 @@ INSERT INTO mcp_server (
     $7,
     $8
 )
-ON CONFLICT (entry_id)
+ON CONFLICT (version_id)
 DO UPDATE SET
     website = $2,
     upstream_meta = $3,
@@ -833,11 +839,11 @@ DO UPDATE SET
     repository_id = $6,
     repository_subfolder = $7,
     repository_type = $8
-RETURNING entry_id
+RETURNING version_id
 `
 
 type UpsertServerVersionForSyncParams struct {
-	EntryID             uuid.UUID `json:"entry_id"`
+	VersionID           uuid.UUID `json:"version_id"`
 	Website             *string   `json:"website"`
 	UpstreamMeta        []byte    `json:"upstream_meta"`
 	ServerMeta          []byte    `json:"server_meta"`
@@ -849,7 +855,7 @@ type UpsertServerVersionForSyncParams struct {
 
 func (q *Queries) UpsertServerVersionForSync(ctx context.Context, arg UpsertServerVersionForSyncParams) (uuid.UUID, error) {
 	row := q.db.QueryRow(ctx, upsertServerVersionForSync,
-		arg.EntryID,
+		arg.VersionID,
 		arg.Website,
 		arg.UpstreamMeta,
 		arg.ServerMeta,
@@ -858,7 +864,7 @@ func (q *Queries) UpsertServerVersionForSync(ctx context.Context, arg UpsertServ
 		arg.RepositorySubfolder,
 		arg.RepositoryType,
 	)
-	var entry_id uuid.UUID
-	err := row.Scan(&entry_id)
-	return entry_id, err
+	var version_id uuid.UUID
+	err := row.Scan(&version_id)
+	return version_id, err
 }

--- a/internal/db/sqlc/servers_test.go
+++ b/internal/db/sqlc/servers_test.go
@@ -32,69 +32,114 @@ func setupRegistry(t *testing.T, queries *Queries) uuid.UUID {
 	return regID
 }
 
+//nolint:thelper // We want to see these lines in the test output
+func createEntry(
+	t *testing.T,
+	queries *Queries,
+	regID uuid.UUID,
+	name string,
+	createdAt *time.Time,
+) uuid.UUID {
+	entryID, err := queries.InsertRegistryEntry(
+		context.Background(),
+		InsertRegistryEntryParams{
+			Name:      name,
+			RegID:     regID,
+			EntryType: EntryTypeMCP,
+			CreatedAt: createdAt,
+			UpdatedAt: createdAt,
+		},
+	)
+	require.NoError(t, err)
+	return entryID
+}
+
+//nolint:thelper // We want to see these lines in the test output
+func createVersion(
+	t *testing.T,
+	queries *Queries,
+	entryID uuid.UUID,
+	version string,
+	description, title *string,
+	createdAt *time.Time,
+) uuid.UUID {
+	versionID, err := queries.InsertEntryVersion(
+		context.Background(),
+		InsertEntryVersionParams{
+			EntryID:     entryID,
+			Version:     version,
+			Title:       title,
+			Description: description,
+			CreatedAt:   createdAt,
+			UpdatedAt:   createdAt,
+		},
+	)
+	require.NoError(t, err)
+	return versionID
+}
+
+//nolint:thelper // We want to see these lines in the test output
+func createServer(
+	t *testing.T,
+	queries *Queries,
+	versionID uuid.UUID,
+) uuid.UUID {
+	serverID, err := queries.InsertServerVersion(
+		context.Background(),
+		InsertServerVersionParams{
+			VersionID: versionID,
+		},
+	)
+	require.NoError(t, err)
+	return serverID
+}
+
 func TestInsertServerVersion(t *testing.T) {
 	t.Parallel()
 
 	testCases := []struct {
 		name         string
-		setupFunc    func(t *testing.T, queries *Queries, regID uuid.UUID)
-		scenarioFunc func(t *testing.T, queries *Queries, regID uuid.UUID)
+		setupFunc    func(t *testing.T, queries *Queries, regID uuid.UUID) uuid.UUID
+		scenarioFunc func(t *testing.T, queries *Queries, regID uuid.UUID, entryID uuid.UUID)
 	}{
 		{
 			name: "insert server version with minimal fields",
 			//nolint:thelper // We want to see these lines in the test output
-			setupFunc: func(_ *testing.T, _ *Queries, _ uuid.UUID) {},
+			setupFunc: func(_ *testing.T, _ *Queries, _ uuid.UUID) uuid.UUID {
+				return uuid.Nil
+			},
 			//nolint:thelper // We want to see these lines in the test output
-			scenarioFunc: func(t *testing.T, queries *Queries, regID uuid.UUID) {
+			scenarioFunc: func(t *testing.T, queries *Queries, regID uuid.UUID, _ uuid.UUID) {
 				createdAt := time.Now().UTC()
-
-				entryID, err := queries.InsertRegistryEntry(
-					context.Background(),
-					InsertRegistryEntryParams{
-						Name:      "test-server",
-						Version:   "1.0.0",
-						RegID:     regID,
-						EntryType: EntryTypeMCP,
-						CreatedAt: &createdAt,
-					},
-				)
-				require.NoError(t, err)
-
-				_, err = queries.InsertServerVersion(
-					context.Background(),
-					InsertServerVersionParams{
-						EntryID: entryID,
-					},
-				)
-				require.NoError(t, err)
+				entryID := createEntry(t, queries, regID, "test-server", &createdAt)
+				versionID := createVersion(t, queries, entryID, "1.0.0", nil, nil, &createdAt)
+				createServer(t, queries, versionID)
 			},
 		},
 		{
 			name: "insert server version with all fields",
 			//nolint:thelper // We want to see these lines in the test output
-			setupFunc: func(_ *testing.T, _ *Queries, _ uuid.UUID) {},
-			//nolint:thelper // We want to see these lines in the test output
-			scenarioFunc: func(t *testing.T, queries *Queries, regID uuid.UUID) {
+			setupFunc: func(t *testing.T, queries *Queries, regID uuid.UUID) uuid.UUID {
 				createdAt := time.Now().UTC()
-				entryID, err := queries.InsertRegistryEntry(
-					context.Background(),
-					InsertRegistryEntryParams{
-						Name:        "test-server",
-						Version:     "1.0.0",
-						RegID:       regID,
-						Description: ptr.String("Test description"),
-						Title:       ptr.String("Test Title"),
-						EntryType:   EntryTypeMCP,
-						CreatedAt:   &createdAt,
-						UpdatedAt:   &createdAt,
-					},
+				entryID := createEntry(t, queries, regID, "test-server", &createdAt)
+				return entryID
+			},
+			//nolint:thelper // We want to see these lines in the test output
+			scenarioFunc: func(t *testing.T, queries *Queries, _ uuid.UUID, entryID uuid.UUID) {
+				createdAt := time.Now().UTC()
+				versionID := createVersion(
+					t,
+					queries,
+					entryID,
+					"1.0.0",
+					ptr.String("Test description"),
+					ptr.String("Test Title"),
+					&createdAt,
 				)
-				require.NoError(t, err)
-
-				_, err = queries.InsertServerVersion(
+				_, err := queries.InsertServerVersion(
 					context.Background(),
 					InsertServerVersionParams{
-						EntryID:             entryID,
+						VersionID:           versionID,
 						Website:             ptr.String("https://example.com"),
 						UpstreamMeta:        []byte(`{"key": "value"}`),
 						ServerMeta:          []byte(`{"meta": "data"}`),
@@ -108,15 +153,66 @@ func TestInsertServerVersion(t *testing.T) {
 			},
 		},
 		{
-			name: "insert duplicate server version fails",
+			name: "insert duplicate entry version fails",
 			//nolint:thelper // We want to see these lines in the test output
-			setupFunc: func(t *testing.T, queries *Queries, regID uuid.UUID) {
+			setupFunc: func(t *testing.T, queries *Queries, regID uuid.UUID) uuid.UUID {
 				createdAt := time.Now().UTC()
-				entryID, err := queries.InsertRegistryEntry(
+				entryID := createEntry(t, queries, regID, "test-server", &createdAt)
+				createVersion(t, queries, entryID, "1.0.0", nil, nil, &createdAt)
+				return entryID
+			},
+			//nolint:thelper // We want to see these lines in the test output
+			scenarioFunc: func(t *testing.T, queries *Queries, _ uuid.UUID, entryID uuid.UUID) {
+				// Inserting a duplicate entry_version (same entry_id+version) should fail
+				createdAt := time.Now().UTC()
+				_, err := queries.InsertEntryVersion(
+					context.Background(),
+					InsertEntryVersionParams{
+						EntryID:   entryID,
+						Version:   "1.0.0",
+						CreatedAt: &createdAt,
+						UpdatedAt: &createdAt,
+					},
+				)
+				require.Error(t, err)
+			},
+		},
+		{
+			name: "insert server version with invalid reg_id",
+			//nolint:thelper // We want to see these lines in the test output
+			setupFunc: func(_ *testing.T, _ *Queries, _ uuid.UUID) uuid.UUID {
+				return uuid.Nil
+			},
+			//nolint:thelper // We want to see these lines in the test output
+			scenarioFunc: func(t *testing.T, queries *Queries, _ uuid.UUID, _ uuid.UUID) {
+				createdAt := time.Now().UTC()
+				invalidRegID := uuid.New()
+				_, err := queries.InsertRegistryEntry(
 					context.Background(),
 					InsertRegistryEntryParams{
 						Name:      "test-server",
-						Version:   "1.0.0",
+						RegID:     invalidRegID,
+						EntryType: EntryTypeMCP,
+						CreatedAt: &createdAt,
+						UpdatedAt: &createdAt,
+					},
+				)
+				require.Error(t, err)
+			},
+		},
+		{
+			name: "insert server version with invalid entry_id",
+			//nolint:thelper // We want to see these lines in the test output
+			setupFunc: func(_ *testing.T, _ *Queries, _ uuid.UUID) uuid.UUID {
+				return uuid.Nil
+			},
+			//nolint:thelper // We want to see these lines in the test output
+			scenarioFunc: func(t *testing.T, queries *Queries, regID uuid.UUID, _ uuid.UUID) {
+				createdAt := time.Now().UTC()
+				_, err := queries.InsertRegistryEntry(
+					context.Background(),
+					InsertRegistryEntryParams{
+						Name:      "test-server",
 						RegID:     regID,
 						EntryType: EntryTypeMCP,
 						CreatedAt: &createdAt,
@@ -125,55 +221,12 @@ func TestInsertServerVersion(t *testing.T) {
 				)
 				require.NoError(t, err)
 
-				_, err = queries.InsertServerVersion(
+				invalidEntryID := uuid.New()
+				_, err = queries.InsertEntryVersion(
 					context.Background(),
-					InsertServerVersionParams{
-						EntryID: entryID,
-					},
-				)
-				require.NoError(t, err)
-			},
-			//nolint:thelper // We want to see these lines in the test output
-			scenarioFunc: func(t *testing.T, queries *Queries, regID uuid.UUID) {
-				updatedAt := time.Now().UTC()
-				entryID, err := queries.InsertRegistryEntry(
-					context.Background(),
-					InsertRegistryEntryParams{
-						Name:        "test-server",
-						Version:     "1.0.0",
-						RegID:       regID,
-						Description: ptr.String("Updated description"),
-						Title:       ptr.String("Updated Title"),
-						EntryType:   EntryTypeMCP,
-						UpdatedAt:   &updatedAt,
-					},
-				)
-				require.Error(t, err)
-
-				_, err = queries.InsertServerVersion(
-					context.Background(),
-					InsertServerVersionParams{
-						EntryID: entryID,
-					},
-				)
-				require.Error(t, err) // Should fail with unique constraint violation
-			},
-		},
-		{
-			name: "insert server version with invalid reg_id",
-			//nolint:thelper // We want to see these lines in the test output
-			setupFunc: func(_ *testing.T, _ *Queries, _ uuid.UUID) {},
-			//nolint:thelper // We want to see these lines in the test output
-			scenarioFunc: func(t *testing.T, queries *Queries, _ uuid.UUID) {
-				createdAt := time.Now().UTC()
-				regID := uuid.New()
-				_, err := queries.InsertRegistryEntry(
-					context.Background(),
-					InsertRegistryEntryParams{
-						Name:      "test-server",
+					InsertEntryVersionParams{
+						EntryID:   invalidEntryID,
 						Version:   "1.0.0",
-						RegID:     regID,
-						EntryType: EntryTypeMCP,
 						CreatedAt: &createdAt,
 						UpdatedAt: &createdAt,
 					},
@@ -196,8 +249,8 @@ func TestInsertServerVersion(t *testing.T) {
 			regID := setupRegistry(t, queries)
 			require.NotNil(t, regID)
 
-			tc.setupFunc(t, queries, regID)
-			tc.scenarioFunc(t, queries, regID)
+			entryID := tc.setupFunc(t, queries, regID)
+			tc.scenarioFunc(t, queries, regID, entryID)
 		})
 	}
 }
@@ -234,26 +287,9 @@ func TestListServerVersions(t *testing.T) {
 			//nolint:thelper // We want to see these lines in the test output
 			setupFunc: func(t *testing.T, queries *Queries, regID uuid.UUID) string {
 				createdAt := time.Now().UTC()
-				entryID, err := queries.InsertRegistryEntry(
-					context.Background(),
-					InsertRegistryEntryParams{
-						Name:      "test-server",
-						Version:   "1.0.0",
-						RegID:     regID,
-						EntryType: EntryTypeMCP,
-						CreatedAt: &createdAt,
-						UpdatedAt: &createdAt,
-					},
-				)
-				require.NoError(t, err)
-
-				_, err = queries.InsertServerVersion(
-					context.Background(),
-					InsertServerVersionParams{
-						EntryID: entryID,
-					},
-				)
-				require.NoError(t, err)
+				entryID := createEntry(t, queries, regID, "test-server", &createdAt)
+				versionID := createVersion(t, queries, entryID, "1.0.0", nil, nil, &createdAt)
+				createServer(t, queries, versionID)
 				//nolint:goconst
 				return "test-server"
 			},
@@ -277,28 +313,11 @@ func TestListServerVersions(t *testing.T) {
 			//nolint:thelper // We want to see these lines in the test output
 			setupFunc: func(t *testing.T, queries *Queries, regID uuid.UUID) string {
 				createdAt := time.Now().UTC().Add(-1 * time.Minute)
+				entryID := createEntry(t, queries, regID, "test-server", &createdAt)
 				for _, version := range []string{"1.0.0", "2.0.0", "3.0.0"} {
 					createdAt = createdAt.Add(1 * time.Second)
-					entryID, err := queries.InsertRegistryEntry(
-						context.Background(),
-						InsertRegistryEntryParams{
-							Name:      "test-server",
-							Version:   version,
-							RegID:     regID,
-							EntryType: EntryTypeMCP,
-							CreatedAt: &createdAt,
-							UpdatedAt: &createdAt,
-						},
-					)
-					require.NoError(t, err)
-
-					_, err = queries.InsertServerVersion(
-						context.Background(),
-						InsertServerVersionParams{
-							EntryID: entryID,
-						},
-					)
-					require.NoError(t, err)
+					versionID := createVersion(t, queries, entryID, version, nil, nil, &createdAt)
+					createServer(t, queries, versionID)
 				}
 				return "test-server"
 			},
@@ -321,28 +340,11 @@ func TestListServerVersions(t *testing.T) {
 			//nolint:thelper // We want to see these lines in the test output
 			setupFunc: func(t *testing.T, queries *Queries, regID uuid.UUID) string {
 				createdAt := time.Now().UTC().Add(-1 * time.Minute)
+				entryID := createEntry(t, queries, regID, "test-server", &createdAt)
 				for _, version := range []string{"1.0.0", "2.0.0", "3.0.0"} {
 					createdAt = createdAt.Add(1 * time.Second)
-					entryID, err := queries.InsertRegistryEntry(
-						context.Background(),
-						InsertRegistryEntryParams{
-							Name:      "test-server",
-							Version:   version,
-							RegID:     regID,
-							EntryType: EntryTypeMCP,
-							CreatedAt: &createdAt,
-							UpdatedAt: &createdAt,
-						},
-					)
-					require.NoError(t, err)
-
-					_, err = queries.InsertServerVersion(
-						context.Background(),
-						InsertServerVersionParams{
-							EntryID: entryID,
-						},
-					)
-					require.NoError(t, err)
+					versionID := createVersion(t, queries, entryID, version, nil, nil, &createdAt)
+					createServer(t, queries, versionID)
 				}
 				return "test-server"
 			},
@@ -383,28 +385,11 @@ func TestListServerVersions(t *testing.T) {
 			//nolint:thelper // We want to see these lines in the test output
 			setupFunc: func(t *testing.T, queries *Queries, regID uuid.UUID) string {
 				createdAt := time.Now().UTC().Add(-1 * time.Minute)
+				entryID := createEntry(t, queries, regID, "test-server", &createdAt)
 				for _, version := range []string{"1.0.0", "2.0.0", "3.0.0"} {
 					createdAt = createdAt.Add(1 * time.Second)
-					entryID, err := queries.InsertRegistryEntry(
-						context.Background(),
-						InsertRegistryEntryParams{
-							Name:      "test-server",
-							Version:   version,
-							RegID:     regID,
-							EntryType: EntryTypeMCP,
-							CreatedAt: &createdAt,
-							UpdatedAt: &createdAt,
-						},
-					)
-					require.NoError(t, err)
-
-					_, err = queries.InsertServerVersion(
-						context.Background(),
-						InsertServerVersionParams{
-							EntryID: entryID,
-						},
-					)
-					require.NoError(t, err)
+					versionID := createVersion(t, queries, entryID, version, nil, nil, &createdAt)
+					createServer(t, queries, versionID)
 				}
 				return "test-server"
 			},
@@ -471,26 +456,9 @@ func TestListServers(t *testing.T) {
 			//nolint:thelper // We want to see these lines in the test output
 			setupFunc: func(t *testing.T, queries *Queries, regID uuid.UUID) {
 				createdAt := time.Now().UTC()
-				entryID, err := queries.InsertRegistryEntry(
-					context.Background(),
-					InsertRegistryEntryParams{
-						Name:      "test-server",
-						Version:   "1.0.0",
-						RegID:     regID,
-						EntryType: EntryTypeMCP,
-						CreatedAt: &createdAt,
-						UpdatedAt: &createdAt,
-					},
-				)
-				require.NoError(t, err)
-
-				_, err = queries.InsertServerVersion(
-					context.Background(),
-					InsertServerVersionParams{
-						EntryID: entryID,
-					},
-				)
-				require.NoError(t, err)
+				entryID := createEntry(t, queries, regID, "test-server", &createdAt)
+				versionID := createVersion(t, queries, entryID, "1.0.0", nil, nil, &createdAt)
+				createServer(t, queries, versionID)
 			},
 			//nolint:thelper // We want to see these lines in the test output
 			scenarioFunc: func(t *testing.T, queries *Queries) {
@@ -512,28 +480,11 @@ func TestListServers(t *testing.T) {
 			//nolint:thelper // We want to see these lines in the test output
 			setupFunc: func(t *testing.T, queries *Queries, regID uuid.UUID) {
 				createdAt := time.Now().UTC()
+				entryID := createEntry(t, queries, regID, "test-server", &createdAt)
 				for _, version := range []string{"1.0.0", "2.0.0"} {
 					createdAt = createdAt.Add(1 * time.Second)
-					entryID, err := queries.InsertRegistryEntry(
-						context.Background(),
-						InsertRegistryEntryParams{
-							Name:      "test-server",
-							Version:   version,
-							RegID:     regID,
-							EntryType: EntryTypeMCP,
-							CreatedAt: &createdAt,
-							UpdatedAt: &createdAt,
-						},
-					)
-					require.NoError(t, err)
-
-					_, err = queries.InsertServerVersion(
-						context.Background(),
-						InsertServerVersionParams{
-							EntryID: entryID,
-						},
-					)
-					require.NoError(t, err)
+					versionID := createVersion(t, queries, entryID, version, nil, nil, &createdAt)
+					createServer(t, queries, versionID)
 				}
 			},
 			//nolint:thelper // We want to see these lines in the test output
@@ -553,28 +504,11 @@ func TestListServers(t *testing.T) {
 			//nolint:thelper // We want to see these lines in the test output
 			setupFunc: func(t *testing.T, queries *Queries, regID uuid.UUID) {
 				createdAt := time.Now().UTC().Add(-1 * time.Minute)
+				entryID := createEntry(t, queries, regID, "test-server", &createdAt)
 				for _, version := range []string{"1.0.0", "2.0.0"} {
 					createdAt = createdAt.Add(1 * time.Second)
-					entryID, err := queries.InsertRegistryEntry(
-						context.Background(),
-						InsertRegistryEntryParams{
-							Name:      "test-server",
-							Version:   version,
-							RegID:     regID,
-							EntryType: EntryTypeMCP,
-							CreatedAt: &createdAt,
-							UpdatedAt: &createdAt,
-						},
-					)
-					require.NoError(t, err)
-
-					_, err = queries.InsertServerVersion(
-						context.Background(),
-						InsertServerVersionParams{
-							EntryID: entryID,
-						},
-					)
-					require.NoError(t, err)
+					versionID := createVersion(t, queries, entryID, version, nil, nil, &createdAt)
+					createServer(t, queries, versionID)
 				}
 			},
 			//nolint:thelper // We want to see these lines in the test output
@@ -617,42 +551,17 @@ func TestListServers(t *testing.T) {
 			//nolint:thelper // We want to see these lines in the test output
 			setupFunc: func(t *testing.T, queries *Queries, regID uuid.UUID) {
 				createdAt := time.Now().UTC()
-				entryID, err := queries.InsertRegistryEntry(
-					context.Background(),
-					InsertRegistryEntryParams{
-						Name:      "test-server",
-						Version:   "1.0.0",
-						RegID:     regID,
-						EntryType: EntryTypeMCP,
-						CreatedAt: &createdAt,
-						UpdatedAt: &createdAt,
-					},
-				)
-				require.NoError(t, err)
+				entryID := createEntry(t, queries, regID, "test-server", &createdAt)
+				versionID := createVersion(t, queries, entryID, "1.0.0", nil, nil, &createdAt)
+				createServer(t, queries, versionID)
 
-				_, err = queries.InsertServerVersion(
-					context.Background(),
-					InsertServerVersionParams{
-						EntryID: entryID,
-					},
-				)
-				require.NoError(t, err)
-
-				// Get the server ID by listing
-				servers, err := queries.ListServers(
-					context.Background(),
-					ListServersParams{Size: 10},
-				)
-				require.NoError(t, err)
-				require.Len(t, servers, 1)
-
-				_, err = queries.UpsertLatestServerVersion(
+				_, err := queries.UpsertLatestServerVersion(
 					context.Background(),
 					UpsertLatestServerVersionParams{
-						RegID:   regID,
-						Name:    "test-server",
-						Version: "1.0.0",
-						EntryID: servers[0].ID,
+						RegID:     regID,
+						Name:      "test-server",
+						Version:   "1.0.0",
+						VersionID: versionID,
 					},
 				)
 				require.NoError(t, err)
@@ -674,28 +583,11 @@ func TestListServers(t *testing.T) {
 			//nolint:thelper // We want to see these lines in the test output
 			setupFunc: func(t *testing.T, queries *Queries, regID uuid.UUID) {
 				createdAt := time.Now().UTC().Add(-1 * time.Minute)
+				entryID := createEntry(t, queries, regID, "test-server", &createdAt)
 				for _, version := range []string{"1.0.0", "2.0.0"} {
 					createdAt = createdAt.Add(1 * time.Second)
-					entryID, err := queries.InsertRegistryEntry(
-						context.Background(),
-						InsertRegistryEntryParams{
-							Name:      "test-server",
-							Version:   version,
-							RegID:     regID,
-							EntryType: EntryTypeMCP,
-							CreatedAt: &createdAt,
-							UpdatedAt: &createdAt,
-						},
-					)
-					require.NoError(t, err)
-
-					_, err = queries.InsertServerVersion(
-						context.Background(),
-						InsertServerVersionParams{
-							EntryID: entryID,
-						},
-					)
-					require.NoError(t, err)
+					versionID := createVersion(t, queries, entryID, version, nil, nil, &createdAt)
+					createServer(t, queries, versionID)
 				}
 			},
 			//nolint:thelper // We want to see these lines in the test output
@@ -715,28 +607,11 @@ func TestListServers(t *testing.T) {
 			//nolint:thelper // We want to see these lines in the test output
 			setupFunc: func(t *testing.T, queries *Queries, regID uuid.UUID) {
 				createdAt := time.Now().UTC().Add(-1 * time.Minute)
+				entryID := createEntry(t, queries, regID, "test-server", &createdAt)
 				for _, version := range []string{"1.0.0", "2.0.0", "3.0.0"} {
 					createdAt = createdAt.Add(1 * time.Second)
-					entryID, err := queries.InsertRegistryEntry(
-						context.Background(),
-						InsertRegistryEntryParams{
-							Name:      "test-server",
-							Version:   version,
-							RegID:     regID,
-							EntryType: EntryTypeMCP,
-							CreatedAt: &createdAt,
-							UpdatedAt: &createdAt,
-						},
-					)
-					require.NoError(t, err)
-
-					_, err = queries.InsertServerVersion(
-						context.Background(),
-						InsertServerVersionParams{
-							EntryID: entryID,
-						},
-					)
-					require.NoError(t, err)
+					versionID := createVersion(t, queries, entryID, version, nil, nil, &createdAt)
+					createServer(t, queries, versionID)
 				}
 			},
 			//nolint:thelper // We want to see these lines in the test output
@@ -761,40 +636,23 @@ func TestListServers(t *testing.T) {
 			//nolint:thelper // We want to see these lines in the test output
 			setupFunc: func(t *testing.T, queries *Queries, regID uuid.UUID) {
 				createdAt := time.Now().UTC().Add(-1 * time.Minute)
-				var entryIDs []uuid.UUID
+				entryID := createEntry(t, queries, regID, "test-server", &createdAt)
+				var versionIDs []uuid.UUID
 				for _, version := range []string{"1.0.0", "2.0.0"} {
 					createdAt = createdAt.Add(1 * time.Second)
-					entryID, err := queries.InsertRegistryEntry(
-						context.Background(),
-						InsertRegistryEntryParams{
-							Name:      "test-server",
-							Version:   version,
-							RegID:     regID,
-							EntryType: EntryTypeMCP,
-							CreatedAt: &createdAt,
-							UpdatedAt: &createdAt,
-						},
-					)
-					require.NoError(t, err)
-
-					_, err = queries.InsertServerVersion(
-						context.Background(),
-						InsertServerVersionParams{
-							EntryID: entryID,
-						},
-					)
-					require.NoError(t, err)
-					entryIDs = append(entryIDs, entryID)
+					versionID := createVersion(t, queries, entryID, version, nil, nil, &createdAt)
+					createServer(t, queries, versionID)
+					versionIDs = append(versionIDs, versionID)
 				}
 
 				// Mark 2.0.0 as latest
 				_, err := queries.UpsertLatestServerVersion(
 					context.Background(),
 					UpsertLatestServerVersionParams{
-						RegID:   regID,
-						Name:    "test-server",
-						Version: "2.0.0",
-						EntryID: entryIDs[1],
+						RegID:     regID,
+						Name:      "test-server",
+						Version:   "2.0.0",
+						VersionID: versionIDs[1],
 					},
 				)
 				require.NoError(t, err)
@@ -821,26 +679,9 @@ func TestListServers(t *testing.T) {
 			//nolint:thelper // We want to see these lines in the test output
 			setupFunc: func(t *testing.T, queries *Queries, regID uuid.UUID) {
 				createdAt := time.Now().UTC()
-				entryID, err := queries.InsertRegistryEntry(
-					context.Background(),
-					InsertRegistryEntryParams{
-						Name:      "test-server",
-						Version:   "1.0.0",
-						RegID:     regID,
-						EntryType: EntryTypeMCP,
-						CreatedAt: &createdAt,
-						UpdatedAt: &createdAt,
-					},
-				)
-				require.NoError(t, err)
-
-				_, err = queries.InsertServerVersion(
-					context.Background(),
-					InsertServerVersionParams{
-						EntryID: entryID,
-					},
-				)
-				require.NoError(t, err)
+				entryID := createEntry(t, queries, regID, "test-server", &createdAt)
+				versionID := createVersion(t, queries, entryID, "1.0.0", nil, nil, &createdAt)
+				createServer(t, queries, versionID)
 			},
 			//nolint:thelper // We want to see these lines in the test output
 			scenarioFunc: func(t *testing.T, queries *Queries) {
@@ -861,28 +702,11 @@ func TestListServers(t *testing.T) {
 			//nolint:thelper // We want to see these lines in the test output
 			setupFunc: func(t *testing.T, queries *Queries, regID uuid.UUID) {
 				createdAt := time.Now().UTC().Add(-1 * time.Minute)
+				entryID := createEntry(t, queries, regID, "test-server", &createdAt)
 				for _, version := range []string{"1.0.0", "2.0.0"} {
 					createdAt = createdAt.Add(1 * time.Second)
-					entryID, err := queries.InsertRegistryEntry(
-						context.Background(),
-						InsertRegistryEntryParams{
-							Name:      "test-server",
-							Version:   version,
-							RegID:     regID,
-							EntryType: EntryTypeMCP,
-							CreatedAt: &createdAt,
-							UpdatedAt: &createdAt,
-						},
-					)
-					require.NoError(t, err)
-
-					_, err = queries.InsertServerVersion(
-						context.Background(),
-						InsertServerVersionParams{
-							EntryID: entryID,
-						},
-					)
-					require.NoError(t, err)
+					versionID := createVersion(t, queries, entryID, version, nil, nil, &createdAt)
+					createServer(t, queries, versionID)
 				}
 			},
 			//nolint:thelper // We want to see these lines in the test output
@@ -904,28 +728,11 @@ func TestListServers(t *testing.T) {
 			//nolint:thelper // We want to see these lines in the test output
 			setupFunc: func(t *testing.T, queries *Queries, regID uuid.UUID) {
 				createdAt := time.Now().UTC().Add(-1 * time.Minute)
+				entryID := createEntry(t, queries, regID, "test-server", &createdAt)
 				for _, version := range []string{"1.0.0", "2.0.0", "3.0.0"} {
 					createdAt = createdAt.Add(1 * time.Second)
-					entryID, err := queries.InsertRegistryEntry(
-						context.Background(),
-						InsertRegistryEntryParams{
-							Name:      "test-server",
-							Version:   version,
-							RegID:     regID,
-							EntryType: EntryTypeMCP,
-							CreatedAt: &createdAt,
-							UpdatedAt: &createdAt,
-						},
-					)
-					require.NoError(t, err)
-
-					_, err = queries.InsertServerVersion(
-						context.Background(),
-						InsertServerVersionParams{
-							EntryID: entryID,
-						},
-					)
-					require.NoError(t, err)
+					versionID := createVersion(t, queries, entryID, version, nil, nil, &createdAt)
+					createServer(t, queries, versionID)
 				}
 			},
 			//nolint:thelper // We want to see these lines in the test output
@@ -978,27 +785,9 @@ func TestUpsertLatestServerVersion(t *testing.T) {
 			//nolint:thelper // We want to see these lines in the test output
 			setupFunc: func(t *testing.T, queries *Queries, regID uuid.UUID) []uuid.UUID {
 				createdAt := time.Now().UTC()
-				entryID, err := queries.InsertRegistryEntry(
-					context.Background(),
-					InsertRegistryEntryParams{
-						Name:      "test-server",
-						Version:   "1.0.0",
-						RegID:     regID,
-						EntryType: EntryTypeMCP,
-						CreatedAt: &createdAt,
-						UpdatedAt: &createdAt,
-					},
-				)
-				require.NoError(t, err)
-
-				serverID, err := queries.InsertServerVersion(
-					context.Background(),
-					InsertServerVersionParams{
-						EntryID: entryID,
-					},
-				)
-				require.NoError(t, err)
-				require.NotNil(t, serverID)
+				entryID := createEntry(t, queries, regID, "test-server", &createdAt)
+				versionID := createVersion(t, queries, entryID, "1.0.0", nil, nil, &createdAt)
+				serverID := createServer(t, queries, versionID)
 				return []uuid.UUID{serverID}
 			},
 			//nolint:thelper // We want to see these lines in the test output
@@ -1006,10 +795,10 @@ func TestUpsertLatestServerVersion(t *testing.T) {
 				serverID, err := queries.UpsertLatestServerVersion(
 					context.Background(),
 					UpsertLatestServerVersionParams{
-						RegID:   regID,
-						Name:    "test-server",
-						Version: "1.0.0",
-						EntryID: ids[0],
+						RegID:     regID,
+						Name:      "test-server",
+						Version:   "1.0.0",
+						VersionID: ids[0],
 					},
 				)
 				require.NoError(t, err)
@@ -1023,29 +812,11 @@ func TestUpsertLatestServerVersion(t *testing.T) {
 			setupFunc: func(t *testing.T, queries *Queries, regID uuid.UUID) []uuid.UUID {
 				var serverIDs []uuid.UUID
 				createdAt := time.Now().UTC().Add(-1 * time.Minute)
+				entryID := createEntry(t, queries, regID, "test-server", &createdAt)
 				for _, version := range []string{"1.0.0", "2.0.0"} {
 					createdAt = createdAt.Add(1 * time.Second)
-					entryID, err := queries.InsertRegistryEntry(
-						context.Background(),
-						InsertRegistryEntryParams{
-							Name:      "test-server",
-							Version:   version,
-							RegID:     regID,
-							EntryType: EntryTypeMCP,
-							CreatedAt: &createdAt,
-							UpdatedAt: &createdAt,
-						},
-					)
-					require.NoError(t, err)
-
-					serverID, err := queries.InsertServerVersion(
-						context.Background(),
-						InsertServerVersionParams{
-							EntryID: entryID,
-						},
-					)
-					require.NoError(t, err)
-					require.NotNil(t, serverID)
+					versionID := createVersion(t, queries, entryID, version, nil, nil, &createdAt)
+					serverID := createServer(t, queries, versionID)
 					serverIDs = append(serverIDs, serverID)
 				}
 
@@ -1053,10 +824,10 @@ func TestUpsertLatestServerVersion(t *testing.T) {
 				latestServerID, err := queries.UpsertLatestServerVersion(
 					context.Background(),
 					UpsertLatestServerVersionParams{
-						RegID:   regID,
-						Name:    "test-server",
-						Version: "1.0.0",
-						EntryID: serverIDs[0],
+						RegID:     regID,
+						Name:      "test-server",
+						Version:   "1.0.0",
+						VersionID: serverIDs[0],
 					},
 				)
 				require.NoError(t, err)
@@ -1070,10 +841,10 @@ func TestUpsertLatestServerVersion(t *testing.T) {
 				latestServerID, err := queries.UpsertLatestServerVersion(
 					context.Background(),
 					UpsertLatestServerVersionParams{
-						RegID:   regID,
-						Name:    "test-server",
-						Version: "2.0.0",
-						EntryID: ids[0],
+						RegID:     regID,
+						Name:      "test-server",
+						Version:   "2.0.0",
+						VersionID: ids[0],
 					},
 				)
 				require.NoError(t, err)
@@ -1093,10 +864,10 @@ func TestUpsertLatestServerVersion(t *testing.T) {
 				_, err := queries.UpsertLatestServerVersion(
 					context.Background(),
 					UpsertLatestServerVersionParams{
-						RegID:   regID,
-						Name:    "test-server",
-						Version: "1.0.0",
-						EntryID: ids[0],
+						RegID:     regID,
+						Name:      "test-server",
+						Version:   "1.0.0",
+						VersionID: ids[0],
 					},
 				)
 				require.Error(t, err)
@@ -1113,10 +884,10 @@ func TestUpsertLatestServerVersion(t *testing.T) {
 				_, err := queries.UpsertLatestServerVersion(
 					context.Background(),
 					UpsertLatestServerVersionParams{
-						RegID:   regID,
-						Name:    "test-server",
-						Version: "1.0.0",
-						EntryID: ids[0],
+						RegID:     regID,
+						Name:      "test-server",
+						Version:   "1.0.0",
+						VersionID: ids[0],
 					},
 				)
 				require.Error(t, err)
@@ -1156,27 +927,9 @@ func TestInsertServerIcon(t *testing.T) {
 			//nolint:thelper // We want to see these lines in the test output
 			setupFunc: func(t *testing.T, queries *Queries, regID uuid.UUID) uuid.UUID {
 				createdAt := time.Now().UTC()
-				entryID, err := queries.InsertRegistryEntry(
-					context.Background(),
-					InsertRegistryEntryParams{
-						Name:      "test-server",
-						Version:   "1.0.0",
-						RegID:     regID,
-						EntryType: EntryTypeMCP,
-						CreatedAt: &createdAt,
-						UpdatedAt: &createdAt,
-					},
-				)
-				require.NoError(t, err)
-
-				serverID, err := queries.InsertServerVersion(
-					context.Background(),
-					InsertServerVersionParams{
-						EntryID: entryID,
-					},
-				)
-				require.NoError(t, err)
-				require.NotNil(t, serverID)
+				entryID := createEntry(t, queries, regID, "test-server", &createdAt)
+				versionID := createVersion(t, queries, entryID, "1.0.0", nil, nil, &createdAt)
+				serverID := createServer(t, queries, versionID)
 				return serverID
 			},
 			//nolint:thelper // We want to see these lines in the test output
@@ -1184,7 +937,7 @@ func TestInsertServerIcon(t *testing.T) {
 				err := queries.InsertServerIcon(
 					context.Background(),
 					InsertServerIconParams{
-						EntryID:   entryID,
+						ServerID:  entryID,
 						SourceUri: "https://example.com/icon.png",
 						MimeType:  "image/png",
 						Theme:     IconThemeLIGHT,
@@ -1198,27 +951,9 @@ func TestInsertServerIcon(t *testing.T) {
 			//nolint:thelper // We want to see these lines in the test output
 			setupFunc: func(t *testing.T, queries *Queries, regID uuid.UUID) uuid.UUID {
 				createdAt := time.Now().UTC()
-				entryID, err := queries.InsertRegistryEntry(
-					context.Background(),
-					InsertRegistryEntryParams{
-						Name:      "test-server",
-						Version:   "1.0.0",
-						RegID:     regID,
-						EntryType: EntryTypeMCP,
-						CreatedAt: &createdAt,
-						UpdatedAt: &createdAt,
-					},
-				)
-				require.NoError(t, err)
-
-				serverID, err := queries.InsertServerVersion(
-					context.Background(),
-					InsertServerVersionParams{
-						EntryID: entryID,
-					},
-				)
-				require.NoError(t, err)
-				require.NotNil(t, serverID)
+				entryID := createEntry(t, queries, regID, "test-server", &createdAt)
+				versionID := createVersion(t, queries, entryID, "1.0.0", nil, nil, &createdAt)
+				serverID := createServer(t, queries, versionID)
 				return serverID
 			},
 			//nolint:thelper // We want to see these lines in the test output
@@ -1226,7 +961,7 @@ func TestInsertServerIcon(t *testing.T) {
 				err := queries.InsertServerIcon(
 					context.Background(),
 					InsertServerIconParams{
-						EntryID:   entryID,
+						ServerID:  entryID,
 						SourceUri: "https://example.com/icon.png",
 						MimeType:  "image/png",
 						Theme:     IconThemeDARK,
@@ -1240,34 +975,15 @@ func TestInsertServerIcon(t *testing.T) {
 			//nolint:thelper // We want to see these lines in the test output
 			setupFunc: func(t *testing.T, queries *Queries, regID uuid.UUID) uuid.UUID {
 				createdAt := time.Now().UTC()
-				entryID, err := queries.InsertRegistryEntry(
-					context.Background(),
-					InsertRegistryEntryParams{
-						Name:      "test-server",
-						Version:   "1.0.0",
-						RegID:     regID,
-						EntryType: EntryTypeMCP,
-						CreatedAt: &createdAt,
-						UpdatedAt: &createdAt,
-					},
-				)
-				require.NoError(t, err)
-				require.NotNil(t, entryID)
-
-				serverID, err := queries.InsertServerVersion(
-					context.Background(),
-					InsertServerVersionParams{
-						EntryID: entryID,
-					},
-				)
-				require.NoError(t, err)
-				require.Equal(t, entryID, serverID)
+				entryID := createEntry(t, queries, regID, "test-server", &createdAt)
+				versionID := createVersion(t, queries, entryID, "1.0.0", nil, nil, &createdAt)
+				createServer(t, queries, versionID)
 
 				// Insert initial icon
-				err = queries.InsertServerIcon(
+				err := queries.InsertServerIcon(
 					context.Background(),
 					InsertServerIconParams{
-						EntryID:   entryID,
+						ServerID:  versionID,
 						SourceUri: "https://example.com/icon.png",
 						MimeType:  "image/png",
 						Theme:     IconThemeLIGHT,
@@ -1275,14 +991,14 @@ func TestInsertServerIcon(t *testing.T) {
 				)
 				require.NoError(t, err)
 
-				return entryID
+				return versionID
 			},
 			//nolint:thelper // We want to see these lines in the test output
 			scenarioFunc: func(t *testing.T, queries *Queries, entryID uuid.UUID) {
 				err := queries.InsertServerIcon(
 					context.Background(),
 					InsertServerIconParams{
-						EntryID:   entryID,
+						ServerID:  entryID,
 						SourceUri: "https://example.com/icon.png",
 						MimeType:  "image/png",
 						Theme:     IconThemeDARK,
@@ -1302,7 +1018,7 @@ func TestInsertServerIcon(t *testing.T) {
 				err := queries.InsertServerIcon(
 					context.Background(),
 					InsertServerIconParams{
-						EntryID:   entryID,
+						ServerID:  entryID,
 						SourceUri: "https://example.com/icon.png",
 						MimeType:  "image/png",
 						Theme:     IconThemeLIGHT,
@@ -1345,36 +1061,17 @@ func TestInsertServerPackage(t *testing.T) {
 			//nolint:thelper // We want to see these lines in the test output
 			setupFunc: func(t *testing.T, queries *Queries, regID uuid.UUID) uuid.UUID {
 				createdAt := time.Now().UTC()
-				entryID, err := queries.InsertRegistryEntry(
-					context.Background(),
-					InsertRegistryEntryParams{
-						Name:      "test-server",
-						Version:   "1.0.0",
-						RegID:     regID,
-						EntryType: EntryTypeMCP,
-						CreatedAt: &createdAt,
-						UpdatedAt: &createdAt,
-					},
-				)
-				require.NoError(t, err)
-				require.NotNil(t, entryID)
-
-				serverID, err := queries.InsertServerVersion(
-					context.Background(),
-					InsertServerVersionParams{
-						EntryID: entryID,
-					},
-				)
-				require.NoError(t, err)
-				require.Equal(t, entryID, serverID)
-				return entryID
+				entryID := createEntry(t, queries, regID, "test-server", &createdAt)
+				versionID := createVersion(t, queries, entryID, "1.0.0", nil, nil, &createdAt)
+				createServer(t, queries, versionID)
+				return versionID
 			},
 			//nolint:thelper // We want to see these lines in the test output
 			scenarioFunc: func(t *testing.T, queries *Queries, entryID uuid.UUID) {
 				err := queries.InsertServerPackage(
 					context.Background(),
 					InsertServerPackageParams{
-						EntryID:        entryID,
+						ServerID:       entryID,
 						RegistryType:   "npm",
 						PkgRegistryUrl: "https://registry.npmjs.org",
 						PkgIdentifier:  "@test/package",
@@ -1390,36 +1087,17 @@ func TestInsertServerPackage(t *testing.T) {
 			//nolint:thelper // We want to see these lines in the test output
 			setupFunc: func(t *testing.T, queries *Queries, regID uuid.UUID) uuid.UUID {
 				createdAt := time.Now().UTC()
-				entryID, err := queries.InsertRegistryEntry(
-					context.Background(),
-					InsertRegistryEntryParams{
-						Name:      "test-server",
-						Version:   "1.0.0",
-						RegID:     regID,
-						EntryType: EntryTypeMCP,
-						CreatedAt: &createdAt,
-						UpdatedAt: &createdAt,
-					},
-				)
-				require.NoError(t, err)
-				require.NotNil(t, entryID)
-
-				serverID, err := queries.InsertServerVersion(
-					context.Background(),
-					InsertServerVersionParams{
-						EntryID: entryID,
-					},
-				)
-				require.NoError(t, err)
-				require.Equal(t, entryID, serverID)
-				return entryID
+				entryID := createEntry(t, queries, regID, "test-server", &createdAt)
+				versionID := createVersion(t, queries, entryID, "1.0.0", nil, nil, &createdAt)
+				createServer(t, queries, versionID)
+				return versionID
 			},
 			//nolint:thelper // We want to see these lines in the test output
 			scenarioFunc: func(t *testing.T, queries *Queries, entryID uuid.UUID) {
 				err := queries.InsertServerPackage(
 					context.Background(),
 					InsertServerPackageParams{
-						EntryID:          entryID,
+						ServerID:         entryID,
 						RegistryType:     "npm",
 						PkgRegistryUrl:   "https://registry.npmjs.org",
 						PkgIdentifier:    "@test/package",
@@ -1448,7 +1126,7 @@ func TestInsertServerPackage(t *testing.T) {
 				err := queries.InsertServerPackage(
 					context.Background(),
 					InsertServerPackageParams{
-						EntryID:        entryID,
+						ServerID:       entryID,
 						RegistryType:   "npm",
 						PkgRegistryUrl: "https://registry.npmjs.org",
 						PkgIdentifier:  "@test/package",
@@ -1493,36 +1171,17 @@ func TestInsertServerRemote(t *testing.T) {
 			//nolint:thelper // We want to see these lines in the test output
 			setupFunc: func(t *testing.T, queries *Queries, regID uuid.UUID) uuid.UUID {
 				createdAt := time.Now().UTC()
-				entryID, err := queries.InsertRegistryEntry(
-					context.Background(),
-					InsertRegistryEntryParams{
-						Name:      "test-server",
-						Version:   "1.0.0",
-						RegID:     regID,
-						EntryType: EntryTypeMCP,
-						CreatedAt: &createdAt,
-						UpdatedAt: &createdAt,
-					},
-				)
-				require.NoError(t, err)
-				require.NotNil(t, entryID)
-
-				serverID, err := queries.InsertServerVersion(
-					context.Background(),
-					InsertServerVersionParams{
-						EntryID: entryID,
-					},
-				)
-				require.NoError(t, err)
-				require.Equal(t, entryID, serverID)
-				return entryID
+				entryID := createEntry(t, queries, regID, "test-server", &createdAt)
+				versionID := createVersion(t, queries, entryID, "1.0.0", nil, nil, &createdAt)
+				createServer(t, queries, versionID)
+				return versionID
 			},
 			//nolint:thelper // We want to see these lines in the test output
 			scenarioFunc: func(t *testing.T, queries *Queries, entryID uuid.UUID) {
 				err := queries.InsertServerRemote(
 					context.Background(),
 					InsertServerRemoteParams{
-						EntryID:      entryID,
+						ServerID:     entryID,
 						Transport:    "sse",
 						TransportUrl: "https://example.com/sse",
 					},
@@ -1535,36 +1194,17 @@ func TestInsertServerRemote(t *testing.T) {
 			//nolint:thelper // We want to see these lines in the test output
 			setupFunc: func(t *testing.T, queries *Queries, regID uuid.UUID) uuid.UUID {
 				createdAt := time.Now().UTC()
-				entryID, err := queries.InsertRegistryEntry(
-					context.Background(),
-					InsertRegistryEntryParams{
-						Name:      "test-server",
-						Version:   "1.0.0",
-						RegID:     regID,
-						EntryType: EntryTypeMCP,
-						CreatedAt: &createdAt,
-						UpdatedAt: &createdAt,
-					},
-				)
-				require.NoError(t, err)
-				require.NotNil(t, entryID)
-
-				serverID, err := queries.InsertServerVersion(
-					context.Background(),
-					InsertServerVersionParams{
-						EntryID: entryID,
-					},
-				)
-				require.NoError(t, err)
-				require.Equal(t, entryID, serverID)
-				return entryID
+				entryID := createEntry(t, queries, regID, "test-server", &createdAt)
+				versionID := createVersion(t, queries, entryID, "1.0.0", nil, nil, &createdAt)
+				createServer(t, queries, versionID)
+				return versionID
 			},
 			//nolint:thelper // We want to see these lines in the test output
 			scenarioFunc: func(t *testing.T, queries *Queries, entryID uuid.UUID) {
 				err := queries.InsertServerRemote(
 					context.Background(),
 					InsertServerRemoteParams{
-						EntryID:          entryID,
+						ServerID:         entryID,
 						Transport:        "sse",
 						TransportUrl:     "https://example.com/sse",
 						TransportHeaders: []byte(`[{"name":"Authorization: Bearer token"},{"name":"X-Custom: value"}]`),
@@ -1578,34 +1218,15 @@ func TestInsertServerRemote(t *testing.T) {
 			//nolint:thelper // We want to see these lines in the test output
 			setupFunc: func(t *testing.T, queries *Queries, regID uuid.UUID) uuid.UUID {
 				createdAt := time.Now().UTC()
-				entryID, err := queries.InsertRegistryEntry(
-					context.Background(),
-					InsertRegistryEntryParams{
-						Name:      "test-server",
-						Version:   "1.0.0",
-						RegID:     regID,
-						EntryType: EntryTypeMCP,
-						CreatedAt: &createdAt,
-						UpdatedAt: &createdAt,
-					},
-				)
-				require.NoError(t, err)
-				require.NotNil(t, entryID)
-
-				serverID, err := queries.InsertServerVersion(
-					context.Background(),
-					InsertServerVersionParams{
-						EntryID: entryID,
-					},
-				)
-				require.NoError(t, err)
-				require.Equal(t, entryID, serverID)
+				entryID := createEntry(t, queries, regID, "test-server", &createdAt)
+				versionID := createVersion(t, queries, entryID, "1.0.0", nil, nil, &createdAt)
+				createServer(t, queries, versionID)
 
 				// Insert initial remote
-				err = queries.InsertServerRemote(
+				err := queries.InsertServerRemote(
 					context.Background(),
 					InsertServerRemoteParams{
-						EntryID:          entryID,
+						ServerID:         versionID,
 						Transport:        "sse",
 						TransportUrl:     "https://example.com/sse",
 						TransportHeaders: []byte(`[{"name":"Old-Header: old"}]`),
@@ -1613,7 +1234,7 @@ func TestInsertServerRemote(t *testing.T) {
 				)
 				require.NoError(t, err)
 
-				return entryID
+				return versionID
 			},
 			//nolint:thelper // We want to see these lines in the test output
 			scenarioFunc: func(t *testing.T, queries *Queries, entryID uuid.UUID) {
@@ -1621,7 +1242,7 @@ func TestInsertServerRemote(t *testing.T) {
 				err := queries.InsertServerRemote(
 					context.Background(),
 					InsertServerRemoteParams{
-						EntryID:          entryID,
+						ServerID:         entryID,
 						Transport:        "sse",
 						TransportUrl:     "https://example.com/sse",
 						TransportHeaders: []byte(`[{"name":"New-Header: new"}]`),
@@ -1641,7 +1262,7 @@ func TestInsertServerRemote(t *testing.T) {
 				err := queries.InsertServerRemote(
 					context.Background(),
 					InsertServerRemoteParams{
-						EntryID:      entryID,
+						ServerID:     entryID,
 						Transport:    "sse",
 						TransportUrl: "https://example.com/sse",
 					},
@@ -1683,29 +1304,10 @@ func TestListServerPackages(t *testing.T) {
 			//nolint:thelper // We want to see these lines in the test output
 			setupFunc: func(t *testing.T, queries *Queries, regID uuid.UUID) []uuid.UUID {
 				createdAt := time.Now().UTC()
-				entryID, err := queries.InsertRegistryEntry(
-					context.Background(),
-					InsertRegistryEntryParams{
-						Name:      "test-server",
-						Version:   "1.0.0",
-						RegID:     regID,
-						EntryType: EntryTypeMCP,
-						CreatedAt: &createdAt,
-						UpdatedAt: &createdAt,
-					},
-				)
-				require.NoError(t, err)
-				require.NotNil(t, entryID)
-
-				serverID, err := queries.InsertServerVersion(
-					context.Background(),
-					InsertServerVersionParams{
-						EntryID: entryID,
-					},
-				)
-				require.NoError(t, err)
-				require.Equal(t, entryID, serverID)
-				return []uuid.UUID{entryID}
+				entryID := createEntry(t, queries, regID, "test-server", &createdAt)
+				versionID := createVersion(t, queries, entryID, "1.0.0", nil, nil, &createdAt)
+				createServer(t, queries, versionID)
+				return []uuid.UUID{versionID}
 			},
 			//nolint:thelper // We want to see these lines in the test output
 			scenarioFunc: func(t *testing.T, queries *Queries, entryIDs []uuid.UUID) {
@@ -1722,33 +1324,14 @@ func TestListServerPackages(t *testing.T) {
 			//nolint:thelper // We want to see these lines in the test output
 			setupFunc: func(t *testing.T, queries *Queries, regID uuid.UUID) []uuid.UUID {
 				createdAt := time.Now().UTC()
-				entryID, err := queries.InsertRegistryEntry(
-					context.Background(),
-					InsertRegistryEntryParams{
-						Name:      "test-server",
-						Version:   "1.0.0",
-						RegID:     regID,
-						EntryType: EntryTypeMCP,
-						CreatedAt: &createdAt,
-						UpdatedAt: &createdAt,
-					},
-				)
-				require.NoError(t, err)
-				require.NotNil(t, entryID)
+				entryID := createEntry(t, queries, regID, "test-server", &createdAt)
+				versionID := createVersion(t, queries, entryID, "1.0.0", nil, nil, &createdAt)
+				createServer(t, queries, versionID)
 
-				serverID, err := queries.InsertServerVersion(
-					context.Background(),
-					InsertServerVersionParams{
-						EntryID: entryID,
-					},
-				)
-				require.NoError(t, err)
-				require.Equal(t, entryID, serverID)
-
-				err = queries.InsertServerPackage(
+				err := queries.InsertServerPackage(
 					context.Background(),
 					InsertServerPackageParams{
-						EntryID:        entryID,
+						ServerID:       versionID,
 						RegistryType:   "npm",
 						PkgRegistryUrl: "https://registry.npmjs.org",
 						PkgIdentifier:  "@test/package",
@@ -1758,7 +1341,7 @@ func TestListServerPackages(t *testing.T) {
 				)
 				require.NoError(t, err)
 
-				return []uuid.UUID{entryID}
+				return []uuid.UUID{versionID}
 			},
 			//nolint:thelper // We want to see these lines in the test output
 			scenarioFunc: func(t *testing.T, queries *Queries, entryIDs []uuid.UUID) {
@@ -1768,7 +1351,7 @@ func TestListServerPackages(t *testing.T) {
 				)
 				require.NoError(t, err)
 				require.Len(t, packages, 1)
-				require.Equal(t, entryIDs[0], packages[0].EntryID)
+				require.Equal(t, entryIDs[0], packages[0].ServerID)
 				require.Equal(t, "npm", packages[0].RegistryType)
 				require.Equal(t, "@test/package", packages[0].PkgIdentifier)
 				require.Equal(t, "1.0.0", packages[0].PkgVersion)
@@ -1782,34 +1365,15 @@ func TestListServerPackages(t *testing.T) {
 				createdAt := time.Now().UTC().Add(-1 * time.Minute)
 				for i, version := range []string{"1.0.0", "2.0.0", "3.0.0"} {
 					createdAt = createdAt.Add(1 * time.Second)
-					entryID, err := queries.InsertRegistryEntry(
-						context.Background(),
-						InsertRegistryEntryParams{
-							Name:      fmt.Sprintf("test-server-%d", i+1),
-							Version:   version,
-							RegID:     regID,
-							EntryType: EntryTypeMCP,
-							CreatedAt: &createdAt,
-							UpdatedAt: &createdAt,
-						},
-					)
-					require.NoError(t, err)
-					require.NotNil(t, entryID)
+					eID := createEntry(t, queries, regID, fmt.Sprintf("test-server-%d", i+1), &createdAt)
+					versionID := createVersion(t, queries, eID, version, nil, nil, &createdAt)
+					createServer(t, queries, versionID)
+					entryIDs = append(entryIDs, versionID)
 
-					serverID, err := queries.InsertServerVersion(
-						context.Background(),
-						InsertServerVersionParams{
-							EntryID: entryID,
-						},
-					)
-					require.NoError(t, err)
-					require.Equal(t, entryID, serverID)
-					entryIDs = append(entryIDs, entryID)
-
-					err = queries.InsertServerPackage(
+					vErr := queries.InsertServerPackage(
 						context.Background(),
 						InsertServerPackageParams{
-							EntryID:        entryID,
+							ServerID:       versionID,
 							RegistryType:   "npm",
 							PkgRegistryUrl: "https://registry.npmjs.org",
 							PkgIdentifier:  "@test/package",
@@ -1817,7 +1381,7 @@ func TestListServerPackages(t *testing.T) {
 							Transport:      "stdio",
 						},
 					)
-					require.NoError(t, err)
+					require.NoError(t, vErr)
 				}
 
 				return entryIDs
@@ -1844,34 +1408,15 @@ func TestListServerPackages(t *testing.T) {
 				createdAt := time.Now().UTC().Add(-1 * time.Minute)
 				for i, name := range []string{"server-1", "server-2"} {
 					createdAt = createdAt.Add(1 * time.Second)
-					entryID, err := queries.InsertRegistryEntry(
-						context.Background(),
-						InsertRegistryEntryParams{
-							Name:      name,
-							Version:   "1.0.0",
-							RegID:     regID,
-							EntryType: EntryTypeMCP,
-							CreatedAt: &createdAt,
-							UpdatedAt: &createdAt,
-						},
-					)
-					require.NoError(t, err)
-					require.NotNil(t, entryID)
+					eID := createEntry(t, queries, regID, name, &createdAt)
+					versionID := createVersion(t, queries, eID, "1.0.0", nil, nil, &createdAt)
+					createServer(t, queries, versionID)
+					entryIDs = append(entryIDs, versionID)
 
-					serverID, err := queries.InsertServerVersion(
-						context.Background(),
-						InsertServerVersionParams{
-							EntryID: entryID,
-						},
-					)
-					require.NoError(t, err)
-					require.Equal(t, entryID, serverID)
-					entryIDs = append(entryIDs, entryID)
-
-					err = queries.InsertServerPackage(
+					vErr := queries.InsertServerPackage(
 						context.Background(),
 						InsertServerPackageParams{
-							EntryID:        entryID,
+							ServerID:       versionID,
 							RegistryType:   "npm",
 							PkgRegistryUrl: "https://registry.npmjs.org",
 							PkgIdentifier:  fmt.Sprintf("@test/package-%d", i+1),
@@ -1879,7 +1424,7 @@ func TestListServerPackages(t *testing.T) {
 							Transport:      "stdio",
 						},
 					)
-					require.NoError(t, err)
+					require.NoError(t, vErr)
 				}
 
 				return entryIDs
@@ -1895,7 +1440,7 @@ func TestListServerPackages(t *testing.T) {
 				// Verify both servers are included
 				entryIDMap := make(map[uuid.UUID]bool)
 				for _, pkg := range packages {
-					entryIDMap[pkg.EntryID] = true
+					entryIDMap[pkg.ServerID] = true
 				}
 				require.True(t, entryIDMap[entryIDs[0]])
 				require.True(t, entryIDMap[entryIDs[1]])
@@ -1954,29 +1499,10 @@ func TestListServerRemotes(t *testing.T) {
 			//nolint:thelper // We want to see these lines in the test output
 			setupFunc: func(t *testing.T, queries *Queries, regID uuid.UUID) []uuid.UUID {
 				createdAt := time.Now().UTC()
-				entryID, err := queries.InsertRegistryEntry(
-					context.Background(),
-					InsertRegistryEntryParams{
-						Name:      "test-server",
-						Version:   "1.0.0",
-						RegID:     regID,
-						EntryType: EntryTypeMCP,
-						CreatedAt: &createdAt,
-						UpdatedAt: &createdAt,
-					},
-				)
-				require.NoError(t, err)
-				require.NotNil(t, entryID)
-
-				serverID, err := queries.InsertServerVersion(
-					context.Background(),
-					InsertServerVersionParams{
-						EntryID: entryID,
-					},
-				)
-				require.NoError(t, err)
-				require.Equal(t, entryID, serverID)
-				return []uuid.UUID{entryID}
+				entryID := createEntry(t, queries, regID, "test-server", &createdAt)
+				versionID := createVersion(t, queries, entryID, "1.0.0", nil, nil, &createdAt)
+				createServer(t, queries, versionID)
+				return []uuid.UUID{versionID}
 			},
 			//nolint:thelper // We want to see these lines in the test output
 			scenarioFunc: func(t *testing.T, queries *Queries, entryIDs []uuid.UUID) {
@@ -1993,40 +1519,21 @@ func TestListServerRemotes(t *testing.T) {
 			//nolint:thelper // We want to see these lines in the test output
 			setupFunc: func(t *testing.T, queries *Queries, regID uuid.UUID) []uuid.UUID {
 				createdAt := time.Now().UTC()
-				entryID, err := queries.InsertRegistryEntry(
-					context.Background(),
-					InsertRegistryEntryParams{
-						Name:      "test-server",
-						Version:   "1.0.0",
-						RegID:     regID,
-						EntryType: EntryTypeMCP,
-						CreatedAt: &createdAt,
-						UpdatedAt: &createdAt,
-					},
-				)
-				require.NoError(t, err)
-				require.NotNil(t, entryID)
+				entryID := createEntry(t, queries, regID, "test-server", &createdAt)
+				versionID := createVersion(t, queries, entryID, "1.0.0", nil, nil, &createdAt)
+				createServer(t, queries, versionID)
 
-				serverID, err := queries.InsertServerVersion(
-					context.Background(),
-					InsertServerVersionParams{
-						EntryID: entryID,
-					},
-				)
-				require.NoError(t, err)
-				require.Equal(t, entryID, serverID)
-
-				err = queries.InsertServerRemote(
+				err := queries.InsertServerRemote(
 					context.Background(),
 					InsertServerRemoteParams{
-						EntryID:      entryID,
+						ServerID:     versionID,
 						Transport:    "sse",
 						TransportUrl: "https://example.com/sse",
 					},
 				)
 				require.NoError(t, err)
 
-				return []uuid.UUID{entryID}
+				return []uuid.UUID{versionID}
 			},
 			//nolint:thelper // We want to see these lines in the test output
 			scenarioFunc: func(t *testing.T, queries *Queries, entryIDs []uuid.UUID) {
@@ -2036,7 +1543,7 @@ func TestListServerRemotes(t *testing.T) {
 				)
 				require.NoError(t, err)
 				require.Len(t, remotes, 1)
-				require.Equal(t, entryIDs[0], remotes[0].EntryID)
+				require.Equal(t, entryIDs[0], remotes[0].ServerID)
 				require.Equal(t, "sse", remotes[0].Transport)
 				require.Equal(t, "https://example.com/sse", remotes[0].TransportUrl)
 			},
@@ -2046,28 +1553,9 @@ func TestListServerRemotes(t *testing.T) {
 			//nolint:thelper // We want to see these lines in the test output
 			setupFunc: func(t *testing.T, queries *Queries, regID uuid.UUID) []uuid.UUID {
 				createdAt := time.Now().UTC()
-				entryID, err := queries.InsertRegistryEntry(
-					context.Background(),
-					InsertRegistryEntryParams{
-						Name:      "test-server",
-						Version:   "1.0.0",
-						RegID:     regID,
-						EntryType: EntryTypeMCP,
-						CreatedAt: &createdAt,
-						UpdatedAt: &createdAt,
-					},
-				)
-				require.NoError(t, err)
-				require.NotNil(t, entryID)
-
-				serverID, err := queries.InsertServerVersion(
-					context.Background(),
-					InsertServerVersionParams{
-						EntryID: entryID,
-					},
-				)
-				require.NoError(t, err)
-				require.Equal(t, entryID, serverID)
+				entryID := createEntry(t, queries, regID, "test-server", &createdAt)
+				versionID := createVersion(t, queries, entryID, "1.0.0", nil, nil, &createdAt)
+				createServer(t, queries, versionID)
 
 				remotes := []struct {
 					transport string
@@ -2079,18 +1567,18 @@ func TestListServerRemotes(t *testing.T) {
 				}
 
 				for _, remote := range remotes {
-					err = queries.InsertServerRemote(
+					rErr := queries.InsertServerRemote(
 						context.Background(),
 						InsertServerRemoteParams{
-							EntryID:      entryID,
+							ServerID:     versionID,
 							Transport:    remote.transport,
 							TransportUrl: remote.url,
 						},
 					)
-					require.NoError(t, err)
+					require.NoError(t, rErr)
 				}
 
-				return []uuid.UUID{entryID}
+				return []uuid.UUID{versionID}
 			},
 			//nolint:thelper // We want to see these lines in the test output
 			scenarioFunc: func(t *testing.T, queries *Queries, entryIDs []uuid.UUID) {
@@ -2100,7 +1588,7 @@ func TestListServerRemotes(t *testing.T) {
 				)
 				require.NoError(t, err)
 				require.Len(t, remotes, 3)
-				require.Equal(t, entryIDs[0], remotes[0].EntryID)
+				require.Equal(t, entryIDs[0], remotes[0].ServerID)
 				// Verify ordering by transport, then transport_url
 				require.Equal(t, "http", remotes[0].Transport)
 				require.Equal(t, "sse", remotes[1].Transport)
@@ -2118,39 +1606,20 @@ func TestListServerRemotes(t *testing.T) {
 				createdAt := time.Now().UTC().Add(-1 * time.Minute)
 				for i, name := range []string{"server-1", "server-2"} {
 					createdAt = createdAt.Add(1 * time.Second)
-					entryID, err := queries.InsertRegistryEntry(
-						context.Background(),
-						InsertRegistryEntryParams{
-							Name:      name,
-							Version:   "1.0.0",
-							RegID:     regID,
-							EntryType: EntryTypeMCP,
-							CreatedAt: &createdAt,
-							UpdatedAt: &createdAt,
-						},
-					)
-					require.NoError(t, err)
-					require.NotNil(t, entryID)
+					eID := createEntry(t, queries, regID, name, &createdAt)
+					versionID := createVersion(t, queries, eID, "1.0.0", nil, nil, &createdAt)
+					createServer(t, queries, versionID)
+					entryIDs = append(entryIDs, versionID)
 
-					serverID, err := queries.InsertServerVersion(
-						context.Background(),
-						InsertServerVersionParams{
-							EntryID: entryID,
-						},
-					)
-					require.NoError(t, err)
-					require.Equal(t, entryID, serverID)
-					entryIDs = append(entryIDs, entryID)
-
-					err = queries.InsertServerRemote(
+					vErr := queries.InsertServerRemote(
 						context.Background(),
 						InsertServerRemoteParams{
-							EntryID:      entryID,
+							ServerID:     versionID,
 							Transport:    "sse",
 							TransportUrl: fmt.Sprintf("https://example.com/sse-%d", i+1),
 						},
 					)
-					require.NoError(t, err)
+					require.NoError(t, vErr)
 				}
 
 				return entryIDs
@@ -2166,7 +1635,7 @@ func TestListServerRemotes(t *testing.T) {
 				// Verify both servers are included
 				entryIDMap := make(map[uuid.UUID]bool)
 				for _, remote := range remotes {
-					entryIDMap[remote.EntryID] = true
+					entryIDMap[remote.ServerID] = true
 				}
 				require.True(t, entryIDMap[entryIDs[0]])
 				require.True(t, entryIDMap[entryIDs[1]])
@@ -2225,28 +1694,9 @@ func TestGetServerVersion(t *testing.T) {
 			//nolint:thelper // We want to see these lines in the test output
 			setupFunc: func(t *testing.T, queries *Queries, regID uuid.UUID) (string, string) {
 				createdAt := time.Now().UTC()
-				entryID, err := queries.InsertRegistryEntry(
-					context.Background(),
-					InsertRegistryEntryParams{
-						Name:      "test-server",
-						Version:   "1.0.0",
-						RegID:     regID,
-						EntryType: EntryTypeMCP,
-						CreatedAt: &createdAt,
-						UpdatedAt: &createdAt,
-					},
-				)
-				require.NoError(t, err)
-				require.NotNil(t, entryID)
-
-				serverID, err := queries.InsertServerVersion(
-					context.Background(),
-					InsertServerVersionParams{
-						EntryID: entryID,
-					},
-				)
-				require.NoError(t, err)
-				require.Equal(t, entryID, serverID)
+				entryID := createEntry(t, queries, regID, "test-server", &createdAt)
+				versionID := createVersion(t, queries, entryID, "1.0.0", nil, nil, &createdAt)
+				createServer(t, queries, versionID)
 
 				//nolint:goconst
 				return "test-server", "1.0.0"
@@ -2274,26 +1724,12 @@ func TestGetServerVersion(t *testing.T) {
 			//nolint:thelper // We want to see these lines in the test output
 			setupFunc: func(t *testing.T, queries *Queries, regID uuid.UUID) (string, string) {
 				createdAt := time.Now().UTC()
-				entryID, err := queries.InsertRegistryEntry(
-					context.Background(),
-					InsertRegistryEntryParams{
-						Name:        "test-server",
-						Version:     "1.0.0",
-						RegID:       regID,
-						Description: ptr.String("Test description"),
-						Title:       ptr.String("Test Title"),
-						EntryType:   EntryTypeMCP,
-						CreatedAt:   &createdAt,
-						UpdatedAt:   &createdAt,
-					},
-				)
-				require.NoError(t, err)
-				require.NotNil(t, entryID)
-
+				entryID := createEntry(t, queries, regID, "test-server", &createdAt)
+				versionID := createVersion(t, queries, entryID, "1.0.0", ptr.String("Test description"), ptr.String("Test Title"), &createdAt)
 				serverID, err := queries.InsertServerVersion(
 					context.Background(),
 					InsertServerVersionParams{
-						EntryID:             entryID,
+						VersionID:           versionID,
 						Website:             ptr.String("https://example.com"),
 						UpstreamMeta:        []byte(`{"key": "value"}`),
 						ServerMeta:          []byte(`{"meta": "data"}`),
@@ -2304,7 +1740,7 @@ func TestGetServerVersion(t *testing.T) {
 					},
 				)
 				require.NoError(t, err)
-				require.Equal(t, entryID, serverID)
+				require.Equal(t, versionID, serverID)
 				return "test-server", "1.0.0"
 			},
 			//nolint:thelper // We want to see these lines in the test output
@@ -2343,36 +1779,17 @@ func TestGetServerVersion(t *testing.T) {
 			//nolint:thelper // We want to see these lines in the test output
 			setupFunc: func(t *testing.T, queries *Queries, regID uuid.UUID) (string, string) {
 				createdAt := time.Now().UTC()
-				entryID, err := queries.InsertRegistryEntry(
-					context.Background(),
-					InsertRegistryEntryParams{
-						Name:      "test-server",
-						Version:   "1.0.0",
-						RegID:     regID,
-						EntryType: EntryTypeMCP,
-						CreatedAt: &createdAt,
-						UpdatedAt: &createdAt,
-					},
-				)
-				require.NoError(t, err)
-				require.NotNil(t, entryID)
+				entryID := createEntry(t, queries, regID, "test-server", &createdAt)
+				versionID := createVersion(t, queries, entryID, "1.0.0", nil, nil, &createdAt)
+				createServer(t, queries, versionID)
 
-				serverID, err := queries.InsertServerVersion(
-					context.Background(),
-					InsertServerVersionParams{
-						EntryID: entryID,
-					},
-				)
-				require.NoError(t, err)
-				require.Equal(t, entryID, serverID)
-
-				_, err = queries.UpsertLatestServerVersion(
+				_, err := queries.UpsertLatestServerVersion(
 					context.Background(),
 					UpsertLatestServerVersionParams{
-						RegID:   regID,
-						Name:    "test-server",
-						Version: "1.0.0",
-						EntryID: entryID,
+						RegID:     regID,
+						Name:      "test-server",
+						Version:   "1.0.0",
+						VersionID: versionID,
 					},
 				)
 				require.NoError(t, err)
@@ -2398,65 +1815,27 @@ func TestGetServerVersion(t *testing.T) {
 			//nolint:thelper // We want to see these lines in the test output
 			setupFunc: func(t *testing.T, queries *Queries, regID uuid.UUID) (string, string) {
 				createdAt := time.Now().UTC().Add(-1 * time.Minute)
-				entryID1, err := queries.InsertRegistryEntry(
-					context.Background(),
-					InsertRegistryEntryParams{
-						Name:      "test-server",
-						Version:   "1.0.0",
-						RegID:     regID,
-						EntryType: EntryTypeMCP,
-						CreatedAt: &createdAt,
-						UpdatedAt: &createdAt,
-					},
-				)
-				require.NoError(t, err)
-				require.NotNil(t, entryID1)
+				entryID := createEntry(t, queries, regID, "test-server", &createdAt)
 
 				// Create first version and mark it as latest
-				serverID1, err := queries.InsertServerVersion(
-					context.Background(),
-					InsertServerVersionParams{
-						EntryID: entryID1,
-					},
-				)
-				require.NoError(t, err)
-				require.Equal(t, entryID1, serverID1)
+				versionID1 := createVersion(t, queries, entryID, "1.0.0", nil, nil, &createdAt)
+				createServer(t, queries, versionID1)
 
-				_, err = queries.UpsertLatestServerVersion(
+				_, err := queries.UpsertLatestServerVersion(
 					context.Background(),
 					UpsertLatestServerVersionParams{
-						RegID:   regID,
-						Name:    "test-server",
-						Version: "1.0.0",
-						EntryID: entryID1,
+						RegID:     regID,
+						Name:      "test-server",
+						Version:   "1.0.0",
+						VersionID: versionID1,
 					},
 				)
 				require.NoError(t, err)
 
 				// Create second version (not marked as latest)
 				createdAt2 := createdAt.Add(1 * time.Second)
-				entryID2, err := queries.InsertRegistryEntry(
-					context.Background(),
-					InsertRegistryEntryParams{
-						Name:      "test-server",
-						Version:   "2.0.0",
-						RegID:     regID,
-						EntryType: EntryTypeMCP,
-						CreatedAt: &createdAt2,
-						UpdatedAt: &createdAt2,
-					},
-				)
-				require.NoError(t, err)
-				require.NotNil(t, entryID2)
-
-				serverID2, err := queries.InsertServerVersion(
-					context.Background(),
-					InsertServerVersionParams{
-						EntryID: entryID2,
-					},
-				)
-				require.NoError(t, err)
-				require.Equal(t, entryID2, serverID2)
+				versionID2 := createVersion(t, queries, entryID, "2.0.0", nil, nil, &createdAt2)
+				createServer(t, queries, versionID2)
 				return "test-server", "2.0.0"
 			},
 			//nolint:thelper // We want to see these lines in the test output
@@ -2497,28 +1876,9 @@ func TestGetServerVersion(t *testing.T) {
 			//nolint:thelper // We want to see these lines in the test output
 			setupFunc: func(t *testing.T, queries *Queries, regID uuid.UUID) (string, string) {
 				createdAt := time.Now().UTC()
-				entryID, err := queries.InsertRegistryEntry(
-					context.Background(),
-					InsertRegistryEntryParams{
-						Name:      "test-server",
-						Version:   "1.0.0",
-						RegID:     regID,
-						EntryType: EntryTypeMCP,
-						CreatedAt: &createdAt,
-						UpdatedAt: &createdAt,
-					},
-				)
-				require.NoError(t, err)
-				require.NotNil(t, entryID)
-
-				serverID, err := queries.InsertServerVersion(
-					context.Background(),
-					InsertServerVersionParams{
-						EntryID: entryID,
-					},
-				)
-				require.NoError(t, err)
-				require.Equal(t, entryID, serverID)
+				entryID := createEntry(t, queries, regID, "test-server", &createdAt)
+				versionID := createVersion(t, queries, entryID, "1.0.0", nil, nil, &createdAt)
+				createServer(t, queries, versionID)
 				return "test-server", "2.0.0"
 			},
 			//nolint:thelper // We want to see these lines in the test output

--- a/internal/db/sqlc/skills.sql.go
+++ b/internal/db/sqlc/skills.sql.go
@@ -14,13 +14,14 @@ import (
 
 const deleteOrphanedSkills = `-- name: DeleteOrphanedSkills :exec
 WITH subset AS (
-    SELECT e.id
-      FROM registry_entry e
-     WHERE reg_id = $1
-       AND e.id != ALL($2::UUID[])
+    SELECT v.id
+      FROM entry_version v
+      JOIN registry_entry e ON v.entry_id = e.id
+     WHERE e.reg_id = $1
+       AND v.id != ALL($2::UUID[])
 )
 DELETE FROM skill s
- WHERE s.entry_id IN (SELECT id FROM subset)
+ WHERE s.version_id IN (SELECT id FROM subset)
 `
 
 type DeleteOrphanedSkillsParams struct {
@@ -34,14 +35,15 @@ func (q *Queries) DeleteOrphanedSkills(ctx context.Context, arg DeleteOrphanedSk
 }
 
 const deleteSkillsByRegistry = `-- name: DeleteSkillsByRegistry :exec
-WITH registry_entries AS (
-    SELECT e.id
-      FROM registry_entry e
-      JOIN skill s ON e.id = s.entry_id
+WITH skill_entries AS (
+    SELECT DISTINCT v.entry_id
+      FROM entry_version v
+      JOIN registry_entry e ON v.entry_id = e.id
+      JOIN skill s ON v.id = s.version_id
      WHERE e.reg_id = $1
 )
 DELETE FROM registry_entry
- WHERE id IN (SELECT id FROM registry_entries)
+ WHERE id IN (SELECT entry_id FROM skill_entries)
 `
 
 func (q *Queries) DeleteSkillsByRegistry(ctx context.Context, regID uuid.UUID) error {
@@ -51,15 +53,15 @@ func (q *Queries) DeleteSkillsByRegistry(ctx context.Context, regID uuid.UUID) e
 
 const getSkillVersion = `-- name: GetSkillVersion :one
 SELECT r.reg_type AS registry_type,
-       e.id,
+       v.id,
        e.name,
-       e.version,
-       (l.latest_entry_id IS NOT NULL)::boolean AS is_latest,
-       e.created_at,
-       e.updated_at,
-       e.description,
-       e.title,
-       s.entry_id AS skill_entry_id,
+       v.version,
+       (l.latest_version_id IS NOT NULL)::boolean AS is_latest,
+       v.created_at,
+       v.updated_at,
+       v.description,
+       v.title,
+       s.version_id AS skill_version_id,
        s.namespace,
        s.status,
        s.license,
@@ -70,12 +72,13 @@ SELECT r.reg_type AS registry_type,
        s.metadata,
        s.extension_meta
   FROM skill s
-  JOIN registry_entry e ON s.entry_id = e.id
+  JOIN entry_version v ON s.version_id = v.id
+  JOIN registry_entry e ON v.entry_id = e.id
   JOIN registry r ON e.reg_id = r.id
-  LEFT JOIN latest_entry_version l ON e.id = l.latest_entry_id
+  LEFT JOIN latest_entry_version l ON v.id = l.latest_version_id
  WHERE e.name = $1
-   AND (e.version = $2::text
-       OR ($2::text = 'latest' AND l.latest_entry_id = e.id)
+   AND (v.version = $2::text
+       OR ($2::text = 'latest' AND l.latest_version_id = v.id)
    )
    AND ($3::text IS NULL OR r.name = $3::text)
    AND ($4::text IS NULL OR s.namespace = $4::text)
@@ -89,25 +92,25 @@ type GetSkillVersionParams struct {
 }
 
 type GetSkillVersionRow struct {
-	RegistryType  RegistryType `json:"registry_type"`
-	ID            uuid.UUID    `json:"id"`
-	Name          string       `json:"name"`
-	Version       string       `json:"version"`
-	IsLatest      bool         `json:"is_latest"`
-	CreatedAt     *time.Time   `json:"created_at"`
-	UpdatedAt     *time.Time   `json:"updated_at"`
-	Description   *string      `json:"description"`
-	Title         *string      `json:"title"`
-	SkillEntryID  uuid.UUID    `json:"skill_entry_id"`
-	Namespace     string       `json:"namespace"`
-	Status        SkillStatus  `json:"status"`
-	License       *string      `json:"license"`
-	Compatibility *string      `json:"compatibility"`
-	AllowedTools  []string     `json:"allowed_tools"`
-	Repository    []byte       `json:"repository"`
-	Icons         []byte       `json:"icons"`
-	Metadata      []byte       `json:"metadata"`
-	ExtensionMeta []byte       `json:"extension_meta"`
+	RegistryType   RegistryType `json:"registry_type"`
+	ID             uuid.UUID    `json:"id"`
+	Name           string       `json:"name"`
+	Version        string       `json:"version"`
+	IsLatest       bool         `json:"is_latest"`
+	CreatedAt      *time.Time   `json:"created_at"`
+	UpdatedAt      *time.Time   `json:"updated_at"`
+	Description    *string      `json:"description"`
+	Title          *string      `json:"title"`
+	SkillVersionID uuid.UUID    `json:"skill_version_id"`
+	Namespace      string       `json:"namespace"`
+	Status         SkillStatus  `json:"status"`
+	License        *string      `json:"license"`
+	Compatibility  *string      `json:"compatibility"`
+	AllowedTools   []string     `json:"allowed_tools"`
+	Repository     []byte       `json:"repository"`
+	Icons          []byte       `json:"icons"`
+	Metadata       []byte       `json:"metadata"`
+	ExtensionMeta  []byte       `json:"extension_meta"`
 }
 
 func (q *Queries) GetSkillVersion(ctx context.Context, arg GetSkillVersionParams) (GetSkillVersionRow, error) {
@@ -128,7 +131,7 @@ func (q *Queries) GetSkillVersion(ctx context.Context, arg GetSkillVersionParams
 		&i.UpdatedAt,
 		&i.Description,
 		&i.Title,
-		&i.SkillEntryID,
+		&i.SkillVersionID,
 		&i.Namespace,
 		&i.Status,
 		&i.License,
@@ -144,7 +147,7 @@ func (q *Queries) GetSkillVersion(ctx context.Context, arg GetSkillVersionParams
 
 const insertSkillGitPackage = `-- name: InsertSkillGitPackage :exec
 INSERT INTO skill_git_package (
-    skill_entry_id,
+    skill_id,
     url,
     ref,
     commit_sha,
@@ -159,16 +162,16 @@ INSERT INTO skill_git_package (
 `
 
 type InsertSkillGitPackageParams struct {
-	SkillEntryID uuid.UUID `json:"skill_entry_id"`
-	Url          string    `json:"url"`
-	Ref          *string   `json:"ref"`
-	CommitSha    *string   `json:"commit_sha"`
-	Subfolder    *string   `json:"subfolder"`
+	SkillID   uuid.UUID `json:"skill_id"`
+	Url       string    `json:"url"`
+	Ref       *string   `json:"ref"`
+	CommitSha *string   `json:"commit_sha"`
+	Subfolder *string   `json:"subfolder"`
 }
 
 func (q *Queries) InsertSkillGitPackage(ctx context.Context, arg InsertSkillGitPackageParams) error {
 	_, err := q.db.Exec(ctx, insertSkillGitPackage,
-		arg.SkillEntryID,
+		arg.SkillID,
 		arg.Url,
 		arg.Ref,
 		arg.CommitSha,
@@ -179,7 +182,7 @@ func (q *Queries) InsertSkillGitPackage(ctx context.Context, arg InsertSkillGitP
 
 const insertSkillOciPackage = `-- name: InsertSkillOciPackage :exec
 INSERT INTO skill_oci_package (
-    skill_entry_id,
+    skill_id,
     identifier,
     digest,
     media_type
@@ -192,15 +195,15 @@ INSERT INTO skill_oci_package (
 `
 
 type InsertSkillOciPackageParams struct {
-	SkillEntryID uuid.UUID `json:"skill_entry_id"`
-	Identifier   string    `json:"identifier"`
-	Digest       *string   `json:"digest"`
-	MediaType    *string   `json:"media_type"`
+	SkillID    uuid.UUID `json:"skill_id"`
+	Identifier string    `json:"identifier"`
+	Digest     *string   `json:"digest"`
+	MediaType  *string   `json:"media_type"`
 }
 
 func (q *Queries) InsertSkillOciPackage(ctx context.Context, arg InsertSkillOciPackageParams) error {
 	_, err := q.db.Exec(ctx, insertSkillOciPackage,
-		arg.SkillEntryID,
+		arg.SkillID,
 		arg.Identifier,
 		arg.Digest,
 		arg.MediaType,
@@ -210,7 +213,7 @@ func (q *Queries) InsertSkillOciPackage(ctx context.Context, arg InsertSkillOciP
 
 const insertSkillVersion = `-- name: InsertSkillVersion :one
 INSERT INTO skill (
-    entry_id,
+    version_id,
     namespace,
     status,
     license,
@@ -232,11 +235,11 @@ INSERT INTO skill (
     $9,
     $10
 )
-RETURNING entry_id
+RETURNING version_id
 `
 
 type InsertSkillVersionParams struct {
-	EntryID       uuid.UUID       `json:"entry_id"`
+	VersionID     uuid.UUID       `json:"version_id"`
 	Namespace     string          `json:"namespace"`
 	Status        NullSkillStatus `json:"status"`
 	License       *string         `json:"license"`
@@ -250,7 +253,7 @@ type InsertSkillVersionParams struct {
 
 func (q *Queries) InsertSkillVersion(ctx context.Context, arg InsertSkillVersionParams) (uuid.UUID, error) {
 	row := q.db.QueryRow(ctx, insertSkillVersion,
-		arg.EntryID,
+		arg.VersionID,
 		arg.Namespace,
 		arg.Status,
 		arg.License,
@@ -261,14 +264,14 @@ func (q *Queries) InsertSkillVersion(ctx context.Context, arg InsertSkillVersion
 		arg.Metadata,
 		arg.ExtensionMeta,
 	)
-	var entry_id uuid.UUID
-	err := row.Scan(&entry_id)
-	return entry_id, err
+	var version_id uuid.UUID
+	err := row.Scan(&version_id)
+	return version_id, err
 }
 
 const insertSkillVersionForSync = `-- name: InsertSkillVersionForSync :one
 INSERT INTO skill (
-    entry_id,
+    version_id,
     namespace,
     status,
     license,
@@ -290,11 +293,11 @@ INSERT INTO skill (
     $9,
     $10
 )
-RETURNING entry_id
+RETURNING version_id
 `
 
 type InsertSkillVersionForSyncParams struct {
-	EntryID       uuid.UUID       `json:"entry_id"`
+	VersionID     uuid.UUID       `json:"version_id"`
 	Namespace     string          `json:"namespace"`
 	Status        NullSkillStatus `json:"status"`
 	License       *string         `json:"license"`
@@ -308,7 +311,7 @@ type InsertSkillVersionForSyncParams struct {
 
 func (q *Queries) InsertSkillVersionForSync(ctx context.Context, arg InsertSkillVersionForSyncParams) (uuid.UUID, error) {
 	row := q.db.QueryRow(ctx, insertSkillVersionForSync,
-		arg.EntryID,
+		arg.VersionID,
 		arg.Namespace,
 		arg.Status,
 		arg.License,
@@ -319,25 +322,25 @@ func (q *Queries) InsertSkillVersionForSync(ctx context.Context, arg InsertSkill
 		arg.Metadata,
 		arg.ExtensionMeta,
 	)
-	var entry_id uuid.UUID
-	err := row.Scan(&entry_id)
-	return entry_id, err
+	var version_id uuid.UUID
+	err := row.Scan(&version_id)
+	return version_id, err
 }
 
 const listSkillGitPackages = `-- name: ListSkillGitPackages :many
 SELECT p.id,
-       p.skill_entry_id,
+       p.skill_id,
        p.url,
        p.ref,
        p.commit_sha,
        p.subfolder
   FROM skill_git_package p
-  JOIN skill s ON p.skill_entry_id = s.entry_id
- WHERE s.entry_id = ANY($1::UUID[])
+  JOIN skill s ON p.skill_id = s.version_id
+ WHERE s.version_id = ANY($1::UUID[])
 `
 
-func (q *Queries) ListSkillGitPackages(ctx context.Context, entryIds []uuid.UUID) ([]SkillGitPackage, error) {
-	rows, err := q.db.Query(ctx, listSkillGitPackages, entryIds)
+func (q *Queries) ListSkillGitPackages(ctx context.Context, versionIds []uuid.UUID) ([]SkillGitPackage, error) {
+	rows, err := q.db.Query(ctx, listSkillGitPackages, versionIds)
 	if err != nil {
 		return nil, err
 	}
@@ -347,7 +350,7 @@ func (q *Queries) ListSkillGitPackages(ctx context.Context, entryIds []uuid.UUID
 		var i SkillGitPackage
 		if err := rows.Scan(
 			&i.ID,
-			&i.SkillEntryID,
+			&i.SkillID,
 			&i.Url,
 			&i.Ref,
 			&i.CommitSha,
@@ -365,17 +368,17 @@ func (q *Queries) ListSkillGitPackages(ctx context.Context, entryIds []uuid.UUID
 
 const listSkillOciPackages = `-- name: ListSkillOciPackages :many
 SELECT p.id,
-       p.skill_entry_id,
+       p.skill_id,
        p.identifier,
        p.digest,
        p.media_type
   FROM skill_oci_package p
-  JOIN skill s ON p.skill_entry_id = s.entry_id
- WHERE s.entry_id = ANY($1::UUID[])
+  JOIN skill s ON p.skill_id = s.version_id
+ WHERE s.version_id = ANY($1::UUID[])
 `
 
-func (q *Queries) ListSkillOciPackages(ctx context.Context, entryIds []uuid.UUID) ([]SkillOciPackage, error) {
-	rows, err := q.db.Query(ctx, listSkillOciPackages, entryIds)
+func (q *Queries) ListSkillOciPackages(ctx context.Context, versionIds []uuid.UUID) ([]SkillOciPackage, error) {
+	rows, err := q.db.Query(ctx, listSkillOciPackages, versionIds)
 	if err != nil {
 		return nil, err
 	}
@@ -385,7 +388,7 @@ func (q *Queries) ListSkillOciPackages(ctx context.Context, entryIds []uuid.UUID
 		var i SkillOciPackage
 		if err := rows.Scan(
 			&i.ID,
-			&i.SkillEntryID,
+			&i.SkillID,
 			&i.Identifier,
 			&i.Digest,
 			&i.MediaType,
@@ -402,14 +405,14 @@ func (q *Queries) ListSkillOciPackages(ctx context.Context, entryIds []uuid.UUID
 
 const listSkills = `-- name: ListSkills :many
 SELECT r.reg_type AS registry_type,
-       s.entry_id,
+       s.version_id,
        e.name,
-       e.version,
-       (l.latest_entry_id IS NOT NULL)::boolean AS is_latest,
-       e.created_at,
-       e.updated_at,
-       e.description,
-       e.title,
+       v.version,
+       (l.latest_version_id IS NOT NULL)::boolean AS is_latest,
+       v.created_at,
+       v.updated_at,
+       v.description,
+       v.title,
        s.namespace,
        s.status,
        s.license,
@@ -420,23 +423,24 @@ SELECT r.reg_type AS registry_type,
        s.metadata,
        s.extension_meta
   FROM skill s
-  JOIN registry_entry e ON s.entry_id = e.id
+  JOIN entry_version v ON s.version_id = v.id
+  JOIN registry_entry e ON v.entry_id = e.id
   JOIN registry r ON e.reg_id = r.id
-  LEFT JOIN latest_entry_version l ON e.id = l.latest_entry_id
+  LEFT JOIN latest_entry_version l ON v.id = l.latest_version_id
  WHERE ($1::text IS NULL OR r.name = $1::text)
    AND ($2::text IS NULL OR s.namespace = $2::text)
    AND ($3::text IS NULL OR e.name = $3::text)
    AND ($4::text IS NULL OR (
        LOWER(e.name) LIKE LOWER('%' || $4::text || '%')
-       OR LOWER(e.title) LIKE LOWER('%' || $4::text || '%')
-       OR LOWER(e.description) LIKE LOWER('%' || $4::text || '%')
+       OR LOWER(v.title) LIKE LOWER('%' || $4::text || '%')
+       OR LOWER(v.description) LIKE LOWER('%' || $4::text || '%')
    ))
-   AND ($5::timestamp with time zone IS NULL OR e.updated_at > $5::timestamp with time zone)
+   AND ($5::timestamp with time zone IS NULL OR v.updated_at > $5::timestamp with time zone)
    AND (
        $6::text IS NULL
-       OR (e.name, e.version) > ($6::text, $7::text)
+       OR (e.name, v.version) > ($6::text, $7::text)
    )
- ORDER BY e.name ASC, e.version ASC
+ ORDER BY e.name ASC, v.version ASC
  LIMIT $8::bigint
 `
 
@@ -453,7 +457,7 @@ type ListSkillsParams struct {
 
 type ListSkillsRow struct {
 	RegistryType  RegistryType `json:"registry_type"`
-	EntryID       uuid.UUID    `json:"entry_id"`
+	VersionID     uuid.UUID    `json:"version_id"`
 	Name          string       `json:"name"`
 	Version       string       `json:"version"`
 	IsLatest      bool         `json:"is_latest"`
@@ -495,7 +499,7 @@ func (q *Queries) ListSkills(ctx context.Context, arg ListSkillsParams) ([]ListS
 		var i ListSkillsRow
 		if err := rows.Scan(
 			&i.RegistryType,
-			&i.EntryID,
+			&i.VersionID,
 			&i.Name,
 			&i.Version,
 			&i.IsLatest,
@@ -528,7 +532,7 @@ INSERT INTO latest_entry_version (
     reg_id,
     name,
     version,
-    latest_entry_id
+    latest_version_id
 ) VALUES (
     $1,
     $2,
@@ -537,15 +541,15 @@ INSERT INTO latest_entry_version (
 ) ON CONFLICT (reg_id, name)
   DO UPDATE SET
     version = $3,
-    latest_entry_id = $4
-RETURNING latest_entry_id
+    latest_version_id = $4
+RETURNING latest_version_id
 `
 
 type UpsertLatestSkillVersionParams struct {
-	RegID   uuid.UUID `json:"reg_id"`
-	Name    string    `json:"name"`
-	Version string    `json:"version"`
-	EntryID uuid.UUID `json:"entry_id"`
+	RegID     uuid.UUID `json:"reg_id"`
+	Name      string    `json:"name"`
+	Version   string    `json:"version"`
+	VersionID uuid.UUID `json:"version_id"`
 }
 
 func (q *Queries) UpsertLatestSkillVersion(ctx context.Context, arg UpsertLatestSkillVersionParams) (uuid.UUID, error) {
@@ -553,16 +557,16 @@ func (q *Queries) UpsertLatestSkillVersion(ctx context.Context, arg UpsertLatest
 		arg.RegID,
 		arg.Name,
 		arg.Version,
-		arg.EntryID,
+		arg.VersionID,
 	)
-	var latest_entry_id uuid.UUID
-	err := row.Scan(&latest_entry_id)
-	return latest_entry_id, err
+	var latest_version_id uuid.UUID
+	err := row.Scan(&latest_version_id)
+	return latest_version_id, err
 }
 
 const upsertSkillVersionForSync = `-- name: UpsertSkillVersionForSync :one
 INSERT INTO skill (
-    entry_id,
+    version_id,
     namespace,
     status,
     license,
@@ -584,7 +588,7 @@ INSERT INTO skill (
     $9,
     $10
 )
-ON CONFLICT (entry_id)
+ON CONFLICT (version_id)
 DO UPDATE SET
     status = COALESCE($3::skill_status, skill.status),
     license = $4,
@@ -594,11 +598,11 @@ DO UPDATE SET
     icons = $8,
     metadata = $9,
     extension_meta = $10
-RETURNING entry_id
+RETURNING version_id
 `
 
 type UpsertSkillVersionForSyncParams struct {
-	EntryID       uuid.UUID       `json:"entry_id"`
+	VersionID     uuid.UUID       `json:"version_id"`
 	Namespace     string          `json:"namespace"`
 	Status        NullSkillStatus `json:"status"`
 	License       *string         `json:"license"`
@@ -612,7 +616,7 @@ type UpsertSkillVersionForSyncParams struct {
 
 func (q *Queries) UpsertSkillVersionForSync(ctx context.Context, arg UpsertSkillVersionForSyncParams) (uuid.UUID, error) {
 	row := q.db.QueryRow(ctx, upsertSkillVersionForSync,
-		arg.EntryID,
+		arg.VersionID,
 		arg.Namespace,
 		arg.Status,
 		arg.License,
@@ -623,7 +627,7 @@ func (q *Queries) UpsertSkillVersionForSync(ctx context.Context, arg UpsertSkill
 		arg.Metadata,
 		arg.ExtensionMeta,
 	)
-	var entry_id uuid.UUID
-	err := row.Scan(&entry_id)
-	return entry_id, err
+	var version_id uuid.UUID
+	err := row.Scan(&version_id)
+	return version_id, err
 }

--- a/internal/db/sqlc/skills_test.go
+++ b/internal/db/sqlc/skills_test.go
@@ -26,31 +26,41 @@ func createSkillEntry(
 	entryID, err := queries.InsertRegistryEntry(
 		context.Background(),
 		InsertRegistryEntryParams{
-			Name:        name,
+			Name:      name,
+			RegID:     regID,
+			EntryType: EntryTypeSKILL,
+			CreatedAt: &createdAt,
+			UpdatedAt: &createdAt,
+		},
+	)
+	require.NoError(t, err)
+
+	versionID, err := queries.InsertEntryVersion(
+		context.Background(),
+		InsertEntryVersionParams{
+			EntryID:     entryID,
 			Version:     version,
-			RegID:       regID,
-			EntryType:   EntryTypeSKILL,
-			Description: description,
 			Title:       title,
+			Description: description,
 			CreatedAt:   &createdAt,
 			UpdatedAt:   &createdAt,
 		},
 	)
 	require.NoError(t, err)
-	return entryID
+	return versionID
 }
 
 //nolint:thelper // We want to see these lines in the test output
 func insertSkill(
 	t *testing.T,
 	queries *Queries,
-	entryID uuid.UUID,
+	versionID uuid.UUID,
 	namespace string,
 ) uuid.UUID {
 	skillEntryID, err := queries.InsertSkillVersion(
 		context.Background(),
 		InsertSkillVersionParams{
-			EntryID:       entryID,
+			VersionID:     versionID,
 			Namespace:     namespace,
 			Status:        NullSkillStatus{SkillStatus: SkillStatusACTIVE, Valid: true},
 			Repository:    []byte(`{}`),
@@ -77,12 +87,12 @@ func TestInsertSkillVersion(t *testing.T) {
 			setupFunc: func(_ *testing.T, _ *Queries, _ uuid.UUID) {},
 			//nolint:thelper // We want to see these lines in the test output
 			scenarioFunc: func(t *testing.T, queries *Queries, regID uuid.UUID) {
-				entryID := createSkillEntry(t, queries, regID, "test-skill", "1.0.0", nil, nil)
+				versionID := createSkillEntry(t, queries, regID, "test-skill", "1.0.0", nil, nil)
 
 				skillEntryID, err := queries.InsertSkillVersion(
 					context.Background(),
 					InsertSkillVersionParams{
-						EntryID:       entryID,
+						VersionID:     versionID,
 						Namespace:     "test-namespace",
 						Repository:    []byte(`{}`),
 						Icons:         []byte(`[]`),
@@ -91,7 +101,7 @@ func TestInsertSkillVersion(t *testing.T) {
 					},
 				)
 				require.NoError(t, err)
-				require.Equal(t, entryID, skillEntryID)
+				require.Equal(t, versionID, skillEntryID)
 			},
 		},
 		{
@@ -100,13 +110,13 @@ func TestInsertSkillVersion(t *testing.T) {
 			setupFunc: func(_ *testing.T, _ *Queries, _ uuid.UUID) {},
 			//nolint:thelper // We want to see these lines in the test output
 			scenarioFunc: func(t *testing.T, queries *Queries, regID uuid.UUID) {
-				entryID := createSkillEntry(t, queries, regID, "test-skill", "1.0.0",
+				versionID := createSkillEntry(t, queries, regID, "test-skill", "1.0.0",
 					ptr.String("A test skill"), ptr.String("Test Skill"))
 
 				skillEntryID, err := queries.InsertSkillVersion(
 					context.Background(),
 					InsertSkillVersionParams{
-						EntryID:       entryID,
+						VersionID:     versionID,
 						Namespace:     "test-namespace",
 						Status:        NullSkillStatus{SkillStatus: SkillStatusACTIVE, Valid: true},
 						License:       ptr.String("MIT"),
@@ -119,26 +129,51 @@ func TestInsertSkillVersion(t *testing.T) {
 					},
 				)
 				require.NoError(t, err)
-				require.Equal(t, entryID, skillEntryID)
+				require.Equal(t, versionID, skillEntryID)
 			},
 		},
 		{
 			name: "insert duplicate skill version fails",
 			//nolint:thelper // We want to see these lines in the test output
 			setupFunc: func(t *testing.T, queries *Queries, regID uuid.UUID) {
-				entryID := createSkillEntry(t, queries, regID, "test-skill", "1.0.0", nil, nil)
-				insertSkill(t, queries, entryID, "test-namespace")
+				versionID := createSkillEntry(t, queries, regID, "test-skill", "1.0.0", nil, nil)
+				insertSkill(t, queries, versionID, "test-namespace")
 			},
 			//nolint:thelper // We want to see these lines in the test output
 			scenarioFunc: func(t *testing.T, queries *Queries, regID uuid.UUID) {
-				// Inserting a duplicate registry entry (same name+version+reg_id) should fail
-				_, err := queries.InsertRegistryEntry(
+				// Look up the registry_entry to get its ID for the duplicate version insert
+				createdAt := time.Now().UTC()
+				entryID, err := queries.InsertRegistryEntry(
 					context.Background(),
 					InsertRegistryEntryParams{
-						Name:      "test-skill",
-						Version:   "1.0.0",
+						Name:      "test-skill-dup",
 						RegID:     regID,
 						EntryType: EntryTypeSKILL,
+						CreatedAt: &createdAt,
+						UpdatedAt: &createdAt,
+					},
+				)
+				require.NoError(t, err)
+
+				_, err = queries.InsertEntryVersion(
+					context.Background(),
+					InsertEntryVersionParams{
+						EntryID:   entryID,
+						Version:   "1.0.0",
+						CreatedAt: &createdAt,
+						UpdatedAt: &createdAt,
+					},
+				)
+				require.NoError(t, err)
+
+				// Inserting a duplicate entry_version (same entry_id+version) should fail
+				_, err = queries.InsertEntryVersion(
+					context.Background(),
+					InsertEntryVersionParams{
+						EntryID:   entryID,
+						Version:   "1.0.0",
+						CreatedAt: &createdAt,
+						UpdatedAt: &createdAt,
 					},
 				)
 				require.Error(t, err)
@@ -153,7 +188,7 @@ func TestInsertSkillVersion(t *testing.T) {
 				_, err := queries.InsertSkillVersion(
 					context.Background(),
 					InsertSkillVersionParams{
-						EntryID:       uuid.New(),
+						VersionID:     uuid.New(),
 						Namespace:     "test-namespace",
 						Repository:    []byte(`{}`),
 						Icons:         []byte(`[]`),
@@ -170,12 +205,12 @@ func TestInsertSkillVersion(t *testing.T) {
 			setupFunc: func(_ *testing.T, _ *Queries, _ uuid.UUID) {},
 			//nolint:thelper // We want to see these lines in the test output
 			scenarioFunc: func(t *testing.T, queries *Queries, regID uuid.UUID) {
-				entryID := createSkillEntry(t, queries, regID, "test-skill", "1.0.0", nil, nil)
+				versionID := createSkillEntry(t, queries, regID, "test-skill", "1.0.0", nil, nil)
 
 				skillEntryID, err := queries.InsertSkillVersion(
 					context.Background(),
 					InsertSkillVersionParams{
-						EntryID:       entryID,
+						VersionID:     versionID,
 						Namespace:     "test-namespace",
 						Status:        NullSkillStatus{Valid: false},
 						Repository:    []byte(`{}`),
@@ -195,7 +230,7 @@ func TestInsertSkillVersion(t *testing.T) {
 					},
 				)
 				require.NoError(t, err)
-				require.Equal(t, skillEntryID, skill.SkillEntryID)
+				require.Equal(t, skillEntryID, skill.SkillVersionID)
 				require.Equal(t, SkillStatusACTIVE, skill.Status)
 			},
 		},
@@ -234,12 +269,12 @@ func TestInsertSkillVersionForSync(t *testing.T) {
 			setupFunc: func(_ *testing.T, _ *Queries, _ uuid.UUID) {},
 			//nolint:thelper // We want to see these lines in the test output
 			scenarioFunc: func(t *testing.T, queries *Queries, regID uuid.UUID) {
-				entryID := createSkillEntry(t, queries, regID, "test-skill", "1.0.0", nil, nil)
+				versionID := createSkillEntry(t, queries, regID, "test-skill", "1.0.0", nil, nil)
 
 				skillEntryID, err := queries.InsertSkillVersionForSync(
 					context.Background(),
 					InsertSkillVersionForSyncParams{
-						EntryID:       entryID,
+						VersionID:     versionID,
 						Namespace:     "test-namespace",
 						Repository:    []byte(`{}`),
 						Icons:         []byte(`[]`),
@@ -248,7 +283,7 @@ func TestInsertSkillVersionForSync(t *testing.T) {
 					},
 				)
 				require.NoError(t, err)
-				require.Equal(t, entryID, skillEntryID)
+				require.Equal(t, versionID, skillEntryID)
 			},
 		},
 		{
@@ -257,13 +292,13 @@ func TestInsertSkillVersionForSync(t *testing.T) {
 			setupFunc: func(_ *testing.T, _ *Queries, _ uuid.UUID) {},
 			//nolint:thelper // We want to see these lines in the test output
 			scenarioFunc: func(t *testing.T, queries *Queries, regID uuid.UUID) {
-				entryID := createSkillEntry(t, queries, regID, "test-skill", "1.0.0",
+				versionID := createSkillEntry(t, queries, regID, "test-skill", "1.0.0",
 					ptr.String("Sync skill"), ptr.String("Sync Skill Title"))
 
 				skillEntryID, err := queries.InsertSkillVersionForSync(
 					context.Background(),
 					InsertSkillVersionForSyncParams{
-						EntryID:       entryID,
+						VersionID:     versionID,
 						Namespace:     "sync-namespace",
 						Status:        NullSkillStatus{SkillStatus: SkillStatusDEPRECATED, Valid: true},
 						License:       ptr.String("Apache-2.0"),
@@ -276,7 +311,7 @@ func TestInsertSkillVersionForSync(t *testing.T) {
 					},
 				)
 				require.NoError(t, err)
-				require.Equal(t, entryID, skillEntryID)
+				require.Equal(t, versionID, skillEntryID)
 			},
 		},
 		{
@@ -288,7 +323,7 @@ func TestInsertSkillVersionForSync(t *testing.T) {
 				_, err := queries.InsertSkillVersionForSync(
 					context.Background(),
 					InsertSkillVersionForSyncParams{
-						EntryID:       uuid.New(),
+						VersionID:     uuid.New(),
 						Namespace:     "test-namespace",
 						Repository:    []byte(`{}`),
 						Icons:         []byte(`[]`),
@@ -334,12 +369,12 @@ func TestUpsertSkillVersionForSync(t *testing.T) {
 			setupFunc: func(_ *testing.T, _ *Queries, _ uuid.UUID) {},
 			//nolint:thelper // We want to see these lines in the test output
 			scenarioFunc: func(t *testing.T, queries *Queries, regID uuid.UUID) {
-				entryID := createSkillEntry(t, queries, regID, "test-skill", "1.0.0", nil, nil)
+				versionID := createSkillEntry(t, queries, regID, "test-skill", "1.0.0", nil, nil)
 
 				skillEntryID, err := queries.UpsertSkillVersionForSync(
 					context.Background(),
 					UpsertSkillVersionForSyncParams{
-						EntryID:       entryID,
+						VersionID:     versionID,
 						Namespace:     "test-namespace",
 						Status:        NullSkillStatus{SkillStatus: SkillStatusACTIVE, Valid: true},
 						License:       ptr.String("MIT"),
@@ -350,15 +385,15 @@ func TestUpsertSkillVersionForSync(t *testing.T) {
 					},
 				)
 				require.NoError(t, err)
-				require.Equal(t, entryID, skillEntryID)
+				require.Equal(t, versionID, skillEntryID)
 			},
 		},
 		{
 			name: "update existing skill version via upsert",
 			//nolint:thelper // We want to see these lines in the test output
 			setupFunc: func(t *testing.T, queries *Queries, regID uuid.UUID) {
-				entryID := createSkillEntry(t, queries, regID, "test-skill", "1.0.0", nil, nil)
-				insertSkill(t, queries, entryID, "test-namespace")
+				versionID := createSkillEntry(t, queries, regID, "test-skill", "1.0.0", nil, nil)
+				insertSkill(t, queries, versionID, "test-namespace")
 			},
 			//nolint:thelper // We want to see these lines in the test output
 			scenarioFunc: func(t *testing.T, queries *Queries, _ uuid.UUID) {
@@ -373,10 +408,10 @@ func TestUpsertSkillVersionForSync(t *testing.T) {
 				require.NoError(t, err)
 
 				// Upsert should update the existing row
-				skillEntryID, err := queries.UpsertSkillVersionForSync(
+				skillVersionID, err := queries.UpsertSkillVersionForSync(
 					context.Background(),
 					UpsertSkillVersionForSyncParams{
-						EntryID:       existing.SkillEntryID,
+						VersionID:     existing.SkillVersionID,
 						Namespace:     "test-namespace",
 						Status:        NullSkillStatus{SkillStatus: SkillStatusDEPRECATED, Valid: true},
 						License:       ptr.String("Apache-2.0"),
@@ -389,7 +424,7 @@ func TestUpsertSkillVersionForSync(t *testing.T) {
 					},
 				)
 				require.NoError(t, err)
-				require.Equal(t, existing.SkillEntryID, skillEntryID)
+				require.Equal(t, existing.SkillVersionID, skillVersionID)
 
 				// Verify the update
 				skill, err := queries.GetSkillVersion(
@@ -414,7 +449,7 @@ func TestUpsertSkillVersionForSync(t *testing.T) {
 				_, err := queries.UpsertSkillVersionForSync(
 					context.Background(),
 					UpsertSkillVersionForSyncParams{
-						EntryID:       uuid.New(),
+						VersionID:     uuid.New(),
 						Namespace:     "test-namespace",
 						Repository:    []byte(`{}`),
 						Icons:         []byte(`[]`),
@@ -487,13 +522,13 @@ func TestGetSkillVersion(t *testing.T) {
 			name: "get skill version with all fields",
 			//nolint:thelper // We want to see these lines in the test output
 			setupFunc: func(t *testing.T, queries *Queries, regID uuid.UUID) (string, string) {
-				entryID := createSkillEntry(t, queries, regID, "test-skill", "1.0.0",
+				versionID := createSkillEntry(t, queries, regID, "test-skill", "1.0.0",
 					ptr.String("A test skill"), ptr.String("Test Skill"))
 
 				_, err := queries.InsertSkillVersion(
 					context.Background(),
 					InsertSkillVersionParams{
-						EntryID:       entryID,
+						VersionID:     versionID,
 						Namespace:     "full-namespace",
 						Status:        NullSkillStatus{SkillStatus: SkillStatusACTIVE, Valid: true},
 						License:       ptr.String("MIT"),
@@ -541,16 +576,16 @@ func TestGetSkillVersion(t *testing.T) {
 			name: "get skill version marked as latest",
 			//nolint:thelper // We want to see these lines in the test output
 			setupFunc: func(t *testing.T, queries *Queries, regID uuid.UUID) (string, string) {
-				entryID := createSkillEntry(t, queries, regID, "test-skill", "1.0.0", nil, nil)
-				insertSkill(t, queries, entryID, "test-namespace")
+				versionID := createSkillEntry(t, queries, regID, "test-skill", "1.0.0", nil, nil)
+				insertSkill(t, queries, versionID, "test-namespace")
 
 				_, err := queries.UpsertLatestSkillVersion(
 					context.Background(),
 					UpsertLatestSkillVersionParams{
-						RegID:   regID,
-						Name:    "test-skill",
-						Version: "1.0.0",
-						EntryID: entryID,
+						RegID:     regID,
+						Name:      "test-skill",
+						Version:   "1.0.0",
+						VersionID: versionID,
 					},
 				)
 				require.NoError(t, err)
@@ -575,16 +610,16 @@ func TestGetSkillVersion(t *testing.T) {
 			name: "get skill version using latest alias",
 			//nolint:thelper // We want to see these lines in the test output
 			setupFunc: func(t *testing.T, queries *Queries, regID uuid.UUID) (string, string) {
-				entryID := createSkillEntry(t, queries, regID, "test-skill", "2.0.0", nil, nil)
-				insertSkill(t, queries, entryID, "test-namespace")
+				versionID := createSkillEntry(t, queries, regID, "test-skill", "2.0.0", nil, nil)
+				insertSkill(t, queries, versionID, "test-namespace")
 
 				_, err := queries.UpsertLatestSkillVersion(
 					context.Background(),
 					UpsertLatestSkillVersionParams{
-						RegID:   regID,
-						Name:    "test-skill",
-						Version: "2.0.0",
-						EntryID: entryID,
+						RegID:     regID,
+						Name:      "test-skill",
+						Version:   "2.0.0",
+						VersionID: versionID,
 					},
 				)
 				require.NoError(t, err)
@@ -610,8 +645,8 @@ func TestGetSkillVersion(t *testing.T) {
 			name: "get skill version filtered by registry name",
 			//nolint:thelper // We want to see these lines in the test output
 			setupFunc: func(t *testing.T, queries *Queries, regID uuid.UUID) (string, string) {
-				entryID := createSkillEntry(t, queries, regID, "test-skill", "1.0.0", nil, nil)
-				insertSkill(t, queries, entryID, "test-namespace")
+				versionID := createSkillEntry(t, queries, regID, "test-skill", "1.0.0", nil, nil)
+				insertSkill(t, queries, versionID, "test-namespace")
 				return "test-skill", "1.0.0"
 			},
 			//nolint:thelper // We want to see these lines in the test output
@@ -917,11 +952,10 @@ func TestListSkills(t *testing.T) {
 				oldTime := time.Now().UTC().Add(-1 * time.Hour)
 				recentTime := time.Now().UTC()
 
-				entryID1, err := queries.InsertRegistryEntry(
+				oldEntryID, err := queries.InsertRegistryEntry(
 					context.Background(),
 					InsertRegistryEntryParams{
 						Name:      "old-skill",
-						Version:   "1.0.0",
 						RegID:     regID,
 						EntryType: EntryTypeSKILL,
 						CreatedAt: &oldTime,
@@ -929,13 +963,22 @@ func TestListSkills(t *testing.T) {
 					},
 				)
 				require.NoError(t, err)
-				insertSkill(t, queries, entryID1, "test-namespace")
+				versionID1, err := queries.InsertEntryVersion(
+					context.Background(),
+					InsertEntryVersionParams{
+						EntryID:   oldEntryID,
+						Version:   "1.0.0",
+						CreatedAt: &oldTime,
+						UpdatedAt: &oldTime,
+					},
+				)
+				require.NoError(t, err)
+				insertSkill(t, queries, versionID1, "test-namespace")
 
-				entryID2, err := queries.InsertRegistryEntry(
+				recentEntryID, err := queries.InsertRegistryEntry(
 					context.Background(),
 					InsertRegistryEntryParams{
 						Name:      "recent-skill",
-						Version:   "1.0.0",
 						RegID:     regID,
 						EntryType: EntryTypeSKILL,
 						CreatedAt: &recentTime,
@@ -943,7 +986,17 @@ func TestListSkills(t *testing.T) {
 					},
 				)
 				require.NoError(t, err)
-				insertSkill(t, queries, entryID2, "test-namespace")
+				versionID2, err := queries.InsertEntryVersion(
+					context.Background(),
+					InsertEntryVersionParams{
+						EntryID:   recentEntryID,
+						Version:   "1.0.0",
+						CreatedAt: &recentTime,
+						UpdatedAt: &recentTime,
+					},
+				)
+				require.NoError(t, err)
+				insertSkill(t, queries, versionID2, "test-namespace")
 			},
 			//nolint:thelper // We want to see these lines in the test output
 			scenarioFunc: func(t *testing.T, queries *Queries) {
@@ -997,9 +1050,30 @@ func TestListSkills(t *testing.T) {
 			name: "list skills with multiple versions ordered correctly",
 			//nolint:thelper // We want to see these lines in the test output
 			setupFunc: func(t *testing.T, queries *Queries, regID uuid.UUID) {
+				createdAt := time.Now().UTC()
+				entryID, err := queries.InsertRegistryEntry(
+					context.Background(),
+					InsertRegistryEntryParams{
+						Name:      "test-skill",
+						RegID:     regID,
+						EntryType: EntryTypeSKILL,
+						CreatedAt: &createdAt,
+						UpdatedAt: &createdAt,
+					},
+				)
+				require.NoError(t, err)
 				for _, version := range []string{"1.0.0", "2.0.0", "3.0.0"} {
-					entryID := createSkillEntry(t, queries, regID, "test-skill", version, nil, nil)
-					insertSkill(t, queries, entryID, "test-namespace")
+					versionID, vErr := queries.InsertEntryVersion(
+						context.Background(),
+						InsertEntryVersionParams{
+							EntryID:   entryID,
+							Version:   version,
+							CreatedAt: &createdAt,
+							UpdatedAt: &createdAt,
+						},
+					)
+					require.NoError(t, vErr)
+					insertSkill(t, queries, versionID, "test-namespace")
 				}
 			},
 			//nolint:thelper // We want to see these lines in the test output
@@ -1060,10 +1134,10 @@ func TestUpsertLatestSkillVersion(t *testing.T) {
 				latestID, err := queries.UpsertLatestSkillVersion(
 					context.Background(),
 					UpsertLatestSkillVersionParams{
-						RegID:   regID,
-						Name:    "test-skill",
-						Version: "1.0.0",
-						EntryID: ids[0],
+						RegID:     regID,
+						Name:      "test-skill",
+						Version:   "1.0.0",
+						VersionID: ids[0],
 					},
 				)
 				require.NoError(t, err)
@@ -1074,27 +1148,49 @@ func TestUpsertLatestSkillVersion(t *testing.T) {
 			name: "update existing latest skill version",
 			//nolint:thelper // We want to see these lines in the test output
 			setupFunc: func(t *testing.T, queries *Queries, regID uuid.UUID) []uuid.UUID {
-				var skillIDs []uuid.UUID
+				createdAt := time.Now().UTC()
+				entryID, err := queries.InsertRegistryEntry(
+					context.Background(),
+					InsertRegistryEntryParams{
+						Name:      "test-skill",
+						RegID:     regID,
+						EntryType: EntryTypeSKILL,
+						CreatedAt: &createdAt,
+						UpdatedAt: &createdAt,
+					},
+				)
+				require.NoError(t, err)
+
+				var versionIDs []uuid.UUID
 				for _, version := range []string{"1.0.0", "2.0.0"} {
-					entryID := createSkillEntry(t, queries, regID, "test-skill", version, nil, nil)
-					skillID := insertSkill(t, queries, entryID, "test-namespace")
-					skillIDs = append(skillIDs, skillID)
+					versionID, vErr := queries.InsertEntryVersion(
+						context.Background(),
+						InsertEntryVersionParams{
+							EntryID:   entryID,
+							Version:   version,
+							CreatedAt: &createdAt,
+							UpdatedAt: &createdAt,
+						},
+					)
+					require.NoError(t, vErr)
+					insertSkill(t, queries, versionID, "test-namespace")
+					versionIDs = append(versionIDs, versionID)
 				}
 
 				// Set initial latest version
 				latestID, err := queries.UpsertLatestSkillVersion(
 					context.Background(),
 					UpsertLatestSkillVersionParams{
-						RegID:   regID,
-						Name:    "test-skill",
-						Version: "1.0.0",
-						EntryID: skillIDs[0],
+						RegID:     regID,
+						Name:      "test-skill",
+						Version:   "1.0.0",
+						VersionID: versionIDs[0],
 					},
 				)
 				require.NoError(t, err)
-				require.Equal(t, skillIDs[0], latestID)
+				require.Equal(t, versionIDs[0], latestID)
 
-				return skillIDs
+				return versionIDs
 			},
 			//nolint:thelper // We want to see these lines in the test output
 			scenarioFunc: func(t *testing.T, queries *Queries, regID uuid.UUID, ids []uuid.UUID) {
@@ -1102,10 +1198,10 @@ func TestUpsertLatestSkillVersion(t *testing.T) {
 				latestID, err := queries.UpsertLatestSkillVersion(
 					context.Background(),
 					UpsertLatestSkillVersionParams{
-						RegID:   regID,
-						Name:    "test-skill",
-						Version: "2.0.0",
-						EntryID: ids[1],
+						RegID:     regID,
+						Name:      "test-skill",
+						Version:   "2.0.0",
+						VersionID: ids[1],
 					},
 				)
 				require.NoError(t, err)
@@ -1123,10 +1219,10 @@ func TestUpsertLatestSkillVersion(t *testing.T) {
 				_, err := queries.UpsertLatestSkillVersion(
 					context.Background(),
 					UpsertLatestSkillVersionParams{
-						RegID:   uuid.New(),
-						Name:    "test-skill",
-						Version: "1.0.0",
-						EntryID: ids[0],
+						RegID:     uuid.New(),
+						Name:      "test-skill",
+						Version:   "1.0.0",
+						VersionID: ids[0],
 					},
 				)
 				require.Error(t, err)
@@ -1143,10 +1239,10 @@ func TestUpsertLatestSkillVersion(t *testing.T) {
 				_, err := queries.UpsertLatestSkillVersion(
 					context.Background(),
 					UpsertLatestSkillVersionParams{
-						RegID:   regID,
-						Name:    "test-skill",
-						Version: "1.0.0",
-						EntryID: ids[0],
+						RegID:     regID,
+						Name:      "test-skill",
+						Version:   "1.0.0",
+						VersionID: ids[0],
 					},
 				)
 				require.Error(t, err)
@@ -1291,23 +1387,23 @@ func TestInsertSkillGitPackage(t *testing.T) {
 	testCases := []struct {
 		name         string
 		setupFunc    func(t *testing.T, queries *Queries, regID uuid.UUID) uuid.UUID
-		scenarioFunc func(t *testing.T, queries *Queries, entryID uuid.UUID)
+		scenarioFunc func(t *testing.T, queries *Queries, skillID uuid.UUID)
 	}{
 		{
 			name: "insert git package with minimal fields",
 			//nolint:thelper // We want to see these lines in the test output
 			setupFunc: func(t *testing.T, queries *Queries, regID uuid.UUID) uuid.UUID {
 				entryID := createSkillEntry(t, queries, regID, "test-skill", "1.0.0", nil, nil)
-				insertSkill(t, queries, entryID, "test-namespace")
-				return entryID
+				skillVersionID := insertSkill(t, queries, entryID, "test-namespace")
+				return skillVersionID
 			},
 			//nolint:thelper // We want to see these lines in the test output
-			scenarioFunc: func(t *testing.T, queries *Queries, entryID uuid.UUID) {
+			scenarioFunc: func(t *testing.T, queries *Queries, skillVersionID uuid.UUID) {
 				err := queries.InsertSkillGitPackage(
 					context.Background(),
 					InsertSkillGitPackageParams{
-						SkillEntryID: entryID,
-						Url:          "https://github.com/test/skill-repo",
+						SkillID: skillVersionID,
+						Url:     "https://github.com/test/skill-repo",
 					},
 				)
 				require.NoError(t, err)
@@ -1318,19 +1414,19 @@ func TestInsertSkillGitPackage(t *testing.T) {
 			//nolint:thelper // We want to see these lines in the test output
 			setupFunc: func(t *testing.T, queries *Queries, regID uuid.UUID) uuid.UUID {
 				entryID := createSkillEntry(t, queries, regID, "test-skill", "1.0.0", nil, nil)
-				insertSkill(t, queries, entryID, "test-namespace")
-				return entryID
+				skillVersionID := insertSkill(t, queries, entryID, "test-namespace")
+				return skillVersionID
 			},
 			//nolint:thelper // We want to see these lines in the test output
-			scenarioFunc: func(t *testing.T, queries *Queries, entryID uuid.UUID) {
+			scenarioFunc: func(t *testing.T, queries *Queries, skillVersionID uuid.UUID) {
 				err := queries.InsertSkillGitPackage(
 					context.Background(),
 					InsertSkillGitPackageParams{
-						SkillEntryID: entryID,
-						Url:          "https://github.com/test/skill-repo",
-						Ref:          ptr.String("refs/tags/v1.0.0"),
-						CommitSha:    ptr.String("abc123def456"),
-						Subfolder:    ptr.String("skills/my-skill"),
+						SkillID:   skillVersionID,
+						Url:       "https://github.com/test/skill-repo",
+						Ref:       ptr.String("refs/tags/v1.0.0"),
+						CommitSha: ptr.String("abc123def456"),
+						Subfolder: ptr.String("skills/my-skill"),
 					},
 				)
 				require.NoError(t, err)
@@ -1343,12 +1439,12 @@ func TestInsertSkillGitPackage(t *testing.T) {
 				return uuid.New()
 			},
 			//nolint:thelper // We want to see these lines in the test output
-			scenarioFunc: func(t *testing.T, queries *Queries, entryID uuid.UUID) {
+			scenarioFunc: func(t *testing.T, queries *Queries, skillVersionID uuid.UUID) {
 				err := queries.InsertSkillGitPackage(
 					context.Background(),
 					InsertSkillGitPackageParams{
-						SkillEntryID: entryID,
-						Url:          "https://github.com/test/skill-repo",
+						SkillID: skillVersionID,
+						Url:     "https://github.com/test/skill-repo",
 					},
 				)
 				require.Error(t, err)
@@ -1381,23 +1477,23 @@ func TestInsertSkillOciPackage(t *testing.T) {
 	testCases := []struct {
 		name         string
 		setupFunc    func(t *testing.T, queries *Queries, regID uuid.UUID) uuid.UUID
-		scenarioFunc func(t *testing.T, queries *Queries, entryID uuid.UUID)
+		scenarioFunc func(t *testing.T, queries *Queries, skillVersionID uuid.UUID)
 	}{
 		{
 			name: "insert oci package with minimal fields",
 			//nolint:thelper // We want to see these lines in the test output
 			setupFunc: func(t *testing.T, queries *Queries, regID uuid.UUID) uuid.UUID {
 				entryID := createSkillEntry(t, queries, regID, "test-skill", "1.0.0", nil, nil)
-				insertSkill(t, queries, entryID, "test-namespace")
-				return entryID
+				skillVersionID := insertSkill(t, queries, entryID, "test-namespace")
+				return skillVersionID
 			},
 			//nolint:thelper // We want to see these lines in the test output
-			scenarioFunc: func(t *testing.T, queries *Queries, entryID uuid.UUID) {
+			scenarioFunc: func(t *testing.T, queries *Queries, skillVersionID uuid.UUID) {
 				err := queries.InsertSkillOciPackage(
 					context.Background(),
 					InsertSkillOciPackageParams{
-						SkillEntryID: entryID,
-						Identifier:   "ghcr.io/test/skill:v1.0.0",
+						SkillID:    skillVersionID,
+						Identifier: "ghcr.io/test/skill:v1.0.0",
 					},
 				)
 				require.NoError(t, err)
@@ -1408,18 +1504,18 @@ func TestInsertSkillOciPackage(t *testing.T) {
 			//nolint:thelper // We want to see these lines in the test output
 			setupFunc: func(t *testing.T, queries *Queries, regID uuid.UUID) uuid.UUID {
 				entryID := createSkillEntry(t, queries, regID, "test-skill", "1.0.0", nil, nil)
-				insertSkill(t, queries, entryID, "test-namespace")
-				return entryID
+				skillVersionID := insertSkill(t, queries, entryID, "test-namespace")
+				return skillVersionID
 			},
 			//nolint:thelper // We want to see these lines in the test output
-			scenarioFunc: func(t *testing.T, queries *Queries, entryID uuid.UUID) {
+			scenarioFunc: func(t *testing.T, queries *Queries, skillVersionID uuid.UUID) {
 				err := queries.InsertSkillOciPackage(
 					context.Background(),
 					InsertSkillOciPackageParams{
-						SkillEntryID: entryID,
-						Identifier:   "ghcr.io/test/skill:v1.0.0",
-						Digest:       ptr.String("sha256:abcdef1234567890"),
-						MediaType:    ptr.String("application/vnd.oci.image.manifest.v1+json"),
+						SkillID:    skillVersionID,
+						Identifier: "ghcr.io/test/skill:v1.0.0",
+						Digest:     ptr.String("sha256:abcdef1234567890"),
+						MediaType:  ptr.String("application/vnd.oci.image.manifest.v1+json"),
 					},
 				)
 				require.NoError(t, err)
@@ -1432,12 +1528,12 @@ func TestInsertSkillOciPackage(t *testing.T) {
 				return uuid.New()
 			},
 			//nolint:thelper // We want to see these lines in the test output
-			scenarioFunc: func(t *testing.T, queries *Queries, entryID uuid.UUID) {
+			scenarioFunc: func(t *testing.T, queries *Queries, skillVersionID uuid.UUID) {
 				err := queries.InsertSkillOciPackage(
 					context.Background(),
 					InsertSkillOciPackageParams{
-						SkillEntryID: entryID,
-						Identifier:   "ghcr.io/test/skill:v1.0.0",
+						SkillID:    skillVersionID,
+						Identifier: "ghcr.io/test/skill:v1.0.0",
 					},
 				)
 				require.Error(t, err)
@@ -1492,16 +1588,16 @@ func TestListSkillGitPackages(t *testing.T) {
 			//nolint:thelper // We want to see these lines in the test output
 			setupFunc: func(t *testing.T, queries *Queries, regID uuid.UUID) []uuid.UUID {
 				entryID := createSkillEntry(t, queries, regID, "test-skill", "1.0.0", nil, nil)
-				insertSkill(t, queries, entryID, "test-namespace")
+				skillVersionID := insertSkill(t, queries, entryID, "test-namespace")
 
 				err := queries.InsertSkillGitPackage(
 					context.Background(),
 					InsertSkillGitPackageParams{
-						SkillEntryID: entryID,
-						Url:          "https://github.com/test/skill-repo",
-						Ref:          ptr.String("refs/tags/v1.0.0"),
-						CommitSha:    ptr.String("abc123"),
-						Subfolder:    ptr.String("skills/my-skill"),
+						SkillID:   skillVersionID,
+						Url:       "https://github.com/test/skill-repo",
+						Ref:       ptr.String("refs/tags/v1.0.0"),
+						CommitSha: ptr.String("abc123"),
+						Subfolder: ptr.String("skills/my-skill"),
 					},
 				)
 				require.NoError(t, err)
@@ -1512,7 +1608,7 @@ func TestListSkillGitPackages(t *testing.T) {
 				packages, err := queries.ListSkillGitPackages(context.Background(), entryIDs)
 				require.NoError(t, err)
 				require.Len(t, packages, 1)
-				assert.Equal(t, entryIDs[0], packages[0].SkillEntryID)
+				assert.Equal(t, entryIDs[0], packages[0].SkillID)
 				assert.Equal(t, "https://github.com/test/skill-repo", packages[0].Url)
 				require.NotNil(t, packages[0].Ref)
 				assert.Equal(t, "refs/tags/v1.0.0", *packages[0].Ref)
@@ -1529,13 +1625,13 @@ func TestListSkillGitPackages(t *testing.T) {
 				var entryIDs []uuid.UUID
 				for i, name := range []string{"skill-1", "skill-2"} {
 					entryID := createSkillEntry(t, queries, regID, name, "1.0.0", nil, nil)
-					insertSkill(t, queries, entryID, "test-namespace")
+					skillVersionID := insertSkill(t, queries, entryID, "test-namespace")
 
 					err := queries.InsertSkillGitPackage(
 						context.Background(),
 						InsertSkillGitPackageParams{
-							SkillEntryID: entryID,
-							Url:          fmt.Sprintf("https://github.com/test/skill-repo-%d", i+1),
+							SkillID: skillVersionID,
+							Url:     fmt.Sprintf("https://github.com/test/skill-repo-%d", i+1),
 						},
 					)
 					require.NoError(t, err)
@@ -1551,7 +1647,7 @@ func TestListSkillGitPackages(t *testing.T) {
 
 				entryIDMap := make(map[uuid.UUID]bool)
 				for _, pkg := range packages {
-					entryIDMap[pkg.SkillEntryID] = true
+					entryIDMap[pkg.SkillID] = true
 				}
 				require.True(t, entryIDMap[entryIDs[0]])
 				require.True(t, entryIDMap[entryIDs[1]])
@@ -1619,15 +1715,15 @@ func TestListSkillOciPackages(t *testing.T) {
 			//nolint:thelper // We want to see these lines in the test output
 			setupFunc: func(t *testing.T, queries *Queries, regID uuid.UUID) []uuid.UUID {
 				entryID := createSkillEntry(t, queries, regID, "test-skill", "1.0.0", nil, nil)
-				insertSkill(t, queries, entryID, "test-namespace")
+				skillVersionID := insertSkill(t, queries, entryID, "test-namespace")
 
 				err := queries.InsertSkillOciPackage(
 					context.Background(),
 					InsertSkillOciPackageParams{
-						SkillEntryID: entryID,
-						Identifier:   "ghcr.io/test/skill:v1.0.0",
-						Digest:       ptr.String("sha256:abcdef1234567890"),
-						MediaType:    ptr.String("application/vnd.oci.image.manifest.v1+json"),
+						SkillID:    skillVersionID,
+						Identifier: "ghcr.io/test/skill:v1.0.0",
+						Digest:     ptr.String("sha256:abcdef1234567890"),
+						MediaType:  ptr.String("application/vnd.oci.image.manifest.v1+json"),
 					},
 				)
 				require.NoError(t, err)
@@ -1638,7 +1734,7 @@ func TestListSkillOciPackages(t *testing.T) {
 				packages, err := queries.ListSkillOciPackages(context.Background(), entryIDs)
 				require.NoError(t, err)
 				require.Len(t, packages, 1)
-				assert.Equal(t, entryIDs[0], packages[0].SkillEntryID)
+				assert.Equal(t, entryIDs[0], packages[0].SkillID)
 				assert.Equal(t, "ghcr.io/test/skill:v1.0.0", packages[0].Identifier)
 				require.NotNil(t, packages[0].Digest)
 				assert.Equal(t, "sha256:abcdef1234567890", *packages[0].Digest)
@@ -1653,13 +1749,13 @@ func TestListSkillOciPackages(t *testing.T) {
 				var entryIDs []uuid.UUID
 				for i, name := range []string{"skill-1", "skill-2"} {
 					entryID := createSkillEntry(t, queries, regID, name, "1.0.0", nil, nil)
-					insertSkill(t, queries, entryID, "test-namespace")
+					skillVersionID := insertSkill(t, queries, entryID, "test-namespace")
 
 					err := queries.InsertSkillOciPackage(
 						context.Background(),
 						InsertSkillOciPackageParams{
-							SkillEntryID: entryID,
-							Identifier:   fmt.Sprintf("ghcr.io/test/skill-%d:v1.0.0", i+1),
+							SkillID:    skillVersionID,
+							Identifier: fmt.Sprintf("ghcr.io/test/skill-%d:v1.0.0", i+1),
 						},
 					)
 					require.NoError(t, err)
@@ -1675,7 +1771,7 @@ func TestListSkillOciPackages(t *testing.T) {
 
 				entryIDMap := make(map[uuid.UUID]bool)
 				for _, pkg := range packages {
-					entryIDMap[pkg.SkillEntryID] = true
+					entryIDMap[pkg.SkillID] = true
 				}
 				require.True(t, entryIDMap[entryIDs[0]])
 				require.True(t, entryIDMap[entryIDs[1]])

--- a/internal/db/sqlc/temp_tables.sql.go
+++ b/internal/db/sqlc/temp_tables.sql.go
@@ -11,10 +11,23 @@ import (
 	"github.com/google/uuid"
 )
 
+const createTempEntryVersionTable = `-- name: CreateTempEntryVersionTable :exec
+
+CREATE TEMP TABLE temp_entry_version ON COMMIT DROP AS
+SELECT id, entry_id, version, title, description, created_at, updated_at FROM entry_version
+  WITH NO DATA
+`
+
+// Temp Entry Version Table Operations
+func (q *Queries) CreateTempEntryVersionTable(ctx context.Context) error {
+	_, err := q.db.Exec(ctx, createTempEntryVersionTable)
+	return err
+}
+
 const createTempIconTable = `-- name: CreateTempIconTable :exec
 
 CREATE TEMP TABLE temp_mcp_server_icon ON COMMIT DROP AS
-SELECT entry_id, source_uri, mime_type, theme FROM mcp_server_icon
+SELECT server_id, source_uri, mime_type, theme FROM mcp_server_icon
   WITH NO DATA
 `
 
@@ -27,7 +40,7 @@ func (q *Queries) CreateTempIconTable(ctx context.Context) error {
 const createTempPackageTable = `-- name: CreateTempPackageTable :exec
 
 CREATE TEMP TABLE temp_mcp_server_package ON COMMIT DROP AS
-SELECT entry_id, registry_type, pkg_registry_url, pkg_identifier, pkg_version, runtime_hint, runtime_arguments, package_arguments, sha256_hash, transport, transport_url, env_vars, transport_headers FROM mcp_server_package
+SELECT server_id, registry_type, pkg_registry_url, pkg_identifier, pkg_version, runtime_hint, runtime_arguments, package_arguments, sha256_hash, transport, transport_url, env_vars, transport_headers FROM mcp_server_package
   WITH NO DATA
 `
 
@@ -41,7 +54,7 @@ const createTempRegistryEntryTable = `-- name: CreateTempRegistryEntryTable :exe
 
 
 CREATE TEMP TABLE temp_registry_entry ON COMMIT DROP AS
-SELECT id, reg_id, entry_type, name, title, description, version, created_at, updated_at FROM registry_entry
+SELECT id, reg_id, entry_type, name, created_at, updated_at FROM registry_entry
   WITH NO DATA
 `
 
@@ -57,7 +70,7 @@ func (q *Queries) CreateTempRegistryEntryTable(ctx context.Context) error {
 const createTempRemoteTable = `-- name: CreateTempRemoteTable :exec
 
 CREATE TEMP TABLE temp_mcp_server_remote ON COMMIT DROP AS
-SELECT entry_id, transport, transport_url, transport_headers FROM mcp_server_remote
+SELECT server_id, transport, transport_url, transport_headers FROM mcp_server_remote
   WITH NO DATA
 `
 
@@ -68,11 +81,13 @@ func (q *Queries) CreateTempRemoteTable(ctx context.Context) error {
 }
 
 const createTempServerTable = `-- name: CreateTempServerTable :exec
+
 CREATE TEMP TABLE temp_mcp_server ON COMMIT DROP AS
-SELECT website, upstream_meta, server_meta, repository_url, repository_id, repository_subfolder, repository_type, entry_id FROM mcp_server
+SELECT website, upstream_meta, server_meta, repository_url, repository_id, repository_subfolder, repository_type, version_id FROM mcp_server
   WITH NO DATA
 `
 
+// Temp Server Table Operations
 func (q *Queries) CreateTempServerTable(ctx context.Context) error {
 	_, err := q.db.Exec(ctx, createTempServerTable)
 	return err
@@ -80,48 +95,94 @@ func (q *Queries) CreateTempServerTable(ctx context.Context) error {
 
 const deleteOrphanedIcons = `-- name: DeleteOrphanedIcons :exec
 DELETE FROM mcp_server_icon
-WHERE entry_id = ANY($1::UUID[])
-  AND (entry_id, source_uri, mime_type, theme) NOT IN (
-    SELECT entry_id, source_uri, mime_type, theme FROM temp_mcp_server_icon
+WHERE server_id = ANY($1::UUID[])
+  AND (server_id, source_uri, mime_type, theme) NOT IN (
+    SELECT server_id, source_uri, mime_type, theme FROM temp_mcp_server_icon
   )
 `
 
-func (q *Queries) DeleteOrphanedIcons(ctx context.Context, entryIds []uuid.UUID) error {
-	_, err := q.db.Exec(ctx, deleteOrphanedIcons, entryIds)
+func (q *Queries) DeleteOrphanedIcons(ctx context.Context, serverIds []uuid.UUID) error {
+	_, err := q.db.Exec(ctx, deleteOrphanedIcons, serverIds)
 	return err
 }
 
 const deleteOrphanedPackages = `-- name: DeleteOrphanedPackages :exec
 DELETE FROM mcp_server_package
-WHERE entry_id = ANY($1::UUID[])
-  AND (entry_id, pkg_identifier, transport) NOT IN (
-    SELECT entry_id, pkg_identifier, transport FROM temp_mcp_server_package
+WHERE server_id = ANY($1::UUID[])
+  AND (server_id, pkg_identifier, transport) NOT IN (
+    SELECT server_id, pkg_identifier, transport FROM temp_mcp_server_package
   )
 `
 
-func (q *Queries) DeleteOrphanedPackages(ctx context.Context, entryIds []uuid.UUID) error {
-	_, err := q.db.Exec(ctx, deleteOrphanedPackages, entryIds)
+func (q *Queries) DeleteOrphanedPackages(ctx context.Context, serverIds []uuid.UUID) error {
+	_, err := q.db.Exec(ctx, deleteOrphanedPackages, serverIds)
 	return err
 }
 
 const deleteOrphanedRemotes = `-- name: DeleteOrphanedRemotes :exec
 DELETE FROM mcp_server_remote
-WHERE entry_id = ANY($1::UUID[])
-  AND (entry_id, transport, transport_url) NOT IN (
-    SELECT entry_id, transport, transport_url FROM temp_mcp_server_remote
+WHERE server_id = ANY($1::UUID[])
+  AND (server_id, transport, transport_url) NOT IN (
+    SELECT server_id, transport, transport_url FROM temp_mcp_server_remote
   )
 `
 
-func (q *Queries) DeleteOrphanedRemotes(ctx context.Context, entryIds []uuid.UUID) error {
-	_, err := q.db.Exec(ctx, deleteOrphanedRemotes, entryIds)
+func (q *Queries) DeleteOrphanedRemotes(ctx context.Context, serverIds []uuid.UUID) error {
+	_, err := q.db.Exec(ctx, deleteOrphanedRemotes, serverIds)
 	return err
 }
 
+const upsertEntryVersionsFromTemp = `-- name: UpsertEntryVersionsFromTemp :many
+INSERT INTO entry_version (
+    id, entry_id, version, title, description, created_at, updated_at
+)
+SELECT id,
+       entry_id,
+       version,
+       title,
+       description,
+       created_at,
+       updated_at
+  FROM temp_entry_version
+    ON CONFLICT (entry_id, version)
+    DO UPDATE SET
+      title = EXCLUDED.title,
+      description = EXCLUDED.description,
+      updated_at = EXCLUDED.updated_at
+RETURNING id, entry_id, version
+`
+
+type UpsertEntryVersionsFromTempRow struct {
+	ID      uuid.UUID `json:"id"`
+	EntryID uuid.UUID `json:"entry_id"`
+	Version string    `json:"version"`
+}
+
+func (q *Queries) UpsertEntryVersionsFromTemp(ctx context.Context) ([]UpsertEntryVersionsFromTempRow, error) {
+	rows, err := q.db.Query(ctx, upsertEntryVersionsFromTemp)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []UpsertEntryVersionsFromTempRow{}
+	for rows.Next() {
+		var i UpsertEntryVersionsFromTempRow
+		if err := rows.Scan(&i.ID, &i.EntryID, &i.Version); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const upsertIconsFromTemp = `-- name: UpsertIconsFromTemp :exec
-INSERT INTO mcp_server_icon (entry_id, source_uri, mime_type, theme)
-SELECT entry_id, source_uri, mime_type, theme::icon_theme
+INSERT INTO mcp_server_icon (server_id, source_uri, mime_type, theme)
+SELECT server_id, source_uri, mime_type, theme::icon_theme
 FROM temp_mcp_server_icon
-ON CONFLICT (entry_id, source_uri, mime_type, theme)
+ON CONFLICT (server_id, source_uri, mime_type, theme)
 DO NOTHING
 `
 
@@ -132,16 +193,16 @@ func (q *Queries) UpsertIconsFromTemp(ctx context.Context) error {
 
 const upsertPackagesFromTemp = `-- name: UpsertPackagesFromTemp :exec
 INSERT INTO mcp_server_package (
-    entry_id, registry_type, pkg_registry_url, pkg_identifier, pkg_version,
+    server_id, registry_type, pkg_registry_url, pkg_identifier, pkg_version,
     runtime_hint, runtime_arguments, package_arguments, env_vars, sha256_hash,
     transport, transport_url, transport_headers
 )
 SELECT
-    entry_id, registry_type, pkg_registry_url, pkg_identifier, pkg_version,
+    server_id, registry_type, pkg_registry_url, pkg_identifier, pkg_version,
     runtime_hint, runtime_arguments, package_arguments, env_vars, sha256_hash,
     transport, transport_url, transport_headers
 FROM temp_mcp_server_package
-ON CONFLICT (entry_id, registry_type, pkg_identifier, transport)
+ON CONFLICT (server_id, registry_type, pkg_identifier, transport)
 DO UPDATE SET
     pkg_registry_url = EXCLUDED.pkg_registry_url,
     pkg_version = EXCLUDED.pkg_version,
@@ -161,24 +222,19 @@ func (q *Queries) UpsertPackagesFromTemp(ctx context.Context) error {
 
 const upsertRegistryEntriesFromTemp = `-- name: UpsertRegistryEntriesFromTemp :many
 INSERT INTO registry_entry (
-    id, reg_id, entry_type, name, title, description, version, created_at, updated_at
+    id, reg_id, entry_type, name, created_at, updated_at
 )
 SELECT id,
        reg_id,
        entry_type,
        name,
-       title,
-       description,
-       version,
        created_at,
        updated_at
   FROM temp_registry_entry
-    ON CONFLICT (reg_id, entry_type, name, version)
+    ON CONFLICT (reg_id, entry_type, name)
     DO UPDATE SET
-      title = EXCLUDED.title,
-      description = EXCLUDED.description,
       updated_at = EXCLUDED.updated_at
-RETURNING id, reg_id, entry_type, name, version
+RETURNING id, reg_id, entry_type, name
 `
 
 type UpsertRegistryEntriesFromTempRow struct {
@@ -186,7 +242,6 @@ type UpsertRegistryEntriesFromTempRow struct {
 	RegID     uuid.UUID `json:"reg_id"`
 	EntryType EntryType `json:"entry_type"`
 	Name      string    `json:"name"`
-	Version   string    `json:"version"`
 }
 
 func (q *Queries) UpsertRegistryEntriesFromTemp(ctx context.Context) ([]UpsertRegistryEntriesFromTempRow, error) {
@@ -203,7 +258,6 @@ func (q *Queries) UpsertRegistryEntriesFromTemp(ctx context.Context) ([]UpsertRe
 			&i.RegID,
 			&i.EntryType,
 			&i.Name,
-			&i.Version,
 		); err != nil {
 			return nil, err
 		}
@@ -216,10 +270,10 @@ func (q *Queries) UpsertRegistryEntriesFromTemp(ctx context.Context) ([]UpsertRe
 }
 
 const upsertRemotesFromTemp = `-- name: UpsertRemotesFromTemp :exec
-INSERT INTO mcp_server_remote (entry_id, transport, transport_url, transport_headers)
-SELECT entry_id, transport, transport_url, transport_headers
+INSERT INTO mcp_server_remote (server_id, transport, transport_url, transport_headers)
+SELECT server_id, transport, transport_url, transport_headers
 FROM temp_mcp_server_remote
-ON CONFLICT (entry_id, transport, transport_url)
+ON CONFLICT (server_id, transport, transport_url)
 DO UPDATE SET transport_headers = EXCLUDED.transport_headers
 `
 
@@ -230,10 +284,10 @@ func (q *Queries) UpsertRemotesFromTemp(ctx context.Context) error {
 
 const upsertServersFromTemp = `-- name: UpsertServersFromTemp :exec
 INSERT INTO mcp_server (
-    entry_id, website, upstream_meta, server_meta,
+    version_id, website, upstream_meta, server_meta,
     repository_url, repository_id, repository_subfolder, repository_type
 )
-SELECT entry_id,
+SELECT version_id,
        website,
        upstream_meta,
        server_meta,
@@ -242,7 +296,7 @@ SELECT entry_id,
        repository_subfolder,
        repository_type
 FROM temp_mcp_server
-  ON CONFLICT (entry_id)
+  ON CONFLICT (version_id)
   DO UPDATE SET
     website = EXCLUDED.website,
     upstream_meta = EXCLUDED.upstream_meta,

--- a/internal/service/db/impl_mcp.go
+++ b/internal/service/db/impl_mcp.go
@@ -307,8 +307,8 @@ func (s *dbService) GetServerVersion(
 	return res[0], nil
 }
 
-// insertServerVersionData inserts the server version record and returns the server ID.
-// It validates unique constraints on (registry_id, name, version) and returns ErrVersionAlreadyExists if violated.
+// insertServerVersionData inserts the server version record and returns the entry_version ID.
+// It validates unique constraints on (entry_id, version) and returns ErrVersionAlreadyExists if violated.
 func insertServerVersionData(
 	ctx context.Context,
 	querier *sqlc.Queries,
@@ -331,30 +331,47 @@ func insertServerVersionData(
 		return uuid.Nil, fmt.Errorf("failed to serialize metadata: %w", err)
 	}
 
-	// Insert the server version
 	now := time.Now()
-	entryID, err := querier.InsertRegistryEntry(ctx, sqlc.InsertRegistryEntryParams{
-		Name:        serverData.Name,
+
+	// Get or create the registry entry (one per unique name)
+	entryID, err := querier.GetRegistryEntryByName(ctx, sqlc.GetRegistryEntryByNameParams{
+		RegID:     registryID,
+		EntryType: sqlc.EntryTypeMCP,
+		Name:      serverData.Name,
+	})
+	if errors.Is(err, pgx.ErrNoRows) {
+		entryID, err = querier.InsertRegistryEntry(ctx, sqlc.InsertRegistryEntryParams{
+			RegID:     registryID,
+			EntryType: sqlc.EntryTypeMCP,
+			Name:      serverData.Name,
+			CreatedAt: &now,
+			UpdatedAt: &now,
+		})
+	}
+	if err != nil {
+		return uuid.Nil, fmt.Errorf("failed to get or create registry entry: %w", err)
+	}
+
+	// Insert the entry version (one per name+version)
+	versionID, err := querier.InsertEntryVersion(ctx, sqlc.InsertEntryVersionParams{
+		EntryID:     entryID,
 		Version:     serverData.Version,
-		RegID:       registryID,
-		EntryType:   sqlc.EntryTypeMCP,
+		Title:       &serverData.Title,
+		Description: &serverData.Description,
 		CreatedAt:   &now,
 		UpdatedAt:   &now,
-		Description: &serverData.Description,
-		Title:       &serverData.Title,
 	})
 	if err != nil {
-		// Check if this is a unique constraint violation
 		var pgErr *pgconn.PgError
 		if errors.As(err, &pgErr) && pgErr.Code == "23505" {
 			return uuid.Nil, fmt.Errorf("%w: %s@%s",
 				service.ErrVersionAlreadyExists, serverData.Name, serverData.Version)
 		}
-		return uuid.Nil, fmt.Errorf("failed to insert server version: %w", err)
+		return uuid.Nil, fmt.Errorf("failed to insert entry version: %w", err)
 	}
 
-	_, err = querier.InsertServerVersion(ctx, sqlc.InsertServerVersionParams{
-		EntryID:             entryID,
+	serverVersionID, err := querier.InsertServerVersion(ctx, sqlc.InsertServerVersionParams{
+		VersionID:           versionID,
 		Website:             &serverData.WebsiteURL,
 		UpstreamMeta:        nil,
 		ServerMeta:          serverMeta,
@@ -367,7 +384,7 @@ func insertServerVersionData(
 		return uuid.Nil, fmt.Errorf("failed to insert server version: %w", err)
 	}
 
-	return entryID, nil
+	return serverVersionID, nil
 }
 
 // insertServerPackages inserts all packages for a server version.
@@ -390,7 +407,7 @@ func insertServerPackages(
 		}
 
 		err = querier.InsertServerPackage(ctx, sqlc.InsertServerPackageParams{
-			EntryID:          entryID,
+			ServerID:         entryID,
 			RegistryType:     pkg.RegistryType,
 			PkgRegistryUrl:   pkg.RegistryBaseURL,
 			PkgIdentifier:    pkg.Identifier,
@@ -426,7 +443,7 @@ func insertServerRemotes(
 		}
 
 		err = querier.InsertServerRemote(ctx, sqlc.InsertServerRemoteParams{
-			EntryID:          entryID,
+			ServerID:         entryID,
 			Transport:        remote.Type,
 			TransportUrl:     remote.URL,
 			TransportHeaders: headersJSON,
@@ -469,7 +486,7 @@ func insertServerIcons(
 		}
 
 		err := querier.InsertServerIcon(ctx, sqlc.InsertServerIconParams{
-			EntryID:   entryID,
+			ServerID:  entryID,
 			SourceUri: icon.Src,
 			MimeType:  mimeType,
 			Theme:     theme,
@@ -494,8 +511,9 @@ func validateRegistryExists(ctx context.Context, querier *sqlc.Queries, registry
 	return nil
 }
 
-// validateManagedRegistry validates that the registry exists and is a managed (LOCAL) registry.
-// Returns ErrRegistryNotFound if the registry doesn't exist, or ErrNotManagedRegistry if it's not a LOCAL type.
+// validateManagedRegistry validates that the registry exists and is a managed
+// registry. Returns ErrRegistryNotFound if the registry doesn't exist, or
+// ErrNotManagedRegistry if it's not of type managed.
 func validateManagedRegistry(
 	ctx context.Context,
 	querier *sqlc.Queries,
@@ -644,23 +662,23 @@ func (s *dbService) insertServerData(
 	registryID uuid.UUID,
 ) error {
 	// Insert the server version
-	entryID, err := insertServerVersionData(ctx, querier, serverData, registryID, s.maxMetaSize)
+	serverVersionID, err := insertServerVersionData(ctx, querier, serverData, registryID, s.maxMetaSize)
 	if err != nil {
 		return err
 	}
 
 	// Insert packages
-	if err := insertServerPackages(ctx, querier, entryID, serverData.Packages); err != nil {
+	if err := insertServerPackages(ctx, querier, serverVersionID, serverData.Packages); err != nil {
 		return err
 	}
 
 	// Insert remotes
-	if err := insertServerRemotes(ctx, querier, entryID, serverData.Remotes); err != nil {
+	if err := insertServerRemotes(ctx, querier, serverVersionID, serverData.Remotes); err != nil {
 		return err
 	}
 
 	// Insert icons
-	if err := insertServerIcons(ctx, querier, entryID, serverData.Icons); err != nil {
+	if err := insertServerIcons(ctx, querier, serverVersionID, serverData.Icons); err != nil {
 		return err
 	}
 
@@ -678,10 +696,10 @@ func (s *dbService) insertServerData(
 
 	if shouldUpdateLatest {
 		_, err = querier.UpsertLatestServerVersion(ctx, sqlc.UpsertLatestServerVersionParams{
-			RegID:   registryID,
-			Name:    serverData.Name,
-			Version: serverData.Version,
-			EntryID: entryID,
+			RegID:     registryID,
+			Name:      serverData.Name,
+			Version:   serverData.Version,
+			VersionID: serverVersionID,
 		})
 		if err != nil {
 			return fmt.Errorf("failed to upsert latest server version: %w", err)
@@ -700,7 +718,6 @@ func (s *dbService) DeleteServerVersion(
 	defer span.End()
 	start := time.Now()
 
-	// 1. Parse options
 	options := &service.DeleteServerVersionOptions{}
 	for _, opt := range opts {
 		if err := opt(options); err != nil {
@@ -709,20 +726,37 @@ func (s *dbService) DeleteServerVersion(
 		}
 	}
 
-	// Add tracing attributes
 	span.SetAttributes(
 		otel.AttrRegistryName.String(options.RegistryName),
 		otel.AttrServerName.String(options.ServerName),
 		otel.AttrServerVersion.String(options.Version),
 	)
 
-	// 2. Begin transaction
+	if err := s.executeDeleteTransaction(ctx, options); err != nil {
+		otel.RecordError(span, err)
+		return err
+	}
+
+	slog.InfoContext(ctx, "Server version deleted",
+		"duration_ms", time.Since(start).Milliseconds(),
+		"registry", options.RegistryName,
+		"server", options.ServerName,
+		"version", options.Version,
+		"request_id", middleware.GetReqID(ctx))
+
+	return nil
+}
+
+// executeDeleteTransaction runs the version deletion within a serializable transaction.
+func (s *dbService) executeDeleteTransaction(
+	ctx context.Context,
+	options *service.DeleteServerVersionOptions,
+) error {
 	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{
 		IsoLevel:   pgx.Serializable,
 		AccessMode: pgx.ReadWrite,
 	})
 	if err != nil {
-		otel.RecordError(span, err)
 		return fmt.Errorf("failed to begin transaction: %w", err)
 	}
 	defer func() {
@@ -734,58 +768,80 @@ func (s *dbService) DeleteServerVersion(
 
 	querier := sqlc.New(tx)
 
-	// 3. Validate registry exists and get registry info
-	registry, err := querier.GetRegistryByName(ctx, options.RegistryName)
+	registry, err := validateManagedRegistry(ctx, querier, options.RegistryName)
 	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			err = fmt.Errorf("%w: %s", service.ErrRegistryNotFound, options.RegistryName)
-			otel.RecordError(span, err)
-			return err
-		}
-		otel.RecordError(span, err)
-		return fmt.Errorf("failed to get registry: %w", err)
-	}
-
-	// 4. Validate registry is MANAGED type
-	if registry.RegType != sqlc.RegistryTypeMANAGED {
-		err = fmt.Errorf("%w: registry %s has type %s",
-			service.ErrNotManagedRegistry, options.RegistryName, registry.RegType)
-		otel.RecordError(span, err)
 		return err
 	}
 
-	// 5. Delete the server version
-	rowsAffected, err := querier.DeleteRegistryEntry(ctx, sqlc.DeleteRegistryEntryParams{
-		RegID:   registry.ID,
-		Name:    options.ServerName,
-		Version: options.Version,
-	})
+	entryID, err := lookupAndDeleteEntryVersion(ctx, querier, registry.ID, sqlc.EntryTypeMCP, options.ServerName, options.Version)
 	if err != nil {
-		otel.RecordError(span, err)
-		return fmt.Errorf("failed to delete server version: %w", err)
-	}
-
-	// 5.1. Check if the server version was found and deleted
-	if rowsAffected == 0 {
-		err = fmt.Errorf("%w: %s@%s",
-			service.ErrNotFound, options.ServerName, options.Version)
-		otel.RecordError(span, err)
 		return err
 	}
 
-	// 6. Commit transaction
+	if err := cleanupOrphanedEntry(ctx, querier, entryID); err != nil {
+		return err
+	}
+
 	if err := tx.Commit(ctx); err != nil {
-		otel.RecordError(span, err)
 		return fmt.Errorf("failed to commit transaction: %w", err)
 	}
 
-	slog.InfoContext(ctx, "Server version deleted",
-		"duration_ms", time.Since(start).Milliseconds(),
-		"registry", options.RegistryName,
-		"server", options.ServerName,
-		"version", options.Version,
-		"request_id", middleware.GetReqID(ctx))
+	return nil
+}
 
+// lookupAndDeleteEntryVersion finds the registry entry by name and entry type,
+// then deletes the specified version. Returns the entry ID for potential
+// cleanup, or an error if the entry or version is not found.
+func lookupAndDeleteEntryVersion(
+	ctx context.Context,
+	querier *sqlc.Queries,
+	registryID uuid.UUID,
+	entryType sqlc.EntryType,
+	name string,
+	version string,
+) (uuid.UUID, error) {
+	entryID, err := querier.GetRegistryEntryByName(ctx, sqlc.GetRegistryEntryByNameParams{
+		RegID:     registryID,
+		EntryType: entryType,
+		Name:      name,
+	})
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return uuid.Nil, fmt.Errorf("%w: %s@%s", service.ErrNotFound, name, version)
+		}
+		return uuid.Nil, fmt.Errorf("failed to look up registry entry: %w", err)
+	}
+
+	rowsAffected, err := querier.DeleteEntryVersion(ctx, sqlc.DeleteEntryVersionParams{
+		EntryID: entryID,
+		Version: version,
+	})
+	if err != nil {
+		return uuid.Nil, fmt.Errorf("failed to delete entry version: %w", err)
+	}
+
+	if rowsAffected == 0 {
+		return uuid.Nil, fmt.Errorf("%w: %s@%s", service.ErrNotFound, name, version)
+	}
+
+	return entryID, nil
+}
+
+// cleanupOrphanedEntry removes the parent registry entry if no versions remain.
+func cleanupOrphanedEntry(
+	ctx context.Context,
+	querier *sqlc.Queries,
+	entryID uuid.UUID,
+) error {
+	remaining, err := querier.CountEntryVersions(ctx, entryID)
+	if err != nil {
+		return fmt.Errorf("failed to count remaining versions: %w", err)
+	}
+	if remaining == 0 {
+		if _, err := querier.DeleteRegistryEntryByID(ctx, entryID); err != nil {
+			return fmt.Errorf("failed to delete empty registry entry: %w", err)
+		}
+	}
 	return nil
 }
 
@@ -884,7 +940,7 @@ func (s *dbService) sharedListServersWithCursor(
 	}
 	packagesMap := make(map[uuid.UUID][]sqlc.ListServerPackagesRow)
 	for _, pkg := range packages {
-		packagesMap[pkg.EntryID] = append(packagesMap[pkg.EntryID], pkg)
+		packagesMap[pkg.ServerID] = append(packagesMap[pkg.ServerID], pkg)
 	}
 
 	remotes, err := querier.ListServerRemotes(ctx, ids)
@@ -893,7 +949,7 @@ func (s *dbService) sharedListServersWithCursor(
 	}
 	remotesMap := make(map[uuid.UUID][]sqlc.McpServerRemote)
 	for _, remote := range remotes {
-		remotesMap[remote.EntryID] = append(remotesMap[remote.EntryID], remote)
+		remotesMap[remote.ServerID] = append(remotesMap[remote.ServerID], remote)
 	}
 
 	result := make([]*upstreamv0.ServerJSON, 0, len(servers))

--- a/internal/service/db/impl_skills.go
+++ b/internal/service/db/impl_skills.go
@@ -85,7 +85,7 @@ func (s *dbService) ListSkills(
 
 	ids := make([]uuid.UUID, 0)
 	for _, row := range listRows {
-		ids = append(ids, row.EntryID)
+		ids = append(ids, row.VersionID)
 	}
 
 	ociPackages, err := querier.ListSkillOciPackages(ctx, ids)
@@ -101,10 +101,10 @@ func (s *dbService) ListSkills(
 
 	packages := make(map[uuid.UUID][]service.SkillPackage)
 	for _, pkg := range ociPackages {
-		packages[pkg.SkillEntryID] = append(packages[pkg.SkillEntryID], toServiceSkillOciPackage(pkg))
+		packages[pkg.SkillID] = append(packages[pkg.SkillID], toServiceSkillOciPackage(pkg))
 	}
 	for _, pkg := range gitPackages {
-		packages[pkg.SkillEntryID] = append(packages[pkg.SkillEntryID], toServiceSkillGitPackage(pkg))
+		packages[pkg.SkillID] = append(packages[pkg.SkillID], toServiceSkillGitPackage(pkg))
 	}
 
 	nextCursor := ""
@@ -117,7 +117,7 @@ func (s *dbService) ListSkills(
 	skills := make([]*service.Skill, len(listRows))
 	for i, row := range listRows {
 		skill := service.ListSkillsRowToSkill(row)
-		skill.Packages = packages[row.EntryID]
+		skill.Packages = packages[row.VersionID]
 		skills[i] = skill
 	}
 
@@ -170,12 +170,12 @@ func (s *dbService) GetSkillVersion(
 		return nil, err
 	}
 
-	ociPackages, err := querier.ListSkillOciPackages(ctx, []uuid.UUID{row.SkillEntryID})
+	ociPackages, err := querier.ListSkillOciPackages(ctx, []uuid.UUID{row.SkillVersionID})
 	if err != nil {
 		otel.RecordError(span, err)
 		return nil, err
 	}
-	gitPackages, err := querier.ListSkillGitPackages(ctx, []uuid.UUID{row.SkillEntryID})
+	gitPackages, err := querier.ListSkillGitPackages(ctx, []uuid.UUID{row.SkillVersionID})
 	if err != nil {
 		otel.RecordError(span, err)
 		return nil, err
@@ -295,22 +295,41 @@ func (s *dbService) executePublishSkillTransaction(
 	}
 
 	now := time.Now().UTC()
-	entryParams := sqlc.InsertRegistryEntryParams{
+
+	// Get or create the registry entry (one per unique name)
+	entryID, err := querier.GetRegistryEntryByName(ctx, sqlc.GetRegistryEntryByNameParams{
 		RegID:     registry.ID,
 		EntryType: sqlc.EntryTypeSKILL,
 		Name:      skill.Name,
+	})
+	if errors.Is(err, pgx.ErrNoRows) {
+		entryID, err = querier.InsertRegistryEntry(ctx, sqlc.InsertRegistryEntryParams{
+			RegID:     registry.ID,
+			EntryType: sqlc.EntryTypeSKILL,
+			Name:      skill.Name,
+			CreatedAt: &now,
+			UpdatedAt: &now,
+		})
+	}
+	if err != nil {
+		return fmt.Errorf("failed to get or create registry entry: %w", err)
+	}
+
+	// Insert the entry version (one per name+version)
+	versionParams := sqlc.InsertEntryVersionParams{
+		EntryID:   entryID,
 		Version:   skill.Version,
 		CreatedAt: &now,
 		UpdatedAt: &now,
 	}
 	if skill.Title != "" {
-		entryParams.Title = &skill.Title
+		versionParams.Title = &skill.Title
 	}
 	if skill.Description != "" {
-		entryParams.Description = &skill.Description
+		versionParams.Description = &skill.Description
 	}
 
-	entryID, err := querier.InsertRegistryEntry(ctx, entryParams)
+	versionID, err := querier.InsertEntryVersion(ctx, versionParams)
 	if err != nil {
 		var pgErr *pgconn.PgError
 		if errors.As(err, &pgErr) && pgErr.Code == "23505" {
@@ -319,7 +338,7 @@ func (s *dbService) executePublishSkillTransaction(
 		return err
 	}
 
-	skillParams, err := makeInsertSkillVersionParams(entryID, skill)
+	skillParams, err := makeInsertSkillVersionParams(versionID, skill)
 	if err != nil {
 		return err
 	}
@@ -334,18 +353,18 @@ func (s *dbService) executePublishSkillTransaction(
 		switch pkg.RegistryType {
 		case service.SkillPackageTypeOCI:
 			err = querier.InsertSkillOciPackage(ctx, sqlc.InsertSkillOciPackageParams{
-				SkillEntryID: entryID,
-				Identifier:   pkg.Identifier,
-				Digest:       &pkg.Digest,
-				MediaType:    &pkg.MediaType,
+				SkillID:    versionID,
+				Identifier: pkg.Identifier,
+				Digest:     &pkg.Digest,
+				MediaType:  &pkg.MediaType,
 			})
 		case service.SkillPackageTypeGit:
 			err = querier.InsertSkillGitPackage(ctx, sqlc.InsertSkillGitPackageParams{
-				SkillEntryID: entryID,
-				Url:          pkg.URL,
-				Ref:          &pkg.Ref,
-				CommitSha:    &pkg.Commit,
-				Subfolder:    &pkg.Subfolder,
+				SkillID:   versionID,
+				Url:       pkg.URL,
+				Ref:       &pkg.Ref,
+				CommitSha: &pkg.Commit,
+				Subfolder: &pkg.Subfolder,
 			})
 		}
 		if err != nil {
@@ -369,10 +388,10 @@ func (s *dbService) executePublishSkillTransaction(
 
 	if shouldUpdateLatest {
 		_, err = querier.UpsertLatestSkillVersion(ctx, sqlc.UpsertLatestSkillVersionParams{
-			RegID:   registry.ID,
-			Name:    skill.Name,
-			Version: skill.Version,
-			EntryID: entryID,
+			RegID:     registry.ID,
+			Name:      skill.Name,
+			Version:   skill.Version,
+			VersionID: versionID,
 		})
 		if err != nil {
 			return fmt.Errorf("failed to upsert latest skill version: %w", err)
@@ -387,7 +406,7 @@ func (s *dbService) executePublishSkillTransaction(
 }
 
 func makeInsertSkillVersionParams(
-	entryID uuid.UUID,
+	versionID uuid.UUID,
 	skill *service.Skill,
 ) (*sqlc.InsertSkillVersionParams, error) {
 
@@ -417,7 +436,7 @@ func makeInsertSkillVersionParams(
 	}
 
 	skillParams := sqlc.InsertSkillVersionParams{
-		EntryID:       entryID,
+		VersionID:     versionID,
 		Namespace:     skill.Namespace,
 		Status:        status,
 		AllowedTools:  skill.AllowedTools,
@@ -452,24 +471,58 @@ func (s *dbService) DeleteSkillVersion(
 		}
 	}
 
-	registry, err := validateManagedRegistry(ctx, sqlc.New(s.pool), options.RegistryName)
-	if err != nil {
+	if err := s.executeDeleteSkillTransaction(ctx, options); err != nil {
 		otel.RecordError(span, err)
 		return err
 	}
 
-	querier := sqlc.New(s.pool)
-	affected, err := querier.DeleteRegistryEntry(ctx, sqlc.DeleteRegistryEntryParams{
-		RegID:   registry.ID,
-		Name:    options.Name,
-		Version: options.Version,
+	return nil
+}
+
+// executeDeleteSkillTransaction runs the skill version deletion within a serializable transaction.
+func (s *dbService) executeDeleteSkillTransaction(
+	ctx context.Context,
+	options *service.DeleteSkillVersionOptions,
+) error {
+	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{
+		IsoLevel:   pgx.Serializable,
+		AccessMode: pgx.ReadWrite,
 	})
 	if err != nil {
-		otel.RecordError(span, err)
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer func() {
+		err := tx.Rollback(ctx)
+		if err != nil && !errors.Is(err, pgx.ErrTxClosed) {
+			slog.WarnContext(ctx, "Failed to rollback transaction", "error", err)
+		}
+	}()
+
+	querier := sqlc.New(tx)
+
+	registry, err := validateManagedRegistry(ctx, querier, options.RegistryName)
+	if err != nil {
 		return err
 	}
-	if affected == 0 {
-		return fmt.Errorf("%w: %s %s", service.ErrNotFound, options.Name, options.Version)
+
+	entryID, err := lookupAndDeleteEntryVersion(
+		ctx,
+		querier,
+		registry.ID,
+		sqlc.EntryTypeSKILL,
+		options.Name,
+		options.Version,
+	)
+	if err != nil {
+		return err
+	}
+
+	if err := cleanupOrphanedEntry(ctx, querier, entryID); err != nil {
+		return err
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("failed to commit transaction: %w", err)
 	}
 
 	return nil

--- a/internal/service/db/impl_test.go
+++ b/internal/service/db/impl_test.go
@@ -66,18 +66,28 @@ func setupTestData(t *testing.T, pool *pgxpool.Pool) {
 	// Create server versions
 	now := time.Now().UTC()
 
-	// Server 1 with multiple versions
+	// Server 1: one registry entry, multiple versions
+	entryID1, err := queries.InsertRegistryEntry(
+		ctx,
+		sqlc.InsertRegistryEntryParams{
+			RegID:     regID,
+			EntryType: sqlc.EntryTypeMCP,
+			Name:      "com.example/test-server-1",
+			CreatedAt: &now,
+			UpdatedAt: &now,
+		},
+	)
+	require.NoError(t, err)
+
 	for i, version := range []string{"1.0.0", "1.1.0", "2.0.0"} {
 		createdAt := now.Add(time.Duration(i) * time.Hour)
-		entryID, err := queries.InsertRegistryEntry(
-			context.Background(),
-			sqlc.InsertRegistryEntryParams{
-				Name:        "com.example/test-server-1",
+		versionID, err := queries.InsertEntryVersion(
+			ctx,
+			sqlc.InsertEntryVersionParams{
+				EntryID:     entryID1,
 				Version:     version,
-				RegID:       regID,
-				Description: ptr.String("Test server 1 description"),
 				Title:       ptr.String("Test Server 1"),
-				EntryType:   sqlc.EntryTypeMCP,
+				Description: ptr.String("Test server 1 description"),
 				CreatedAt:   &createdAt,
 				UpdatedAt:   &createdAt,
 			},
@@ -87,7 +97,7 @@ func setupTestData(t *testing.T, pool *pgxpool.Pool) {
 		serverID, err := queries.InsertServerVersion(
 			ctx,
 			sqlc.InsertServerVersionParams{
-				EntryID:             entryID,
+				VersionID:           versionID,
 				Website:             ptr.String("https://example.com/server1"),
 				UpstreamMeta:        []byte(`{"key": "value1"}`),
 				ServerMeta:          []byte(`{"meta": "data1"}`),
@@ -98,16 +108,16 @@ func setupTestData(t *testing.T, pool *pgxpool.Pool) {
 			},
 		)
 		require.NoError(t, err)
-		require.Equal(t, entryID, serverID)
+		require.Equal(t, versionID, serverID)
 
 		if version == "2.0.0" {
 			_, err := queries.UpsertLatestServerVersion(
 				ctx,
 				sqlc.UpsertLatestServerVersionParams{
-					RegID:   regID,
-					Name:    "com.example/test-server-1",
-					Version: "2.0.0",
-					EntryID: entryID,
+					RegID:     regID,
+					Name:      "com.example/test-server-1",
+					Version:   "2.0.0",
+					VersionID: versionID,
 				},
 			)
 			require.NoError(t, err)
@@ -117,14 +127,24 @@ func setupTestData(t *testing.T, pool *pgxpool.Pool) {
 	// Server 2 with single version
 	createdAt := now.Add(2 * time.Hour)
 	entryID2, err := queries.InsertRegistryEntry(
-		context.Background(),
+		ctx,
 		sqlc.InsertRegistryEntryParams{
-			Name:        "com.example/test-server-2",
+			RegID:     regID,
+			EntryType: sqlc.EntryTypeMCP,
+			Name:      "com.example/test-server-2",
+			CreatedAt: &createdAt,
+			UpdatedAt: &createdAt,
+		},
+	)
+	require.NoError(t, err)
+
+	versionID2, err := queries.InsertEntryVersion(
+		ctx,
+		sqlc.InsertEntryVersionParams{
+			EntryID:     entryID2,
 			Version:     "1.0.0",
-			RegID:       regID,
-			Description: ptr.String("Test server 2 description"),
 			Title:       ptr.String("Test Server 2"),
-			EntryType:   sqlc.EntryTypeMCP,
+			Description: ptr.String("Test server 2 description"),
 			CreatedAt:   &createdAt,
 			UpdatedAt:   &createdAt,
 		},
@@ -134,7 +154,7 @@ func setupTestData(t *testing.T, pool *pgxpool.Pool) {
 	serverID2, err := queries.InsertServerVersion(
 		ctx,
 		sqlc.InsertServerVersionParams{
-			EntryID:             entryID2,
+			VersionID:           versionID2,
 			Website:             ptr.String("https://example.com/server2"),
 			UpstreamMeta:        []byte(`{"key": "value2"}`),
 			ServerMeta:          []byte(`{"meta": "data2"}`),
@@ -145,7 +165,7 @@ func setupTestData(t *testing.T, pool *pgxpool.Pool) {
 		},
 	)
 	require.NoError(t, err)
-	require.Equal(t, entryID2, serverID2)
+	require.Equal(t, versionID2, serverID2)
 }
 
 func TestListServers(t *testing.T) {
@@ -738,14 +758,24 @@ func TestGetServerVersion(t *testing.T) {
 				// Create a server version
 				now := time.Now().UTC()
 				entryID, err := queries.InsertRegistryEntry(
-					context.Background(),
+					ctx,
 					sqlc.InsertRegistryEntryParams{
-						Name:        "com.test/server-with-packages",
+						RegID:     regID,
+						EntryType: sqlc.EntryTypeMCP,
+						Name:      "com.test/server-with-packages",
+						CreatedAt: &now,
+						UpdatedAt: &now,
+					},
+				)
+				require.NoError(t, err)
+
+				versionID, err := queries.InsertEntryVersion(
+					ctx,
+					sqlc.InsertEntryVersionParams{
+						EntryID:     entryID,
 						Version:     "1.0.0",
-						RegID:       regID,
-						Description: ptr.String("Test server with packages and remotes"),
 						Title:       ptr.String("Test Server With Packages"),
-						EntryType:   sqlc.EntryTypeMCP,
+						Description: ptr.String("Test server with packages and remotes"),
 						CreatedAt:   &now,
 						UpdatedAt:   &now,
 					},
@@ -755,7 +785,7 @@ func TestGetServerVersion(t *testing.T) {
 				serverID, err := queries.InsertServerVersion(
 					ctx,
 					sqlc.InsertServerVersionParams{
-						EntryID:             entryID,
+						VersionID:           versionID,
 						Website:             ptr.String("https://example.com/server-with-packages"),
 						UpstreamMeta:        []byte(`{"key": "value"}`),
 						ServerMeta:          []byte(`{"meta": "data"}`),
@@ -766,13 +796,13 @@ func TestGetServerVersion(t *testing.T) {
 					},
 				)
 				require.NoError(t, err)
-				require.Equal(t, entryID, serverID)
+				require.Equal(t, versionID, serverID)
 
 				// Add a package
 				err = queries.InsertServerPackage(
 					ctx,
 					sqlc.InsertServerPackageParams{
-						EntryID:          entryID,
+						ServerID:         versionID,
 						RegistryType:     "npm",
 						PkgRegistryUrl:   "https://registry.npmjs.org",
 						PkgIdentifier:    "@test/package",
@@ -793,7 +823,7 @@ func TestGetServerVersion(t *testing.T) {
 				err = queries.InsertServerRemote(
 					ctx,
 					sqlc.InsertServerRemoteParams{
-						EntryID:          entryID,
+						ServerID:         versionID,
 						Transport:        "sse",
 						TransportUrl:     "https://example.com/sse",
 						TransportHeaders: []byte(`[{"name":"Authorization: Bearer token"}]`),
@@ -1324,24 +1354,27 @@ func TestPublishServerVersion(t *testing.T) {
 				})
 				require.NoError(t, err)
 
-				// Insert a server version
 				now := time.Now()
-				entryID, err := queries.InsertRegistryEntry(
-					context.Background(),
-					sqlc.InsertRegistryEntryParams{
-						Name:        "com.example/existing-server",
-						Version:     "1.0.0",
-						RegID:       regID,
-						EntryType:   sqlc.EntryTypeMCP,
-						Description: ptr.String("Existing"),
-						CreatedAt:   &now,
-						UpdatedAt:   &now,
-					},
-				)
+				entryID, err := queries.InsertRegistryEntry(ctx, sqlc.InsertRegistryEntryParams{
+					RegID:     regID,
+					EntryType: sqlc.EntryTypeMCP,
+					Name:      "com.example/existing-server",
+					CreatedAt: &now,
+					UpdatedAt: &now,
+				})
+				require.NoError(t, err)
+
+				versionID, err := queries.InsertEntryVersion(ctx, sqlc.InsertEntryVersionParams{
+					EntryID:     entryID,
+					Version:     "1.0.0",
+					Description: ptr.String("Existing"),
+					CreatedAt:   &now,
+					UpdatedAt:   &now,
+				})
 				require.NoError(t, err)
 
 				_, err = queries.InsertServerVersion(ctx, sqlc.InsertServerVersionParams{
-					EntryID: entryID,
+					VersionID: versionID,
 				})
 				require.NoError(t, err)
 

--- a/internal/service/db/types_test.go
+++ b/internal/service/db/types_test.go
@@ -97,7 +97,7 @@ func TestHelperToServer(t *testing.T) {
 			},
 			packages: []sqlc.ListServerPackagesRow{
 				{
-					EntryID:        uuid.New(),
+					ServerID:       uuid.New(),
 					RegistryType:   "npm",
 					PkgRegistryUrl: "https://registry.npmjs.org",
 					PkgIdentifier:  "@example/mcp",
@@ -107,7 +107,7 @@ func TestHelperToServer(t *testing.T) {
 			},
 			remotes: []sqlc.McpServerRemote{
 				{
-					EntryID:      uuid.New(),
+					ServerID:     uuid.New(),
 					Transport:    "sse",
 					TransportUrl: "https://example.com/sse",
 				},

--- a/internal/service/skill_types.go
+++ b/internal/service/skill_types.go
@@ -68,24 +68,24 @@ type ListSkillsResult struct {
 
 // skillRow holds the common shape of sqlc skill list/get rows for mapping.
 type skillRow struct {
-	ID            uuid.UUID
-	Name          string
-	Version       string
-	IsLatest      bool
-	CreatedAt     *time.Time
-	UpdatedAt     *time.Time
-	Description   *string
-	Title         *string
-	SkillEntryID  uuid.UUID
-	Namespace     string
-	Status        sqlc.SkillStatus
-	License       *string
-	Compatibility *string
-	AllowedTools  []string
-	Repository    []byte
-	Icons         []byte
-	Metadata      []byte
-	ExtensionMeta []byte
+	ID             uuid.UUID
+	Name           string
+	Version        string
+	IsLatest       bool
+	CreatedAt      *time.Time
+	UpdatedAt      *time.Time
+	Description    *string
+	Title          *string
+	SkillVersionID uuid.UUID
+	Namespace      string
+	Status         sqlc.SkillStatus
+	License        *string
+	Compatibility  *string
+	AllowedTools   []string
+	Repository     []byte
+	Icons          []byte
+	Metadata       []byte
+	ExtensionMeta  []byte
 }
 
 func rowToSkill(r skillRow) *Skill {
@@ -142,7 +142,7 @@ func rowToSkill(r skillRow) *Skill {
 // ListSkillsRowToSkill maps a sqlc ListSkillsRow to a service Skill.
 func ListSkillsRowToSkill(row sqlc.ListSkillsRow) *Skill {
 	return rowToSkill(skillRow{
-		ID:            row.EntryID,
+		ID:            row.VersionID,
 		Name:          row.Name,
 		Version:       row.Version,
 		IsLatest:      row.IsLatest,
@@ -165,23 +165,23 @@ func ListSkillsRowToSkill(row sqlc.ListSkillsRow) *Skill {
 // GetSkillVersionRowToSkill maps a sqlc GetSkillVersionRow to a service Skill.
 func GetSkillVersionRowToSkill(row sqlc.GetSkillVersionRow) *Skill {
 	return rowToSkill(skillRow{
-		ID:            row.ID,
-		Name:          row.Name,
-		Version:       row.Version,
-		IsLatest:      row.IsLatest,
-		CreatedAt:     row.CreatedAt,
-		UpdatedAt:     row.UpdatedAt,
-		Description:   row.Description,
-		Title:         row.Title,
-		SkillEntryID:  row.SkillEntryID,
-		Namespace:     row.Namespace,
-		Status:        row.Status,
-		License:       row.License,
-		Compatibility: row.Compatibility,
-		AllowedTools:  row.AllowedTools,
-		Repository:    row.Repository,
-		Icons:         row.Icons,
-		Metadata:      row.Metadata,
-		ExtensionMeta: row.ExtensionMeta,
+		ID:             row.ID,
+		Name:           row.Name,
+		Version:        row.Version,
+		IsLatest:       row.IsLatest,
+		CreatedAt:      row.CreatedAt,
+		UpdatedAt:      row.UpdatedAt,
+		Description:    row.Description,
+		Title:          row.Title,
+		SkillVersionID: row.SkillVersionID,
+		Namespace:      row.Namespace,
+		Status:         row.Status,
+		License:        row.License,
+		Compatibility:  row.Compatibility,
+		AllowedTools:   row.AllowedTools,
+		Repository:     row.Repository,
+		Icons:          row.Icons,
+		Metadata:       row.Metadata,
+		ExtensionMeta:  row.ExtensionMeta,
 	})
 }

--- a/internal/sync/writer/db.go
+++ b/internal/sync/writer/db.go
@@ -46,11 +46,12 @@ func NewDBSyncWriter(pool *pgxpool.Pool, maxMetaSize int) (SyncWriter, error) {
 // Store saves a UpstreamRegistry instance to database storage for a specific registry.
 //
 // This method performs an efficient bulk sync using temporary tables and COPY operations:
-// 1. Validates the registry exists
-// 2. Creates temp tables, copies server data, and bulk upserts to preserve existing UUIDs
-// 3. Deletes orphaned servers that no longer exist in upstream (CASCADE cleans related data)
-// 4. For packages/remotes/icons: creates temp tables, copies data, bulk upserts, deletes orphans
-// 5. Updates the latest_server_version table for each unique server name
+//  1. Validates the registry exists
+//  2. Upserts registry entries (one per name), entry versions (one per name+version),
+//     and mcp_server rows via temp tables and COPY to preserve existing UUIDs
+//  3. Deletes orphaned servers that no longer exist in upstream (CASCADE cleans related data)
+//  4. For packages/remotes/icons: creates temp tables, copies data, bulk upserts, deletes orphans
+//  5. Updates the latest_entry_version table for each unique server name
 //
 // The operation is performed within a serializable transaction to ensure consistency.
 // Temp tables are automatically dropped at transaction end (ON COMMIT DROP).
@@ -124,8 +125,8 @@ func serverKey(name, version string) string {
 }
 
 // storeSyncInTempTables upserts all servers using temp table and COPY for maximum performance.
-// Uses ON CONFLICT UPDATE to preserve existing server UUIDs.
-// Returns a map of serverKey (name@version) to server UUID for subsequent operations.
+// Uses ON CONFLICT UPDATE to preserve existing UUIDs.
+// Returns a map of serverKey (name@version) to entry_version UUID for subsequent operations.
 func (d *dbSyncWriter) storeSyncInTempTables(
 	ctx context.Context,
 	tx pgx.Tx,
@@ -136,30 +137,32 @@ func (d *dbSyncWriter) storeSyncInTempTables(
 		return make(map[string]uuid.UUID), nil
 	}
 
-	// 1. Create temp table
 	querier := sqlc.New(tx)
-	copiedEntryRows, err := sqlCopyEntries(ctx, tx, registryID, servers)
+
+	// 1. Upsert registry entries (one per unique name)
+	entryMap, err := sqlCopyEntries(ctx, tx, registryID, servers)
 	if err != nil {
 		return nil, fmt.Errorf("failed to copy entries: %w", err)
 	}
 
-	entryIDMap := make(map[string]uuid.UUID, len(copiedEntryRows))
-	for _, row := range copiedEntryRows {
-		key := serverKey(row.Name, row.Version)
-		entryIDMap[key] = row.ID
+	// 2. Upsert entry versions (one per name+version)
+	versionMap, err := sqlCopyEntryVersions(ctx, tx, entryMap, servers)
+	if err != nil {
+		return nil, fmt.Errorf("failed to copy entry versions: %w", err)
 	}
 
-	if err := sqlCopyServers(ctx, tx, servers, entryIDMap, d.maxMetaSize); err != nil {
+	// 3. Copy mcp_server rows using entry_version IDs
+	if err := sqlCopyServers(ctx, tx, servers, versionMap, d.maxMetaSize); err != nil {
 		return nil, fmt.Errorf("failed to copy servers: %w", err)
 	}
 
-	// 5. Build a set of expected server keys from input
+	// 4. Build a set of expected server keys from input
 	expectedKeys := make(map[string]bool, len(servers))
 	for _, server := range servers {
 		expectedKeys[serverKey(server.Name, server.Version)] = true
 	}
 
-	// 6. Query back server IDs from permanent table
+	// 5. Query back server IDs from permanent table
 	dbServers, err := querier.GetServerIDsByRegistryNameVersion(ctx, registryID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query server IDs: %w", err)
@@ -170,7 +173,7 @@ func (d *dbSyncWriter) storeSyncInTempTables(
 	for _, dbServer := range dbServers {
 		key := serverKey(dbServer.Name, dbServer.Version)
 		if expectedKeys[key] {
-			serverIDMap[key] = dbServer.EntryID
+			serverIDMap[key] = dbServer.VersionID
 		}
 	}
 
@@ -178,7 +181,7 @@ func (d *dbSyncWriter) storeSyncInTempTables(
 }
 
 // deleteOrphanedServers removes servers for a registry that are not in the keepIDs set.
-// Due to CASCADE constraints, this also removes related packages, remotes, icons, and latest_server_version entries.
+// Due to CASCADE constraints, this also removes related packages, remotes, icons, and latest_entry_version entries.
 func (*dbSyncWriter) deleteOrphanedServers(
 	ctx context.Context,
 	tx pgx.Tx,
@@ -275,10 +278,10 @@ func (*dbSyncWriter) updateLatestVersions(
 	// Insert latest version pointers
 	for name, latest := range latestVersions {
 		_, err := querier.UpsertLatestServerVersion(ctx, sqlc.UpsertLatestServerVersionParams{
-			RegID:   registryID,
-			Name:    name,
-			Version: latest.version,
-			EntryID: latest.serverID,
+			RegID:     registryID,
+			Name:      name,
+			Version:   latest.version,
+			VersionID: latest.serverID,
 		})
 		if err != nil {
 			return fmt.Errorf("failed to upsert latest version for server %s: %w", name, err)
@@ -338,7 +341,7 @@ func bulkInsertPackages(
 
 	// COPY into temp table
 	_, err := tx.CopyFrom(ctx, pgx.Identifier{"temp_mcp_server_package"},
-		[]string{"entry_id", "registry_type", "pkg_registry_url", "pkg_identifier", "pkg_version",
+		[]string{"server_id", "registry_type", "pkg_registry_url", "pkg_identifier", "pkg_version",
 			"runtime_hint", "runtime_arguments", "package_arguments", "env_vars", "sha256_hash",
 			"transport", "transport_url", "transport_headers"},
 		pgx.CopyFromRows(packageRows))
@@ -433,7 +436,7 @@ func bulkInsertRemotes(
 
 	// COPY into temp table
 	_, err := tx.CopyFrom(ctx, pgx.Identifier{"temp_mcp_server_remote"},
-		[]string{"entry_id", "transport", "transport_url", "transport_headers"},
+		[]string{"server_id", "transport", "transport_url", "transport_headers"},
 		pgx.CopyFromRows(remoteRows))
 	if err != nil {
 		return fmt.Errorf("failed to copy remotes: %w", err)
@@ -517,7 +520,7 @@ func bulkInsertIcons(
 
 	// COPY into temp table
 	_, err := tx.CopyFrom(ctx, pgx.Identifier{"temp_mcp_server_icon"},
-		[]string{"entry_id", "source_uri", "mime_type", "theme"},
+		[]string{"server_id", "source_uri", "mime_type", "theme"},
 		pgx.CopyFromRows(iconRows))
 	if err != nil {
 		return fmt.Errorf("failed to copy icons: %w", err)
@@ -606,23 +609,30 @@ func nilIfEmpty(s string) *string {
 	return &s
 }
 
+// sqlCopyEntries upserts registry entries (one per unique name) using temp table and COPY.
+// Returns a map of server name to registry_entry UUID.
 func sqlCopyEntries(
 	ctx context.Context,
 	tx pgx.Tx,
 	registryID uuid.UUID,
 	servers []upstreamv0.ServerJSON,
-) ([]sqlc.UpsertRegistryEntriesFromTempRow, error) {
+) (map[string]uuid.UUID, error) {
 	querier := sqlc.New(tx)
 
 	if err := querier.CreateTempRegistryEntryTable(ctx); err != nil {
 		return nil, fmt.Errorf("failed to create temp registry entry table: %w", err)
 	}
 
-	// 2. Prepare rows for COPY
-	entryRows := make([][]any, 0, len(servers))
+	// Deduplicate by name — one registry_entry per unique server name
+	seen := make(map[string]bool, len(servers))
+	var entryRows [][]any
 	for _, server := range servers {
-		now := time.Now()
+		if seen[server.Name] {
+			continue
+		}
+		seen[server.Name] = true
 
+		now := time.Now()
 		entryID, err := uuid.NewV7()
 		if err != nil {
 			return nil, fmt.Errorf("failed to generate entry ID: %w", err)
@@ -633,34 +643,106 @@ func sqlCopyEntries(
 			registryID,
 			sqlc.EntryTypeMCP,
 			server.Name,
-			nilIfEmpty(server.Title),
-			nilIfEmpty(server.Description),
-			server.Version,
 			&now,
 			&now,
 		})
 	}
 
-	// 3. COPY into temp table
 	entryCopyCount, err := tx.CopyFrom(
 		ctx,
 		pgx.Identifier{"temp_registry_entry"},
-		[]string{"id", "reg_id", "entry_type", "name", "title", "description", "version", "created_at", "updated_at"},
+		[]string{"id", "reg_id", "entry_type", "name", "created_at", "updated_at"},
 		pgx.CopyFromRows(entryRows),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to copy entries to temp table: %w", err)
 	}
-	if int(entryCopyCount) != len(servers) {
-		return nil, fmt.Errorf("copy count mismatch: expected %d, got %d", len(servers), entryCopyCount)
+	if int(entryCopyCount) != len(entryRows) {
+		return nil, fmt.Errorf("copy count mismatch: expected %d, got %d", len(entryRows), entryCopyCount)
 	}
 
-	copiedEntryRows, err := querier.UpsertRegistryEntriesFromTemp(ctx)
+	copiedRows, err := querier.UpsertRegistryEntriesFromTemp(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to upsert registry entries from temp table: %w", err)
 	}
 
-	return copiedEntryRows, nil
+	entryMap := make(map[string]uuid.UUID, len(copiedRows))
+	for _, row := range copiedRows {
+		entryMap[row.Name] = row.ID
+	}
+
+	return entryMap, nil
+}
+
+// sqlCopyEntryVersions upserts entry versions (one per name+version) using temp table and COPY.
+// Returns a map of serverKey (name@version) to entry_version UUID.
+func sqlCopyEntryVersions(
+	ctx context.Context,
+	tx pgx.Tx,
+	entryMap map[string]uuid.UUID,
+	servers []upstreamv0.ServerJSON,
+) (map[string]uuid.UUID, error) {
+	querier := sqlc.New(tx)
+
+	if err := querier.CreateTempEntryVersionTable(ctx); err != nil {
+		return nil, fmt.Errorf("failed to create temp entry version table: %w", err)
+	}
+
+	versionRows := make([][]any, 0, len(servers))
+	for _, server := range servers {
+		entryID, ok := entryMap[server.Name]
+		if !ok {
+			return nil, fmt.Errorf("entry ID not found for %s", server.Name)
+		}
+
+		now := time.Now()
+		versionID, err := uuid.NewV7()
+		if err != nil {
+			return nil, fmt.Errorf("failed to generate version ID: %w", err)
+		}
+
+		versionRows = append(versionRows, []any{
+			versionID,
+			entryID,
+			server.Version,
+			nilIfEmpty(server.Title),
+			nilIfEmpty(server.Description),
+			&now,
+			&now,
+		})
+	}
+
+	copyCount, err := tx.CopyFrom(
+		ctx,
+		pgx.Identifier{"temp_entry_version"},
+		[]string{"id", "entry_id", "version", "title", "description", "created_at", "updated_at"},
+		pgx.CopyFromRows(versionRows),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to copy entry versions to temp table: %w", err)
+	}
+	if int(copyCount) != len(servers) {
+		return nil, fmt.Errorf("copy count mismatch: expected %d, got %d", len(servers), copyCount)
+	}
+
+	copiedRows, err := querier.UpsertEntryVersionsFromTemp(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to upsert entry versions from temp table: %w", err)
+	}
+
+	// Build reverse lookup: entry_id → name
+	entryIDToName := make(map[uuid.UUID]string, len(entryMap))
+	for name, id := range entryMap {
+		entryIDToName[id] = name
+	}
+
+	versionMap := make(map[string]uuid.UUID, len(copiedRows))
+	for _, row := range copiedRows {
+		name := entryIDToName[row.EntryID]
+		versionMap[serverKey(name, row.Version)] = row.ID
+	}
+
+	return versionMap, nil
 }
 
 func sqlCopyServers(
@@ -708,7 +790,7 @@ func sqlCopyServers(
 	copyCount, err := tx.CopyFrom(
 		ctx,
 		pgx.Identifier{"temp_mcp_server"},
-		[]string{"entry_id", "website", "upstream_meta", "server_meta",
+		[]string{"version_id", "website", "upstream_meta", "server_meta",
 			"repository_url", "repository_id", "repository_subfolder", "repository_type"},
 		pgx.CopyFromRows(mcpRows),
 	)

--- a/internal/sync/writer/db_test.go
+++ b/internal/sync/writer/db_test.go
@@ -26,7 +26,8 @@ const (
 
 	testQuery = `
 	SELECT COUNT(s.*) FROM mcp_server s
-	  JOIN registry_entry e ON s.entry_id = e.id
+	  JOIN entry_version v ON s.version_id = v.id
+	  JOIN registry_entry e ON v.entry_id = e.id
 	 WHERE e.reg_id = $1
 	   AND e.entry_type = 'MCP'
 	`
@@ -305,16 +306,16 @@ func TestDbSyncWriter_Store(t *testing.T) {
 		{
 			name:         "successful sync with single server",
 			registryName: "test-registry",
+			//nolint:thelper // We want to see these lines in the test output
 			setupFunc: func(t *testing.T, pool *pgxpool.Pool) {
-				t.Helper()
 				createTestRegistry(t, pool, "test-registry")
 			},
 			registry: createTestUpstreamRegistry([]upstreamv0.ServerJSON{
 				createTestServer("test.org/server", "1.0.0"),
 			}),
 			expectError: false,
+			//nolint:thelper // We want to see these lines in the test output
 			validateFunc: func(t *testing.T, pool *pgxpool.Pool, _ string) {
-				t.Helper()
 				ctx := context.Background()
 				queries := sqlc.New(pool)
 
@@ -328,8 +329,8 @@ func TestDbSyncWriter_Store(t *testing.T) {
 		{
 			name:         "successful sync with multiple servers",
 			registryName: "test-registry",
+			//nolint:thelper // We want to see these lines in the test output
 			setupFunc: func(t *testing.T, pool *pgxpool.Pool) {
-				t.Helper()
 				createTestRegistry(t, pool, "test-registry")
 			},
 			registry: createTestUpstreamRegistry([]upstreamv0.ServerJSON{
@@ -338,8 +339,8 @@ func TestDbSyncWriter_Store(t *testing.T) {
 				createTestServer("test.org/server3", "3.0.0"),
 			}),
 			expectError: false,
+			//nolint:thelper // We want to see these lines in the test output
 			validateFunc: func(t *testing.T, pool *pgxpool.Pool, _ string) {
-				t.Helper()
 				ctx := context.Background()
 				queries := sqlc.New(pool)
 
@@ -351,16 +352,16 @@ func TestDbSyncWriter_Store(t *testing.T) {
 		{
 			name:         "successful sync with server packages",
 			registryName: "test-registry",
+			//nolint:thelper // We want to see these lines in the test output
 			setupFunc: func(t *testing.T, pool *pgxpool.Pool) {
-				t.Helper()
 				createTestRegistry(t, pool, "test-registry")
 			},
 			registry: createTestUpstreamRegistry([]upstreamv0.ServerJSON{
 				createTestServerWithPackages("test.org/server", "1.0.0"),
 			}),
 			expectError: false,
+			//nolint:thelper // We want to see these lines in the test output
 			validateFunc: func(t *testing.T, pool *pgxpool.Pool, _ string) {
-				t.Helper()
 				ctx := context.Background()
 				queries := sqlc.New(pool)
 
@@ -378,16 +379,16 @@ func TestDbSyncWriter_Store(t *testing.T) {
 		{
 			name:         "successful sync with server remotes",
 			registryName: "test-registry",
+			//nolint:thelper // We want to see these lines in the test output
 			setupFunc: func(t *testing.T, pool *pgxpool.Pool) {
-				t.Helper()
 				createTestRegistry(t, pool, "test-registry")
 			},
 			registry: createTestUpstreamRegistry([]upstreamv0.ServerJSON{
 				createTestServerWithRemotes("test.org/server", "1.0.0"),
 			}),
 			expectError: false,
+			//nolint:thelper // We want to see these lines in the test output
 			validateFunc: func(t *testing.T, pool *pgxpool.Pool, _ string) {
-				t.Helper()
 				ctx := context.Background()
 				queries := sqlc.New(pool)
 
@@ -405,16 +406,16 @@ func TestDbSyncWriter_Store(t *testing.T) {
 		{
 			name:         "successful sync with server icons",
 			registryName: "test-registry",
+			//nolint:thelper // We want to see these lines in the test output
 			setupFunc: func(t *testing.T, pool *pgxpool.Pool) {
-				t.Helper()
 				createTestRegistry(t, pool, "test-registry")
 			},
 			registry: createTestUpstreamRegistry([]upstreamv0.ServerJSON{
 				createTestServerWithIcons("test.org/server", "1.0.0"),
 			}),
 			expectError: false,
+			//nolint:thelper // We want to see these lines in the test output
 			validateFunc: func(t *testing.T, pool *pgxpool.Pool, _ string) {
-				t.Helper()
 				ctx := context.Background()
 				queries := sqlc.New(pool)
 
@@ -427,16 +428,16 @@ func TestDbSyncWriter_Store(t *testing.T) {
 		{
 			name:         "successful sync with repository info",
 			registryName: "test-registry",
+			//nolint:thelper // We want to see these lines in the test output
 			setupFunc: func(t *testing.T, pool *pgxpool.Pool) {
-				t.Helper()
 				createTestRegistry(t, pool, "test-registry")
 			},
 			registry: createTestUpstreamRegistry([]upstreamv0.ServerJSON{
 				createTestServerWithRepository("test.org/server", "1.0.0"),
 			}),
 			expectError: false,
+			//nolint:thelper // We want to see these lines in the test output
 			validateFunc: func(t *testing.T, pool *pgxpool.Pool, _ string) {
-				t.Helper()
 				ctx := context.Background()
 				queries := sqlc.New(pool)
 
@@ -452,16 +453,16 @@ func TestDbSyncWriter_Store(t *testing.T) {
 		{
 			name:         "successful sync with metadata",
 			registryName: "test-registry",
+			//nolint:thelper // We want to see these lines in the test output
 			setupFunc: func(t *testing.T, pool *pgxpool.Pool) {
-				t.Helper()
 				createTestRegistry(t, pool, "test-registry")
 			},
 			registry: createTestUpstreamRegistry([]upstreamv0.ServerJSON{
 				createTestServerWithMeta("test.org/server", "1.0.0"),
 			}),
 			expectError: false,
+			//nolint:thelper // We want to see these lines in the test output
 			validateFunc: func(t *testing.T, pool *pgxpool.Pool, _ string) {
-				t.Helper()
 				ctx := context.Background()
 				queries := sqlc.New(pool)
 
@@ -476,16 +477,16 @@ func TestDbSyncWriter_Store(t *testing.T) {
 		{
 			name:         "successful sync with full server",
 			registryName: "test-registry",
+			//nolint:thelper // We want to see these lines in the test output
 			setupFunc: func(t *testing.T, pool *pgxpool.Pool) {
-				t.Helper()
 				createTestRegistry(t, pool, "test-registry")
 			},
 			registry: createTestUpstreamRegistry([]upstreamv0.ServerJSON{
 				createFullTestServer("test.org/server", "1.0.0"),
 			}),
 			expectError: false,
+			//nolint:thelper // We want to see these lines in the test output
 			validateFunc: func(t *testing.T, pool *pgxpool.Pool, _ string) {
-				t.Helper()
 				ctx := context.Background()
 				queries := sqlc.New(pool)
 
@@ -505,14 +506,14 @@ func TestDbSyncWriter_Store(t *testing.T) {
 		{
 			name:         "successful sync with empty servers list",
 			registryName: "test-registry",
+			//nolint:thelper // We want to see these lines in the test output
 			setupFunc: func(t *testing.T, pool *pgxpool.Pool) {
-				t.Helper()
 				createTestRegistry(t, pool, "test-registry")
 			},
 			registry:    createTestUpstreamRegistry([]upstreamv0.ServerJSON{}),
 			expectError: false,
+			//nolint:thelper // We want to see these lines in the test output
 			validateFunc: func(t *testing.T, pool *pgxpool.Pool, _ string) {
-				t.Helper()
 				ctx := context.Background()
 				queries := sqlc.New(pool)
 
@@ -524,8 +525,8 @@ func TestDbSyncWriter_Store(t *testing.T) {
 		{
 			name:         "successful sync replaces existing servers",
 			registryName: "test-registry",
+			//nolint:thelper // We want to see these lines in the test output
 			setupFunc: func(t *testing.T, pool *pgxpool.Pool) {
-				t.Helper()
 				ctx := context.Background()
 				regID := createTestRegistry(t, pool, "test-registry")
 				queries := sqlc.New(pool)
@@ -535,13 +536,19 @@ func TestDbSyncWriter_Store(t *testing.T) {
 					RegID:     regID,
 					EntryType: sqlc.EntryTypeMCP,
 					Name:      "test.org/old-server",
-					Version:   "0.1.0",
+				})
+				require.NoError(t, err)
+
+				// Insert entry version
+				versionID, err := queries.InsertEntryVersion(ctx, sqlc.InsertEntryVersionParams{
+					EntryID: entryID,
+					Version: "0.1.0",
 				})
 				require.NoError(t, err)
 
 				// Insert existing server that should be deleted
 				_, err = queries.InsertServerVersion(ctx, sqlc.InsertServerVersionParams{
-					EntryID: entryID,
+					VersionID: versionID,
 				})
 				require.NoError(t, err)
 			},
@@ -549,8 +556,8 @@ func TestDbSyncWriter_Store(t *testing.T) {
 				createTestServer("test.org/new-server", "1.0.0"),
 			}),
 			expectError: false,
+			//nolint:thelper // We want to see these lines in the test output
 			validateFunc: func(t *testing.T, pool *pgxpool.Pool, _ string) {
-				t.Helper()
 				ctx := context.Background()
 				queries := sqlc.New(pool)
 
@@ -563,16 +570,16 @@ func TestDbSyncWriter_Store(t *testing.T) {
 		{
 			name:         "successful sync updates latest version - single version",
 			registryName: "test-registry",
+			//nolint:thelper // We want to see these lines in the test output
 			setupFunc: func(t *testing.T, pool *pgxpool.Pool) {
-				t.Helper()
 				createTestRegistry(t, pool, "test-registry")
 			},
 			registry: createTestUpstreamRegistry([]upstreamv0.ServerJSON{
 				createTestServer("test.org/server", "1.0.0"),
 			}),
 			expectError: false,
+			//nolint:thelper // We want to see these lines in the test output
 			validateFunc: func(t *testing.T, pool *pgxpool.Pool, _ string) {
-				t.Helper()
 				ctx := context.Background()
 				queries := sqlc.New(pool)
 
@@ -588,8 +595,8 @@ func TestDbSyncWriter_Store(t *testing.T) {
 		{
 			name:         "successful sync updates latest version - multiple versions",
 			registryName: "test-registry",
+			//nolint:thelper // We want to see these lines in the test output
 			setupFunc: func(t *testing.T, pool *pgxpool.Pool) {
-				t.Helper()
 				createTestRegistry(t, pool, "test-registry")
 			},
 			registry: createTestUpstreamRegistry([]upstreamv0.ServerJSON{
@@ -598,8 +605,8 @@ func TestDbSyncWriter_Store(t *testing.T) {
 				createTestServer("test.org/server", "1.5.0"),
 			}),
 			expectError: false,
+			//nolint:thelper // We want to see these lines in the test output
 			validateFunc: func(t *testing.T, pool *pgxpool.Pool, _ string) {
-				t.Helper()
 				ctx := context.Background()
 				queries := sqlc.New(pool)
 
@@ -647,8 +654,8 @@ func TestDbSyncWriter_Store(t *testing.T) {
 		{
 			name:         "multiple servers same name different versions",
 			registryName: "test-registry",
+			//nolint:thelper // We want to see these lines in the test output
 			setupFunc: func(t *testing.T, pool *pgxpool.Pool) {
-				t.Helper()
 				createTestRegistry(t, pool, "test-registry")
 			},
 			registry: createTestUpstreamRegistry([]upstreamv0.ServerJSON{
@@ -657,8 +664,8 @@ func TestDbSyncWriter_Store(t *testing.T) {
 				createTestServer("test.org/server", "2.0.0"),
 			}),
 			expectError: false,
+			//nolint:thelper // We want to see these lines in the test output
 			validateFunc: func(t *testing.T, pool *pgxpool.Pool, _ string) {
-				t.Helper()
 				ctx := context.Background()
 				queries := sqlc.New(pool)
 
@@ -673,8 +680,8 @@ func TestDbSyncWriter_Store(t *testing.T) {
 		{
 			name:         "server with empty optional fields",
 			registryName: "test-registry",
+			//nolint:thelper // We want to see these lines in the test output
 			setupFunc: func(t *testing.T, pool *pgxpool.Pool) {
-				t.Helper()
 				createTestRegistry(t, pool, "test-registry")
 			},
 			registry: createTestUpstreamRegistry([]upstreamv0.ServerJSON{
@@ -687,8 +694,8 @@ func TestDbSyncWriter_Store(t *testing.T) {
 				},
 			}),
 			expectError: false,
+			//nolint:thelper // We want to see these lines in the test output
 			validateFunc: func(t *testing.T, pool *pgxpool.Pool, _ string) {
-				t.Helper()
 				ctx := context.Background()
 				queries := sqlc.New(pool)
 
@@ -1782,7 +1789,7 @@ func TestDbSyncWriter_Store_IconCleanup(t *testing.T) {
 
 	// Count icons using raw query
 	var iconCount int
-	err = pool.QueryRow(ctx, "SELECT COUNT(*) FROM mcp_server_icon WHERE entry_id = $1", originalUUID).Scan(&iconCount)
+	err = pool.QueryRow(ctx, "SELECT COUNT(*) FROM mcp_server_icon WHERE server_id = $1", originalUUID).Scan(&iconCount)
 	require.NoError(t, err)
 	require.Equal(t, 2, iconCount, "Should have 2 icons after first sync")
 
@@ -1809,7 +1816,7 @@ func TestDbSyncWriter_Store_IconCleanup(t *testing.T) {
 	assert.Equal(t, originalUUID, serverAfterUpdate.ID, "Server UUID should be preserved")
 
 	// Verify only 1 icon exists
-	err = pool.QueryRow(ctx, "SELECT COUNT(*) FROM mcp_server_icon WHERE entry_id = $1", originalUUID).Scan(&iconCount)
+	err = pool.QueryRow(ctx, "SELECT COUNT(*) FROM mcp_server_icon WHERE server_id = $1", originalUUID).Scan(&iconCount)
 	require.NoError(t, err)
 	require.Equal(t, 1, iconCount, "Should have 1 icon after second sync")
 }


### PR DESCRIPTION
This change splits the table `registry_entry` into a table containing details common to all versions of the entry (i.e. the name), and a table `entry_version` which will contain information specific to individual versions.

This split is useful because it an entry from its versions, so we can model shadowing in a much more reliable way than trying to do so for each version.