### PR TITLE
Trigger sync when filter configuration changes but source data is unchanged

### DIFF
--- a/internal/sync/manager.go
+++ b/internal/sync/manager.go
@@ -235,6 +235,12 @@ func (s *defaultSyncManager) ShouldSync(
 				if manualSyncRequested {
 					reason = ReasonManualNoChanges
 				}
+				if filterChanged {
+					// Source data hasn't changed, but filter configuration has —
+					// re-apply filters to the existing data.
+					prefetched = fetchResult
+					reason = ReasonFilterChanged
+				}
 			}
 		}
 		dataChangedString = fmt.Sprintf("%t", dataChanged)


### PR DESCRIPTION
  When a registry's filter configuration is updated (e.g. removing a server from an include list), the sync manager correctly detects the filter change via `filterChanged=true`. However, if the upstream source data hash hasn't changed, the `dataChanged=false` branch was only handling the `manualSyncRequested` case — leaving `filterChanged` unhandled. As a result, `ShouldSync` returned `reason=up-to-date-no-policy`
   and skipped the sync entirely, leaving the old filtered data in place.                                                                                                                                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                                                                                                                                                                 
  Fix the `ShouldSync` logic so that when the filter has changed but source data hasn't, the already-fetched data is reused as `prefetched` and the sync proceeds with `ReasonFilterChanged`. This causes the new filter configuration to be applied to the existing data without requiring a redundant upstream fetch.                                                                                                          
                                                                                                                                                                                                                                                                                                                                                                                                                                 
  Fixes: filter changes not reflected after pod restart unless the source file also changes.
  
Fixes https://github.com/stacklok/toolhive-registry-server/issues/567