### PR TITLE
Unify SQL routines to list server and versions

### DIFF
--- a/database/queries/servers.sql
+++ b/database/queries/servers.sql
@@ -3,6 +3,7 @@
 -- The cursor_name and cursor_version parameters define the starting point.
 -- When cursor is provided, results start AFTER the specified (name, version) tuple.
 -- Returns position from registry_source for source priority ordering.
+-- When name is provided, results are filtered to versions of that specific server.
 SELECT src.source_type as registry_type,
        v.id,
        e.name,
@@ -19,7 +20,9 @@ SELECT src.source_type as registry_type,
        s.repository_id,
        s.repository_subfolder,
        s.repository_type,
-       COALESCE(rs.position, 0)::integer AS position
+       -- Sources not linked to the requested registry have no position; default to max int16
+       -- so they sort after all explicitly positioned sources (lower position = higher priority).
+       COALESCE(rs.position, 32767)::integer AS position
   FROM mcp_server s
   JOIN entry_version v ON s.version_id = v.id
   JOIN registry_entry e ON v.entry_id = e.id
@@ -28,6 +31,7 @@ SELECT src.source_type as registry_type,
   LEFT JOIN registry r ON r.name = sqlc.narg(registry_name)::text
   LEFT JOIN registry_source rs ON rs.source_id = e.source_id AND rs.registry_id = r.id
  WHERE (sqlc.narg(registry_name)::text IS NULL OR rs.registry_id IS NOT NULL)
+   AND (sqlc.narg(name)::text IS NULL OR e.name = sqlc.narg(name)::text)
    AND (sqlc.narg(search)::text IS NULL OR (
        LOWER(e.name) LIKE LOWER('%' || sqlc.narg(search)::text || '%')
        OR LOWER(v.title) LIKE LOWER('%' || sqlc.narg(search)::text || '%')
@@ -49,41 +53,6 @@ SELECT src.source_type as registry_type,
  ORDER BY e.name ASC, v.version ASC, rs.position ASC
  LIMIT sqlc.arg(size)::bigint;
 
--- name: ListServerVersions :many
-SELECT src.source_type as registry_type,
-       v.id,
-       e.name,
-       v.version,
-       (l.latest_version_id IS NOT NULL)::boolean AS is_latest,
-       v.created_at,
-       v.updated_at,
-       v.description,
-       v.title,
-       s.website,
-       s.upstream_meta,
-       s.server_meta,
-       s.repository_url,
-       s.repository_id,
-       s.repository_subfolder,
-       s.repository_type,
-       COALESCE(rs.position, 0)::integer AS position
-  FROM mcp_server s
-  JOIN entry_version v ON s.version_id = v.id
-  JOIN registry_entry e ON v.entry_id = e.id
-  JOIN source src ON e.source_id = src.id
-  LEFT JOIN latest_entry_version l ON v.id = l.latest_version_id
-  LEFT JOIN registry r ON r.name = sqlc.narg(registry_name)::text
-  LEFT JOIN registry_source rs ON rs.source_id = e.source_id AND rs.registry_id = r.id
- WHERE e.name = sqlc.arg(name)
-   AND (sqlc.narg(registry_name)::text IS NULL OR rs.registry_id IS NOT NULL)
-   AND ((sqlc.narg(next)::timestamp with time zone IS NULL OR v.created_at > sqlc.narg(next))
-    AND (sqlc.narg(prev)::timestamp with time zone IS NULL OR v.created_at < sqlc.narg(prev)))
- ORDER BY
- CASE WHEN sqlc.narg(next)::timestamp with time zone IS NULL THEN v.created_at END ASC,
- CASE WHEN sqlc.narg(next)::timestamp with time zone IS NULL THEN v.version END DESC, -- acts as tie breaker
- rs.position ASC
- LIMIT sqlc.arg(size)::bigint;
-
 -- name: GetServerVersion :many
 SELECT src.source_type as registry_type,
        v.id,
@@ -101,7 +70,9 @@ SELECT src.source_type as registry_type,
        s.repository_id,
        s.repository_subfolder,
        s.repository_type,
-       COALESCE(rs.position, 0)::integer AS position
+       -- Sources not linked to the requested registry have no position; default to max int16
+       -- so they sort after all explicitly positioned sources (lower position = higher priority).
+       COALESCE(rs.position, 32767)::integer AS position
   FROM mcp_server s
   JOIN entry_version v ON s.version_id = v.id
   JOIN registry_entry e ON v.entry_id = e.id

--- a/database/queries/skills.sql
+++ b/database/queries/skills.sql
@@ -21,7 +21,9 @@ SELECT src.source_type AS registry_type,
        s.icons,
        s.metadata,
        s.extension_meta,
-       COALESCE(rs.position, 0)::integer AS position
+       -- Sources not linked to the requested registry have no position; default to max int16
+       -- so they sort after all explicitly positioned sources (lower position = higher priority).
+       COALESCE(rs.position, 32767)::integer AS position
   FROM skill s
   JOIN entry_version v ON s.version_id = v.id
   JOIN registry_entry e ON v.entry_id = e.id
@@ -65,7 +67,9 @@ SELECT src.source_type AS registry_type,
        s.icons,
        s.metadata,
        s.extension_meta,
-       COALESCE(rs.position, 0)::integer AS position
+       -- Sources not linked to the requested registry have no position; default to max int16
+       -- so they sort after all explicitly positioned sources (lower position = higher priority).
+       COALESCE(rs.position, 32767)::integer AS position
   FROM skill s
   JOIN entry_version v ON s.version_id = v.id
   JOIN registry_entry e ON v.entry_id = e.id

--- a/internal/db/sqlc/querier.go
+++ b/internal/db/sqlc/querier.go
@@ -93,11 +93,11 @@ type Querier interface {
 	ListRegistrySources(ctx context.Context, registryID uuid.UUID) ([]ListRegistrySourcesRow, error)
 	ListServerPackages(ctx context.Context, versionIds []uuid.UUID) ([]ListServerPackagesRow, error)
 	ListServerRemotes(ctx context.Context, versionIds []uuid.UUID) ([]McpServerRemote, error)
-	ListServerVersions(ctx context.Context, arg ListServerVersionsParams) ([]ListServerVersionsRow, error)
 	// Cursor-based pagination using (name, version) compound cursor.
 	// The cursor_name and cursor_version parameters define the starting point.
 	// When cursor is provided, results start AFTER the specified (name, version) tuple.
 	// Returns position from registry_source for source priority ordering.
+	// When name is provided, results are filtered to versions of that specific server.
 	ListServers(ctx context.Context, arg ListServersParams) ([]ListServersRow, error)
 	ListSkillGitPackages(ctx context.Context, versionIds []uuid.UUID) ([]SkillGitPackage, error)
 	ListSkillOciPackages(ctx context.Context, versionIds []uuid.UUID) ([]SkillOciPackage, error)

--- a/internal/db/sqlc/servers.sql.go
+++ b/internal/db/sqlc/servers.sql.go
@@ -132,7 +132,9 @@ SELECT src.source_type as registry_type,
        s.repository_id,
        s.repository_subfolder,
        s.repository_type,
-       COALESCE(rs.position, 0)::integer AS position
+       -- Sources not linked to the requested registry have no position; default to max int16
+       -- so they sort after all explicitly positioned sources (lower position = higher priority).
+       COALESCE(rs.position, 32767)::integer AS position
   FROM mcp_server s
   JOIN entry_version v ON s.version_id = v.id
   JOIN registry_entry e ON v.entry_id = e.id
@@ -556,114 +558,6 @@ func (q *Queries) ListServerRemotes(ctx context.Context, versionIds []uuid.UUID)
 	return items, nil
 }
 
-const listServerVersions = `-- name: ListServerVersions :many
-SELECT src.source_type as registry_type,
-       v.id,
-       e.name,
-       v.version,
-       (l.latest_version_id IS NOT NULL)::boolean AS is_latest,
-       v.created_at,
-       v.updated_at,
-       v.description,
-       v.title,
-       s.website,
-       s.upstream_meta,
-       s.server_meta,
-       s.repository_url,
-       s.repository_id,
-       s.repository_subfolder,
-       s.repository_type,
-       COALESCE(rs.position, 0)::integer AS position
-  FROM mcp_server s
-  JOIN entry_version v ON s.version_id = v.id
-  JOIN registry_entry e ON v.entry_id = e.id
-  JOIN source src ON e.source_id = src.id
-  LEFT JOIN latest_entry_version l ON v.id = l.latest_version_id
-  LEFT JOIN registry r ON r.name = $1::text
-  LEFT JOIN registry_source rs ON rs.source_id = e.source_id AND rs.registry_id = r.id
- WHERE e.name = $2
-   AND ($1::text IS NULL OR rs.registry_id IS NOT NULL)
-   AND (($3::timestamp with time zone IS NULL OR v.created_at > $3)
-    AND ($4::timestamp with time zone IS NULL OR v.created_at < $4))
- ORDER BY
- CASE WHEN $3::timestamp with time zone IS NULL THEN v.created_at END ASC,
- CASE WHEN $3::timestamp with time zone IS NULL THEN v.version END DESC, -- acts as tie breaker
- rs.position ASC
- LIMIT $5::bigint
-`
-
-type ListServerVersionsParams struct {
-	RegistryName *string    `json:"registry_name"`
-	Name         string     `json:"name"`
-	Next         *time.Time `json:"next"`
-	Prev         *time.Time `json:"prev"`
-	Size         int64      `json:"size"`
-}
-
-type ListServerVersionsRow struct {
-	RegistryType        string     `json:"registry_type"`
-	ID                  uuid.UUID  `json:"id"`
-	Name                string     `json:"name"`
-	Version             string     `json:"version"`
-	IsLatest            bool       `json:"is_latest"`
-	CreatedAt           *time.Time `json:"created_at"`
-	UpdatedAt           *time.Time `json:"updated_at"`
-	Description         *string    `json:"description"`
-	Title               *string    `json:"title"`
-	Website             *string    `json:"website"`
-	UpstreamMeta        []byte     `json:"upstream_meta"`
-	ServerMeta          []byte     `json:"server_meta"`
-	RepositoryUrl       *string    `json:"repository_url"`
-	RepositoryID        *string    `json:"repository_id"`
-	RepositorySubfolder *string    `json:"repository_subfolder"`
-	RepositoryType      *string    `json:"repository_type"`
-	Position            int32      `json:"position"`
-}
-
-func (q *Queries) ListServerVersions(ctx context.Context, arg ListServerVersionsParams) ([]ListServerVersionsRow, error) {
-	rows, err := q.db.Query(ctx, listServerVersions,
-		arg.RegistryName,
-		arg.Name,
-		arg.Next,
-		arg.Prev,
-		arg.Size,
-	)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	items := []ListServerVersionsRow{}
-	for rows.Next() {
-		var i ListServerVersionsRow
-		if err := rows.Scan(
-			&i.RegistryType,
-			&i.ID,
-			&i.Name,
-			&i.Version,
-			&i.IsLatest,
-			&i.CreatedAt,
-			&i.UpdatedAt,
-			&i.Description,
-			&i.Title,
-			&i.Website,
-			&i.UpstreamMeta,
-			&i.ServerMeta,
-			&i.RepositoryUrl,
-			&i.RepositoryID,
-			&i.RepositorySubfolder,
-			&i.RepositoryType,
-			&i.Position,
-		); err != nil {
-			return nil, err
-		}
-		items = append(items, i)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
 const listServers = `-- name: ListServers :many
 SELECT src.source_type as registry_type,
        v.id,
@@ -681,7 +575,9 @@ SELECT src.source_type as registry_type,
        s.repository_id,
        s.repository_subfolder,
        s.repository_type,
-       COALESCE(rs.position, 0)::integer AS position
+       -- Sources not linked to the requested registry have no position; default to max int16
+       -- so they sort after all explicitly positioned sources (lower position = higher priority).
+       COALESCE(rs.position, 32767)::integer AS position
   FROM mcp_server s
   JOIN entry_version v ON s.version_id = v.id
   JOIN registry_entry e ON v.entry_id = e.id
@@ -690,30 +586,32 @@ SELECT src.source_type as registry_type,
   LEFT JOIN registry r ON r.name = $1::text
   LEFT JOIN registry_source rs ON rs.source_id = e.source_id AND rs.registry_id = r.id
  WHERE ($1::text IS NULL OR rs.registry_id IS NOT NULL)
-   AND ($2::text IS NULL OR (
-       LOWER(e.name) LIKE LOWER('%' || $2::text || '%')
-       OR LOWER(v.title) LIKE LOWER('%' || $2::text || '%')
-       OR LOWER(v.description) LIKE LOWER('%' || $2::text || '%')
+   AND ($2::text IS NULL OR e.name = $2::text)
+   AND ($3::text IS NULL OR (
+       LOWER(e.name) LIKE LOWER('%' || $3::text || '%')
+       OR LOWER(v.title) LIKE LOWER('%' || $3::text || '%')
+       OR LOWER(v.description) LIKE LOWER('%' || $3::text || '%')
    ))
    -- Filter by updated_since if provided
-   AND ($3::timestamp with time zone IS NULL OR v.updated_at > $3::timestamp with time zone)
+   AND ($4::timestamp with time zone IS NULL OR v.updated_at > $4::timestamp with time zone)
    -- Compound cursor comparison: (name, version) > (cursor_name, cursor_version)
    -- This ensures deterministic pagination even when timestamps are identical
    AND (
-       $4::text IS NULL
-       OR (e.name, v.version) > ($4::text, $5::text)
+       $5::text IS NULL
+       OR (e.name, v.version) > ($5::text, $6::text)
    )
    AND (
-       $6::text IS NULL OR
-       v.version = $6::text OR
-       ($6::text = 'latest' AND l.latest_version_id = v.id)
+       $7::text IS NULL OR
+       v.version = $7::text OR
+       ($7::text = 'latest' AND l.latest_version_id = v.id)
    )
  ORDER BY e.name ASC, v.version ASC, rs.position ASC
- LIMIT $7::bigint
+ LIMIT $8::bigint
 `
 
 type ListServersParams struct {
 	RegistryName  *string    `json:"registry_name"`
+	Name          *string    `json:"name"`
 	Search        *string    `json:"search"`
 	UpdatedSince  *time.Time `json:"updated_since"`
 	CursorName    *string    `json:"cursor_name"`
@@ -746,9 +644,11 @@ type ListServersRow struct {
 // The cursor_name and cursor_version parameters define the starting point.
 // When cursor is provided, results start AFTER the specified (name, version) tuple.
 // Returns position from registry_source for source priority ordering.
+// When name is provided, results are filtered to versions of that specific server.
 func (q *Queries) ListServers(ctx context.Context, arg ListServersParams) ([]ListServersRow, error) {
 	rows, err := q.db.Query(ctx, listServers,
 		arg.RegistryName,
+		arg.Name,
 		arg.Search,
 		arg.UpdatedSince,
 		arg.CursorName,

--- a/internal/db/sqlc/servers_test.go
+++ b/internal/db/sqlc/servers_test.go
@@ -271,7 +271,7 @@ func TestInsertServerVersion(t *testing.T) {
 	}
 }
 
-func TestListServerVersions(t *testing.T) {
+func TestListServersByName(t *testing.T) {
 	t.Parallel()
 
 	testCases := []struct {
@@ -287,10 +287,10 @@ func TestListServerVersions(t *testing.T) {
 			},
 			//nolint:thelper // We want to see these lines in the test output
 			scenarioFunc: func(t *testing.T, queries *Queries, serverName string) {
-				versions, err := queries.ListServerVersions(
+				versions, err := queries.ListServers(
 					context.Background(),
-					ListServerVersionsParams{
-						Name: serverName,
+					ListServersParams{
+						Name: &serverName,
 						Size: 10,
 					},
 				)
@@ -311,10 +311,10 @@ func TestListServerVersions(t *testing.T) {
 			},
 			//nolint:thelper // We want to see these lines in the test output
 			scenarioFunc: func(t *testing.T, queries *Queries, serverName string) {
-				versions, err := queries.ListServerVersions(
+				versions, err := queries.ListServers(
 					context.Background(),
-					ListServerVersionsParams{
-						Name: serverName,
+					ListServersParams{
+						Name: &serverName,
 						Size: 10,
 					},
 				)
@@ -339,10 +339,10 @@ func TestListServerVersions(t *testing.T) {
 			},
 			//nolint:thelper // We want to see these lines in the test output
 			scenarioFunc: func(t *testing.T, queries *Queries, serverName string) {
-				versions, err := queries.ListServerVersions(
+				versions, err := queries.ListServers(
 					context.Background(),
-					ListServerVersionsParams{
-						Name: serverName,
+					ListServersParams{
+						Name: &serverName,
 						Size: 10,
 					},
 				)
@@ -352,7 +352,7 @@ func TestListServerVersions(t *testing.T) {
 			},
 		},
 		{
-			name: "list server versions with pagination",
+			name: "list server versions with cursor pagination",
 			//nolint:thelper // We want to see these lines in the test output
 			setupFunc: func(t *testing.T, queries *Queries, regID uuid.UUID) string {
 				createdAt := time.Now().UTC().Add(-1 * time.Minute)
@@ -366,34 +366,36 @@ func TestListServerVersions(t *testing.T) {
 			},
 			//nolint:thelper // We want to see these lines in the test output
 			scenarioFunc: func(t *testing.T, queries *Queries, serverName string) {
-				// Get first page
-				versions, err := queries.ListServerVersions(
+				// Get all versions
+				allVersions, err := queries.ListServers(
 					context.Background(),
-					ListServerVersionsParams{
-						Name: serverName,
+					ListServersParams{
+						Name: &serverName,
 						Size: 10,
 					},
 				)
 				require.NoError(t, err)
-				require.Len(t, versions, 3)
-				assert.Equal(t, "1.0.0", versions[0].Version)
-				assert.Equal(t, "2.0.0", versions[1].Version)
-				assert.Equal(t, "3.0.0", versions[2].Version)
+				require.Len(t, allVersions, 3)
+				assert.Equal(t, "1.0.0", allVersions[0].Version)
+				assert.Equal(t, "2.0.0", allVersions[1].Version)
+				assert.Equal(t, "3.0.0", allVersions[2].Version)
 
-				// Get next page
-				nextTime := versions[1].CreatedAt.UTC()
-
-				nextVersions, err := queries.ListServerVersions(
+				// Use cursor to skip past first version
+				cursorName := allVersions[0].Name
+				cursorVersion := allVersions[0].Version
+				nextVersions, err := queries.ListServers(
 					context.Background(),
-					ListServerVersionsParams{
-						Name: serverName,
-						Next: &nextTime,
-						Size: 10,
+					ListServersParams{
+						Name:          &serverName,
+						CursorName:    &cursorName,
+						CursorVersion: &cursorVersion,
+						Size:          10,
 					},
 				)
 				require.NoError(t, err)
-				assert.Len(t, nextVersions, 1)
-				assert.Equal(t, "3.0.0", nextVersions[0].Version)
+				assert.Len(t, nextVersions, 2)
+				assert.Equal(t, "2.0.0", nextVersions[0].Version)
+				assert.Equal(t, "3.0.0", nextVersions[1].Version)
 			},
 		},
 		{
@@ -411,10 +413,10 @@ func TestListServerVersions(t *testing.T) {
 			},
 			//nolint:thelper // We want to see these lines in the test output
 			scenarioFunc: func(t *testing.T, queries *Queries, serverName string) {
-				versions, err := queries.ListServerVersions(
+				versions, err := queries.ListServers(
 					context.Background(),
-					ListServerVersionsParams{
-						Name: serverName,
+					ListServersParams{
+						Name: &serverName,
 						Size: 2,
 					},
 				)

--- a/internal/db/sqlc/skills.sql.go
+++ b/internal/db/sqlc/skills.sql.go
@@ -71,7 +71,9 @@ SELECT src.source_type AS registry_type,
        s.icons,
        s.metadata,
        s.extension_meta,
-       COALESCE(rs.position, 0)::integer AS position
+       -- Sources not linked to the requested registry have no position; default to max int16
+       -- so they sort after all explicitly positioned sources (lower position = higher priority).
+       COALESCE(rs.position, 32767)::integer AS position
   FROM skill s
   JOIN entry_version v ON s.version_id = v.id
   JOIN registry_entry e ON v.entry_id = e.id
@@ -444,7 +446,9 @@ SELECT src.source_type AS registry_type,
        s.icons,
        s.metadata,
        s.extension_meta,
-       COALESCE(rs.position, 0)::integer AS position
+       -- Sources not linked to the requested registry have no position; default to max int16
+       -- so they sort after all explicitly positioned sources (lower position = higher priority).
+       COALESCE(rs.position, 32767)::integer AS position
   FROM skill s
   JOIN entry_version v ON s.version_id = v.id
   JOIN registry_entry e ON v.entry_id = e.id

--- a/internal/service/db/impl_mcp.go
+++ b/internal/service/db/impl_mcp.go
@@ -184,12 +184,6 @@ func (s *dbService) ListServerVersions(
 		}
 	}
 
-	if options.Next != nil && options.Prev != nil {
-		err := fmt.Errorf("next and prev cannot be set at the same time")
-		otel.RecordError(span, err)
-		return nil, err
-	}
-
 	// Cap the limit at service.MaxPageSize to prevent potential DoS
 	if options.Limit > service.MaxPageSize {
 		options.Limit = service.MaxPageSize
@@ -209,10 +203,8 @@ func (s *dbService) ListServerVersions(
 		}
 	}
 
-	params := sqlc.ListServerVersionsParams{
-		Name:         options.Name,
-		Next:         options.Next,
-		Prev:         options.Prev,
+	params := sqlc.ListServersParams{
+		Name:         &options.Name,
 		Size:         int64(options.Limit),
 		RegistryName: options.RegistryName,
 	}
@@ -221,14 +213,14 @@ func (s *dbService) ListServerVersions(
 	// found, the called function should return an empty slice as it's
 	// customary in Go.
 	querierFunc := func(ctx context.Context, querier sqlc.Querier) ([]helper, error) {
-		servers, err := querier.ListServerVersions(ctx, params)
+		servers, err := querier.ListServers(ctx, params)
 		if err != nil {
 			return nil, err
 		}
 
 		helpers := make([]helper, 0, len(servers))
 		for _, server := range servers {
-			helpers = append(helpers, listServerVersionsRowToHelper(server))
+			helpers = append(helpers, listServersRowToHelper(server))
 		}
 
 		return deduplicateHelpers(helpers), nil

--- a/internal/service/db/impl_test.go
+++ b/internal/service/db/impl_test.go
@@ -523,53 +523,6 @@ func TestListServerVersions(t *testing.T) {
 			},
 		},
 		{
-			name: "list versions with next cursor",
-			//nolint:thelper // We want to see these lines in the test output
-			setupFunc: func(t *testing.T, pool *pgxpool.Pool) {
-				setupTestData(t, pool)
-			},
-			options: []service.Option{
-				service.WithName("com.example/test-server-1"),
-				func(opts any) error {
-					// Set nextTime to 30 minutes from now, so only versions created at +1h and +2h are returned
-					nextTime := time.Now().Add(30 * time.Minute).UTC()
-
-					castOpts := opts.(*service.ListServerVersionsOptions)
-					castOpts.Next = &nextTime
-					castOpts.Limit = 10
-
-					return nil
-				},
-			},
-			//nolint:thelper // We want to see these lines in the test output
-			validateFunc: func(t *testing.T, servers []*upstreamv0.ServerJSON) {
-				require.Len(t, servers, 2)
-			},
-		},
-		{
-			name: "list versions with prev cursor",
-			//nolint:thelper // We want to see these lines in the test output
-			setupFunc: func(t *testing.T, pool *pgxpool.Pool) {
-				setupTestData(t, pool)
-			},
-			options: []service.Option{
-				service.WithName("com.example/test-server-1"),
-				func(opts any) error {
-					prevTime := time.Now().Add(1 * time.Hour).UTC()
-
-					castOpts := opts.(*service.ListServerVersionsOptions)
-					castOpts.Prev = &prevTime
-					castOpts.Limit = 10
-
-					return nil
-				},
-			},
-			//nolint:thelper // We want to see these lines in the test output
-			validateFunc: func(t *testing.T, servers []*upstreamv0.ServerJSON) {
-				require.Len(t, servers, 2)
-			},
-		},
-		{
 			name: "invalid name option",
 			//nolint:thelper // We want to see these lines in the test output
 			setupFunc: func(t *testing.T, pool *pgxpool.Pool) {

--- a/internal/service/db/types.go
+++ b/internal/service/db/types.go
@@ -83,29 +83,6 @@ func listServersRowToHelper(
 	}
 }
 
-func listServerVersionsRowToHelper(
-	dbServer sqlc.ListServerVersionsRow,
-) helper {
-	return helper{
-		ID:                  dbServer.ID,
-		Name:                dbServer.Name,
-		Version:             dbServer.Version,
-		IsLatest:            dbServer.IsLatest,
-		CreatedAt:           dbServer.CreatedAt,
-		UpdatedAt:           dbServer.UpdatedAt,
-		Description:         dbServer.Description,
-		Title:               dbServer.Title,
-		Website:             dbServer.Website,
-		UpstreamMeta:        dbServer.UpstreamMeta,
-		ServerMeta:          dbServer.ServerMeta,
-		RepositoryUrl:       dbServer.RepositoryUrl,
-		RepositoryID:        dbServer.RepositoryID,
-		RepositorySubfolder: dbServer.RepositorySubfolder,
-		RepositoryType:      dbServer.RepositoryType,
-		Position:            dbServer.Position,
-	}
-}
-
 func getServerVersionRowToHelper(
 	dbServer sqlc.GetServerVersionRow,
 ) helper {

--- a/internal/service/options.go
+++ b/internal/service/options.go
@@ -34,14 +34,6 @@ type updatedSinceOption interface {
 	setUpdatedSince(updatedSince time.Time) error
 }
 
-type nextOption interface {
-	setNext(next time.Time) error
-}
-
-type prevOption interface {
-	setPrev(prev time.Time) error
-}
-
 type namespaceOption interface {
 	setNamespace(namespace string) error
 }
@@ -111,7 +103,7 @@ func WithUpdatedSince(updatedSince time.Time) Option {
 }
 
 // WithRegistryName sets the registry name for the ListServers, ListServerVersions,
-// GetServerVersion, PublishServerVersion, or DeleteServerVersion operation
+// GetServerVersion, or DeleteServerVersion operation
 func WithRegistryName(registryName string) Option {
 	return func(o any) error {
 		if registryName == "" {
@@ -154,38 +146,6 @@ func WithNamespace(namespace string) Option {
 		switch o := o.(type) {
 		case namespaceOption:
 			return o.setNamespace(namespace)
-		default:
-			return fmt.Errorf("invalid option type: %T", o)
-		}
-	}
-}
-
-// WithNext sets the next time for the ListServerVersions operation
-func WithNext(next time.Time) Option {
-	return func(o any) error {
-		if next.IsZero() {
-			return fmt.Errorf("invalid next: %s", next)
-		}
-
-		switch o := o.(type) {
-		case nextOption:
-			return o.setNext(next)
-		default:
-			return fmt.Errorf("invalid option type: %T", o)
-		}
-	}
-}
-
-// WithPrev sets the prev time for the ListServerVersions operation
-func WithPrev(prev time.Time) Option {
-	return func(o any) error {
-		if prev.IsZero() {
-			return fmt.Errorf("invalid prev: %s", prev)
-		}
-
-		switch o := o.(type) {
-		case prevOption:
-			return o.setPrev(prev)
 		default:
 			return fmt.Errorf("invalid option type: %T", o)
 		}

--- a/internal/service/options_mcp.go
+++ b/internal/service/options_mcp.go
@@ -56,8 +56,6 @@ func (o *ListServersOptions) setVersion(version string) error {
 type ListServerVersionsOptions struct {
 	RegistryName *string
 	Name         string
-	Next         *time.Time
-	Prev         *time.Time
 	Limit        int
 }
 
@@ -70,18 +68,6 @@ func (o *ListServerVersionsOptions) setRegistryName(registryName string) error {
 //nolint:unparam
 func (o *ListServerVersionsOptions) setName(name string) error {
 	o.Name = name
-	return nil
-}
-
-//nolint:unparam
-func (o *ListServerVersionsOptions) setNext(next time.Time) error {
-	o.Next = &next
-	return nil
-}
-
-//nolint:unparam
-func (o *ListServerVersionsOptions) setPrev(prev time.Time) error {
-	o.Prev = &prev
 	return nil
 }
 

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/aws/smithy-go/ptr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -269,98 +268,6 @@ func TestWithRegistryNameGetServerVersion(t *testing.T) {
 
 			require.NoError(t, err)
 			assert.Equal(t, tt.expectedValue, opts.RegistryName)
-		})
-	}
-}
-
-func TestWithNext(t *testing.T) {
-	t.Parallel()
-	validTime := time.Date(2024, 1, 15, 10, 30, 0, 0, time.UTC)
-	zeroTime := time.Time{}
-
-	tests := []struct {
-		name          string
-		next          time.Time
-		expectedValue *time.Time
-	}{
-		{
-			name:          "valid time",
-			next:          validTime,
-			expectedValue: &validTime,
-		},
-		{
-			name:          "zero time",
-			next:          zeroTime,
-			expectedValue: nil,
-		},
-		{
-			name:          "time with nanoseconds",
-			next:          time.Date(2024, 1, 15, 10, 30, 45, 123456789, time.UTC),
-			expectedValue: ptr.Time(time.Date(2024, 1, 15, 10, 30, 45, 123456789, time.UTC)),
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			opt := service.WithNext(tt.next)
-			opts := &service.ListServerVersionsOptions{}
-
-			err := opt(opts)
-
-			if tt.expectedValue == nil {
-				require.Error(t, err)
-				return
-			}
-
-			require.NoError(t, err)
-			assert.Equal(t, *tt.expectedValue, *opts.Next)
-		})
-	}
-}
-
-func TestWithPrev(t *testing.T) {
-	t.Parallel()
-	validTime := time.Date(2024, 1, 15, 10, 30, 0, 0, time.UTC)
-	zeroTime := time.Time{}
-
-	tests := []struct {
-		name          string
-		prev          time.Time
-		expectedValue *time.Time
-	}{
-		{
-			name:          "valid time",
-			prev:          validTime,
-			expectedValue: &validTime,
-		},
-		{
-			name:          "zero time",
-			prev:          zeroTime,
-			expectedValue: nil,
-		},
-		{
-			name:          "time in the past",
-			prev:          time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),
-			expectedValue: ptr.Time(time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)),
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			opt := service.WithPrev(tt.prev)
-			opts := &service.ListServerVersionsOptions{}
-
-			err := opt(opts)
-
-			if tt.expectedValue == nil {
-				require.Error(t, err)
-				return
-			}
-
-			require.NoError(t, err)
-			assert.Equal(t, *tt.expectedValue, *opts.Prev)
 		})
 	}
 }

--- a/internal/sync/writer/db_test.go
+++ b/internal/sync/writer/db_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/aws/smithy-go/ptr"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
 	upstreamv0 "github.com/modelcontextprotocol/registry/pkg/api/v0"
@@ -682,8 +683,8 @@ func TestDbSyncWriter_Store(t *testing.T) {
 				ctx := context.Background()
 				queries := sqlc.New(pool)
 
-				versions, err := queries.ListServerVersions(ctx, sqlc.ListServerVersionsParams{
-					Name: "test.org/server",
+				versions, err := queries.ListServers(ctx, sqlc.ListServersParams{
+					Name: ptr.String("test.org/server"),
 					Size: 100,
 				})
 				require.NoError(t, err)


### PR DESCRIPTION
Merge `ListServerVersions` into `ListServers` using an optional `name` parameter, following the same pattern as `ListSkills`.

Both queries shared identical `SELECT` columns and `JOIN` structure, differing only in their `WHERE` clause. Unifying them into a single query reduces duplication, replaces the inconsistent timestamp-based pagination in `ListServerVersions` with the same cursor-based approach used everywhere else, and shrinks the surface area of the SQL and service layers.

References #444