### PR TITLE
Add app-level filtering

### DIFF
--- a/.claude/skills/smoke-test/SKILL.md
+++ b/.claude/skills/smoke-test/SKILL.md
@@ -130,7 +130,7 @@ Feature: Registry Server smoke tests
     Then the response status is 404
 
   Scenario: Create a managed source
-    When I PUT /v1/sources/managed-test with sourceType "managed"
+    When I PUT /v1/sources/managed-test with body {"managed":{}}
     Then the response status is 201
     And the body contains "managed-test"
 

--- a/internal/service/db/filter_test.go
+++ b/internal/service/db/filter_test.go
@@ -1,0 +1,129 @@
+package database
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stacklok/toolhive-registry-server/internal/db/sqlc"
+)
+
+func TestNewDeduplicatingFilterWrongType(t *testing.T) {
+	t.Parallel()
+
+	filter := newDeduplicatingFilter()
+	_, err := filter(t.Context(), "not-a-helper")
+	require.Error(t, err)
+}
+
+func TestNewDeduplicatingSkillFilter(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		input   []any // records passed to the filter; usually []sqlc.ListSkillsRow
+		expect  []sqlc.ListSkillsRow
+		wantErr bool
+	}{
+		{
+			name:   "empty input returns no records",
+			input:  []any{},
+			expect: []sqlc.ListSkillsRow{},
+		},
+		{
+			name: "single skill single version returned as-is",
+			input: []any{
+				sqlc.ListSkillsRow{Name: "skill-a", Version: "1.0.0", Position: 0},
+			},
+			expect: []sqlc.ListSkillsRow{
+				{Name: "skill-a", Version: "1.0.0", Position: 0},
+			},
+		},
+		{
+			name: "multiple versions from same source all kept",
+			input: []any{
+				sqlc.ListSkillsRow{Name: "skill-a", Version: "1.0.0", Position: 2},
+				sqlc.ListSkillsRow{Name: "skill-a", Version: "2.0.0", Position: 2},
+				sqlc.ListSkillsRow{Name: "skill-a", Version: "3.0.0", Position: 2},
+			},
+			expect: []sqlc.ListSkillsRow{
+				{Name: "skill-a", Version: "1.0.0", Position: 2},
+				{Name: "skill-a", Version: "2.0.0", Position: 2},
+				{Name: "skill-a", Version: "3.0.0", Position: 2},
+			},
+		},
+		{
+			name: "same name from two sources keeps only first-seen position",
+			input: []any{
+				sqlc.ListSkillsRow{Name: "skill-a", Version: "1.0.0", Position: 1},
+				sqlc.ListSkillsRow{Name: "skill-a", Version: "2.0.0", Position: 1},
+				sqlc.ListSkillsRow{Name: "skill-a", Version: "1.0.0", Position: 5},
+				sqlc.ListSkillsRow{Name: "skill-a", Version: "3.0.0", Position: 5},
+			},
+			expect: []sqlc.ListSkillsRow{
+				{Name: "skill-a", Version: "1.0.0", Position: 1},
+				{Name: "skill-a", Version: "2.0.0", Position: 1},
+			},
+		},
+		{
+			name: "multiple skill names independently resolved",
+			input: []any{
+				sqlc.ListSkillsRow{Name: "skill-a", Version: "1.0.0", Position: 3},
+				sqlc.ListSkillsRow{Name: "skill-a", Version: "2.0.0", Position: 3},
+				sqlc.ListSkillsRow{Name: "skill-b", Version: "1.0.0", Position: 3},
+				sqlc.ListSkillsRow{Name: "skill-a", Version: "1.0.0", Position: 7},
+				sqlc.ListSkillsRow{Name: "skill-b", Version: "1.0.0", Position: 7},
+				sqlc.ListSkillsRow{Name: "skill-b", Version: "2.0.0", Position: 7},
+			},
+			expect: []sqlc.ListSkillsRow{
+				{Name: "skill-a", Version: "1.0.0", Position: 3},
+				{Name: "skill-a", Version: "2.0.0", Position: 3},
+				{Name: "skill-b", Version: "1.0.0", Position: 3},
+			},
+		},
+		{
+			name: "same position for different names keeps all",
+			input: []any{
+				sqlc.ListSkillsRow{Name: "skill-x", Version: "1.0.0", Position: 4},
+				sqlc.ListSkillsRow{Name: "skill-y", Version: "1.0.0", Position: 4},
+				sqlc.ListSkillsRow{Name: "skill-y", Version: "2.0.0", Position: 4},
+			},
+			expect: []sqlc.ListSkillsRow{
+				{Name: "skill-x", Version: "1.0.0", Position: 4},
+				{Name: "skill-y", Version: "1.0.0", Position: 4},
+				{Name: "skill-y", Version: "2.0.0", Position: 4},
+			},
+		},
+		{
+			name:    "wrong record type returns error",
+			input:   []any{"not-a-skill-row"},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			filter := newDeduplicatingSkillFilter()
+			var got []sqlc.ListSkillsRow
+			for _, record := range tt.input {
+				keep, err := filter(t.Context(), record)
+				if tt.wantErr {
+					require.Error(t, err)
+					return
+				}
+				require.NoError(t, err)
+				if keep {
+					got = append(got, record.(sqlc.ListSkillsRow))
+				}
+			}
+			if got == nil {
+				got = []sqlc.ListSkillsRow{}
+			}
+
+			assert.Equal(t, tt.expect, got)
+		})
+	}
+}

--- a/internal/service/db/impl_mcp.go
+++ b/internal/service/db/impl_mcp.go
@@ -98,50 +98,24 @@ func (s *dbService) ListServers(
 		params.Version = &options.Version
 	}
 
-	// Fetch servers in a loop to ensure we have enough results after dedup.
-	// Dedup can remove entries when multiple sources provide the same name,
-	// so a single SQL fetch of limit+1 rows may yield fewer than limit
-	// deduplicated results. We loop, advancing the SQL cursor, until we
-	// have enough or the database is exhausted.
-	//
-	// All fetched helpers are accumulated and deduped together to ensure
-	// consistent cross-batch dedup (a name's winning source must be the
-	// same regardless of batch boundaries).
-	querierFunc := func(ctx context.Context, querier sqlc.Querier) ([]helper, error) {
-		const maxFetchIterations = 10 // safety cap to prevent runaway loops
-		target := options.Limit + 1   // +1 to detect hasMore
-		var allHelpers []helper
-		batchParams := params // copy so we can mutate cursor
-
-		for range maxFetchIterations {
-			servers, err := querier.ListServers(ctx, batchParams)
-			if err != nil {
-				return nil, err
-			}
-
-			for _, server := range servers {
-				allHelpers = append(allHelpers, listServersRowToHelper(server))
-			}
-
-			deduped := deduplicateHelpers(allHelpers)
-
-			// Stop if we have enough deduplicated results or SQL returned
-			// fewer rows than requested (no more data).
-			if len(deduped) >= target || int64(len(servers)) < batchParams.Size {
-				return deduped, nil
-			}
-
-			// Advance cursor to the last fetched row's (name, version)
-			lastRow := servers[len(servers)-1]
-			batchParams.CursorName = &lastRow.Name
-			batchParams.CursorVersion = &lastRow.Version
+	querierFunc := func(ctx context.Context, querier sqlc.Querier, cursor *serverCursor) ([]helper, error) {
+		p := params // copy so we can mutate cursor
+		if cursor != nil {
+			p.CursorName = &cursor.Name
+			p.CursorVersion = &cursor.Version
 		}
-
-		// Iteration cap reached — return what we have
-		return deduplicateHelpers(allHelpers), nil
+		rows, err := querier.ListServers(ctx, p)
+		if err != nil {
+			return nil, err
+		}
+		helpers := make([]helper, 0, len(rows))
+		for _, row := range rows {
+			helpers = append(helpers, listServersRowToHelper(row))
+		}
+		return helpers, nil
 	}
 
-	results, lastCursor, err := s.sharedListServersWithCursor(ctx, querierFunc, options.Limit)
+	results, lastCursor, err := s.sharedListServersWithCursor(ctx, querierFunc, options.Limit, options.Filter)
 	if err != nil {
 		otel.RecordError(span, err)
 		return nil, err
@@ -212,7 +186,7 @@ func (s *dbService) ListServerVersions(
 	// Note: this function fetches a list of server versions. In case no records are
 	// found, the called function should return an empty slice as it's
 	// customary in Go.
-	querierFunc := func(ctx context.Context, querier sqlc.Querier) ([]helper, error) {
+	querierFunc := func(ctx context.Context, querier sqlc.Querier, _ *serverCursor) ([]helper, error) {
 		servers, err := querier.ListServers(ctx, params)
 		if err != nil {
 			return nil, err
@@ -223,10 +197,10 @@ func (s *dbService) ListServerVersions(
 			helpers = append(helpers, listServersRowToHelper(server))
 		}
 
-		return deduplicateHelpers(helpers), nil
+		return helpers, nil
 	}
 
-	results, err := s.sharedListServers(ctx, querierFunc)
+	results, err := s.sharedListServers(ctx, querierFunc, options.Filter)
 	if err != nil {
 		otel.RecordError(span, err)
 		return nil, err
@@ -289,7 +263,7 @@ func (s *dbService) GetServerVersion(
 	// In case no record is found, the called function maps the underlying
 	// `pgx.ErrNoRows` to `service.ErrNotFound`, and callers should expect
 	// to receive `service.ErrNotFound` for a missing record.
-	querierFunc := func(ctx context.Context, querier sqlc.Querier) ([]helper, error) {
+	querierFunc := func(ctx context.Context, querier sqlc.Querier, _ *serverCursor) ([]helper, error) {
 		servers, err := querier.GetServerVersion(ctx, params)
 		if err != nil {
 			if errors.Is(err, pgx.ErrNoRows) {
@@ -305,13 +279,18 @@ func (s *dbService) GetServerVersion(
 		return []helper{getServerVersionRowToHelper(servers[0])}, nil
 	}
 
-	res, err := s.sharedListServers(ctx, querierFunc)
+	res, err := s.sharedListServers(ctx, querierFunc, options.Filter)
 	if err != nil {
 		otel.RecordError(span, err)
 		return nil, err
 	}
 
-	if len(res) != 1 {
+	if len(res) == 0 {
+		err := fmt.Errorf("%w: %s %s", service.ErrNotFound, options.Name, options.Version)
+		otel.RecordError(span, err)
+		return nil, err
+	}
+	if len(res) > 1 {
 		err := fmt.Errorf("%w: number of servers returned is not 1", ErrBug)
 		otel.RecordError(span, err)
 		return nil, err
@@ -896,7 +875,103 @@ func claimsMatch(a, b []byte) bool {
 //
 // Note that the underlying table does not have to be the `mcp_server` table
 // as it is used now, as long as the result is a slice of helpers.
-type querierFunction func(ctx context.Context, querier sqlc.Querier) ([]helper, error)
+type querierFunction func(ctx context.Context, querier sqlc.Querier, cursor *serverCursor) ([]helper, error)
+
+// newDeduplicatingFilterWith returns a stateful RecordFilter that deduplicates records
+// by entry name, keeping only records from the highest-priority source (lowest position).
+// SQL must return records in position-ascending order per name.
+// extract retrieves the name and source position from a record; returning ok=false causes
+// the filter to reject the record with a type error.
+func newDeduplicatingFilterWith(
+	extract func(record any) (name string, pos int32, ok bool),
+) service.RecordFilter {
+	seen := make(map[string]int32) // name → winning source position
+	return func(_ context.Context, record any) (bool, error) {
+		name, pos, ok := extract(record)
+		if !ok {
+			return false, fmt.Errorf("unexpected record type: %T", record)
+		}
+		winPos, exists := seen[name]
+		if !exists {
+			seen[name] = pos
+			return true, nil
+		}
+		return pos == winPos, nil
+	}
+}
+
+// streamHelpers fetches helpers in batches, applying the auth filter then the dedup
+// filter to each record, until limit+1 records are accumulated or the DB is exhausted.
+// It returns the trimmed slice (≤ limit) and the cursor for the next page, if any.
+func streamHelpers(
+	ctx context.Context,
+	querier *sqlc.Queries,
+	querierFunc querierFunction,
+	filter service.RecordFilter,
+	limit int,
+) ([]helper, *serverCursor, error) {
+	dedupFilter := newDeduplicatingFilter()
+	var accumulated []helper
+	var cursor *serverCursor
+
+	for {
+		batch, err := querierFunc(ctx, querier, cursor)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		for _, h := range batch {
+			keep := true
+			var ferr error
+			if filter != nil {
+				keep, ferr = filter(ctx, h)
+				if ferr != nil {
+					return nil, nil, ferr
+				}
+			}
+			if keep {
+				keep, ferr = dedupFilter(ctx, h)
+				if ferr != nil {
+					return nil, nil, ferr
+				}
+			}
+			if keep {
+				accumulated = append(accumulated, h)
+			}
+		}
+
+		if len(accumulated) >= limit+1 || len(batch) < limit+1 {
+			break
+		}
+
+		// Advance cursor to continue fetching
+		if len(batch) > 0 {
+			lastRow := batch[len(batch)-1]
+			cursor = &serverCursor{Name: lastRow.Name, Version: lastRow.Version}
+		}
+	}
+
+	// Trim to limit and compute next-page cursor
+	var lastCursor *serverCursor
+	if len(accumulated) > limit {
+		last := accumulated[limit-1]
+		lastCursor = &serverCursor{Name: last.Name, Version: last.Version}
+		accumulated = accumulated[:limit]
+	}
+
+	return accumulated, lastCursor, nil
+}
+
+// newDeduplicatingFilter returns a stateful RecordFilter that deduplicates helpers
+// by entry name, keeping only records from the highest-priority source (lowest position).
+func newDeduplicatingFilter() service.RecordFilter {
+	return newDeduplicatingFilterWith(
+		func(record any) (string, int32, bool) {
+			h, ok := record.(helper)
+			return h.Name, h.Position, ok
+		},
+	)
+}
 
 // sharedListServers is a helper function to list servers and mapping them to
 // the API schema.
@@ -915,10 +990,11 @@ type querierFunction func(ctx context.Context, querier sqlc.Querier) ([]helper, 
 func (s *dbService) sharedListServers(
 	ctx context.Context,
 	querierFunc querierFunction,
+	filter service.RecordFilter,
 ) ([]*upstreamv0.ServerJSON, error) {
 	// Delegate to sharedListServersWithCursor with a high limit and discard the cursor.
 	// This avoids duplicating the transaction and fetch logic.
-	result, _, err := s.sharedListServersWithCursor(ctx, querierFunc, service.MaxPageSize)
+	result, _, err := s.sharedListServersWithCursor(ctx, querierFunc, service.MaxPageSize, filter)
 	return result, err
 }
 
@@ -933,6 +1009,7 @@ func (s *dbService) sharedListServersWithCursor(
 	ctx context.Context,
 	querierFunc querierFunction,
 	limit int,
+	filter service.RecordFilter,
 ) ([]*upstreamv0.ServerJSON, *serverCursor, error) {
 	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{
 		IsoLevel:   pgx.ReadCommitted,
@@ -950,28 +1027,26 @@ func (s *dbService) sharedListServersWithCursor(
 
 	querier := sqlc.New(tx)
 
-	servers, err := querierFunc(ctx, querier)
+	accumulated, lastCursor, err := streamHelpers(ctx, querier, querierFunc, filter, limit)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	// Check if there are more results
-	var lastCursor *serverCursor
-	hasMore := len(servers) > limit
-	if hasMore {
-		// Trim to the requested limit
-		servers = servers[:limit]
-		// Get the Name and Version of the last server for the next cursor
-		if len(servers) > 0 {
-			lastServer := servers[len(servers)-1]
-			lastCursor = &serverCursor{
-				Name:    lastServer.Name,
-				Version: lastServer.Version,
-			}
-		}
+	result, err := fetchAndMapServers(ctx, querier, accumulated)
+	if err != nil {
+		return nil, nil, err
 	}
 
-	// Fetch packages and remotes for all servers
+	return result, lastCursor, nil
+}
+
+// fetchAndMapServers fetches packages and remotes for the given server helpers and
+// maps them to the API schema.
+func fetchAndMapServers(
+	ctx context.Context,
+	querier *sqlc.Queries,
+	servers []helper,
+) ([]*upstreamv0.ServerJSON, error) {
 	ids := make([]uuid.UUID, len(servers))
 	for i, server := range servers {
 		ids[i] = server.ID
@@ -979,7 +1054,7 @@ func (s *dbService) sharedListServersWithCursor(
 
 	packages, err := querier.ListServerPackages(ctx, ids)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 	packagesMap := make(map[uuid.UUID][]sqlc.ListServerPackagesRow)
 	for _, pkg := range packages {
@@ -988,7 +1063,7 @@ func (s *dbService) sharedListServersWithCursor(
 
 	remotes, err := querier.ListServerRemotes(ctx, ids)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 	remotesMap := make(map[uuid.UUID][]sqlc.McpServerRemote)
 	for _, remote := range remotes {
@@ -1003,10 +1078,10 @@ func (s *dbService) sharedListServersWithCursor(
 			remotesMap[dbServer.ID],
 		)
 		if err != nil {
-			return nil, nil, err
+			return nil, err
 		}
 		result = append(result, &server)
 	}
 
-	return result, lastCursor, nil
+	return result, nil
 }

--- a/internal/service/db/impl_skills.go
+++ b/internal/service/db/impl_skills.go
@@ -79,63 +79,16 @@ func (s *dbService) ListSkills(
 		params.CursorVersion = &cursorVersion
 	}
 
-	// Fetch skills in a loop to ensure we have enough results after dedup.
-	// Dedup can remove entries when multiple sources provide the same name,
-	// so a single SQL fetch may yield fewer than the target count.
-	const maxFetchIterations = 10 // safety cap to prevent runaway loops
-	target := options.Limit + 1
-	var allRows []sqlc.ListSkillsRow
-	batchParams := params
-	for range maxFetchIterations {
-		rows, err := querier.ListSkills(ctx, batchParams)
-		if err != nil {
-			otel.RecordError(span, err)
-			return nil, err
-		}
-
-		allRows = append(allRows, rows...)
-		deduped := deduplicateSkillRows(allRows)
-
-		if len(deduped) >= target || int64(len(rows)) < batchParams.Size {
-			allRows = deduped
-			break
-		}
-
-		lastRow := rows[len(rows)-1]
-		batchParams.CursorName = &lastRow.Name
-		batchParams.CursorVersion = &lastRow.Version
-	}
-	listRows := allRows
-
-	ids := make([]uuid.UUID, 0)
-	for _, row := range listRows {
-		ids = append(ids, row.VersionID)
-	}
-
-	ociPackages, err := querier.ListSkillOciPackages(ctx, ids)
-	if err != nil {
-		otel.RecordError(span, err)
-		return nil, err
-	}
-	gitPackages, err := querier.ListSkillGitPackages(ctx, ids)
+	listRows, nextCursor, err := streamSkillRows(ctx, querier, params, options.Filter, options.Limit)
 	if err != nil {
 		otel.RecordError(span, err)
 		return nil, err
 	}
 
-	packages := make(map[uuid.UUID][]service.SkillPackage)
-	for _, pkg := range ociPackages {
-		packages[pkg.SkillID] = append(packages[pkg.SkillID], toServiceSkillOciPackage(pkg))
-	}
-	for _, pkg := range gitPackages {
-		packages[pkg.SkillID] = append(packages[pkg.SkillID], toServiceSkillGitPackage(pkg))
-	}
-
-	nextCursor := ""
-	if len(listRows) > options.Limit {
-		last := listRows[options.Limit-1]
-		nextCursor = service.EncodeCursor(last.Name, last.Version)
-		listRows = listRows[:options.Limit]
+	packages, err := fetchSkillPackages(ctx, querier, listRows)
+	if err != nil {
+		otel.RecordError(span, err)
+		return nil, err
 	}
 
 	skills := make([]*service.Skill, len(listRows))
@@ -149,6 +102,38 @@ func (s *dbService) ListSkills(
 		Skills:     skills,
 		NextCursor: nextCursor,
 	}, nil
+}
+
+// fetchSkillPackages fetches OCI and Git packages for the given skill rows and
+// returns them keyed by skill version ID.
+func fetchSkillPackages(
+	ctx context.Context,
+	querier *sqlc.Queries,
+	rows []sqlc.ListSkillsRow,
+) (map[uuid.UUID][]service.SkillPackage, error) {
+	ids := make([]uuid.UUID, len(rows))
+	for i, row := range rows {
+		ids[i] = row.VersionID
+	}
+
+	ociPackages, err := querier.ListSkillOciPackages(ctx, ids)
+	if err != nil {
+		return nil, err
+	}
+	gitPackages, err := querier.ListSkillGitPackages(ctx, ids)
+	if err != nil {
+		return nil, err
+	}
+
+	packages := make(map[uuid.UUID][]service.SkillPackage)
+	for _, pkg := range ociPackages {
+		packages[pkg.SkillID] = append(packages[pkg.SkillID], toServiceSkillOciPackage(pkg))
+	}
+	for _, pkg := range gitPackages {
+		packages[pkg.SkillID] = append(packages[pkg.SkillID], toServiceSkillGitPackage(pkg))
+	}
+
+	return packages, nil
 }
 
 // GetSkillVersion returns a specific skill version by name and version.
@@ -213,6 +198,17 @@ func (s *dbService) GetSkillVersion(
 
 	// Pick the first row (ordered by position ascending = highest priority source)
 	row := rows[0]
+
+	if options.Filter != nil {
+		keep, err := options.Filter(ctx, row)
+		if err != nil {
+			otel.RecordError(span, err)
+			return nil, err
+		}
+		if !keep {
+			return nil, fmt.Errorf("%w: %s %s", service.ErrNotFound, options.Name, options.Version)
+		}
+	}
 
 	ociPackages, err := querier.ListSkillOciPackages(ctx, []uuid.UUID{row.SkillVersionID})
 	if err != nil {
@@ -615,22 +611,74 @@ func (s *dbService) executeDeleteSkillTransaction(
 	return nil
 }
 
-// deduplicateSkillRows removes duplicate entries at the entry name level, keeping
-// all versions from the highest-priority source (lowest position value).
-func deduplicateSkillRows(rows []sqlc.ListSkillsRow) []sqlc.ListSkillsRow {
-	// Pass 1: determine winning position per entry name (lowest position wins)
-	winningPosition := make(map[string]int32, len(rows))
-	for _, r := range rows {
-		if pos, ok := winningPosition[r.Name]; !ok || r.Position < pos {
-			winningPosition[r.Name] = r.Position
+// streamSkillRows fetches skill rows in batches, applying the auth filter then the
+// dedup filter to each record, until limit+1 rows are accumulated or the DB is
+// exhausted. It returns the trimmed slice (≤ limit) and the encoded cursor for the
+// next page, if any.
+func streamSkillRows(
+	ctx context.Context,
+	querier *sqlc.Queries,
+	params sqlc.ListSkillsParams,
+	filter service.RecordFilter,
+	limit int,
+) ([]sqlc.ListSkillsRow, string, error) {
+	dedupFilter := newDeduplicatingSkillFilter()
+	var accumulated []sqlc.ListSkillsRow
+	batchParams := params
+
+	for {
+		batch, err := querier.ListSkills(ctx, batchParams)
+		if err != nil {
+			return nil, "", err
 		}
-	}
-	// Pass 2: keep only versions from the winning source (by position)
-	result := make([]sqlc.ListSkillsRow, 0, len(rows))
-	for _, r := range rows {
-		if r.Position == winningPosition[r.Name] {
-			result = append(result, r)
+
+		for _, row := range batch {
+			keep := true
+			var ferr error
+			if filter != nil {
+				keep, ferr = filter(ctx, row)
+				if ferr != nil {
+					return nil, "", ferr
+				}
+			}
+			if keep {
+				keep, ferr = dedupFilter(ctx, row)
+				if ferr != nil {
+					return nil, "", ferr
+				}
+			}
+			if keep {
+				accumulated = append(accumulated, row)
+			}
 		}
+
+		if len(accumulated) >= limit+1 || int64(len(batch)) < batchParams.Size {
+			break
+		}
+
+		lastRow := batch[len(batch)-1]
+		batchParams.CursorName = &lastRow.Name
+		batchParams.CursorVersion = &lastRow.Version
 	}
-	return result
+
+	nextCursor := ""
+	if len(accumulated) > limit {
+		last := accumulated[limit-1]
+		nextCursor = service.EncodeCursor(last.Name, last.Version)
+		accumulated = accumulated[:limit]
+	}
+
+	return accumulated, nextCursor, nil
+}
+
+// newDeduplicatingSkillFilter returns a stateful RecordFilter that deduplicates
+// skill rows by entry name, keeping only records from the highest-priority source
+// (lowest position). SQL must return records in position-ascending order per name.
+func newDeduplicatingSkillFilter() service.RecordFilter {
+	return newDeduplicatingFilterWith(
+		func(record any) (string, int32, bool) {
+			r, ok := record.(sqlc.ListSkillsRow)
+			return r.Name, r.Position, ok
+		},
+	)
 }

--- a/internal/service/db/impl_test.go
+++ b/internal/service/db/impl_test.go
@@ -2,6 +2,7 @@ package database
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -429,6 +430,47 @@ func TestListServers(t *testing.T) {
 				require.Len(t, result.Servers, 1)
 				require.Equal(t, "com.example/test-server-1", result.Servers[0].Name)
 				require.Equal(t, "2.0.0", result.Servers[0].Version)
+			},
+		},
+		{
+			name: "app-level filter keeps only server-1 records",
+			//nolint:thelper // We want to see these lines in the test output
+			setupFunc: func(t *testing.T, pool *pgxpool.Pool) {
+				setupTestData(t, pool)
+			},
+			options: []service.Option{
+				service.WithLimit(10),
+				service.WithFilter(service.RecordFilter(func(_ context.Context, record any) (bool, error) {
+					h, ok := record.(helper)
+					if !ok {
+						return false, nil
+					}
+					return h.Name == "com.example/test-server-1", nil
+				})),
+			},
+			//nolint:thelper // We want to see these lines in the test output
+			validateFunc: func(t *testing.T, result *service.ListServersResult) {
+				require.Len(t, result.Servers, 3)
+				for _, server := range result.Servers {
+					require.Equal(t, "com.example/test-server-1", server.Name)
+				}
+			},
+		},
+		{
+			name: "app-level filter drops all records returns empty list",
+			//nolint:thelper // We want to see these lines in the test output
+			setupFunc: func(t *testing.T, pool *pgxpool.Pool) {
+				setupTestData(t, pool)
+			},
+			options: []service.Option{
+				service.WithLimit(10),
+				service.WithFilter(service.RecordFilter(func(context.Context, any) (bool, error) {
+					return false, nil
+				})),
+			},
+			//nolint:thelper // We want to see these lines in the test output
+			validateFunc: func(t *testing.T, result *service.ListServersResult) {
+				require.Len(t, result.Servers, 0)
 			},
 		},
 	}
@@ -862,6 +904,20 @@ func TestGetServerVersion(t *testing.T) {
 				service.WithName("com.example/test-server-1"),
 				service.WithVersion("1.0.0"),
 				service.WithRegistryName("non-existent-registry"),
+			},
+		},
+		{
+			name: "filter rejects record returns error",
+			//nolint:thelper // We want to see these lines in the test output
+			setupFunc: func(t *testing.T, pool *pgxpool.Pool) {
+				setupTestData(t, pool)
+			},
+			options: []service.Option{
+				service.WithName("com.example/test-server-1"),
+				service.WithVersion("1.0.0"),
+				service.WithFilter(service.RecordFilter(func(context.Context, any) (bool, error) {
+					return false, nil
+				})),
 			},
 		},
 	}
@@ -2841,6 +2897,218 @@ func TestDeleteSkillVersion(t *testing.T) {
 			require.NotNil(t, result)
 			require.Equal(t, tt.expectLatestVersion, result.Version)
 			require.True(t, result.IsLatest)
+		})
+	}
+}
+
+// setupSkillTestData creates a managed source, registry, and publishes skills for testing.
+//
+//nolint:thelper // We want to see these lines in the test output
+func setupSkillTestData(t *testing.T, svc *dbService, skills []string) {
+	ctx := context.Background()
+	queries := sqlc.New(svc.pool)
+	now := time.Now()
+
+	src, err := queries.InsertSource(ctx, sqlc.InsertSourceParams{
+		Name:         "managed",
+		SourceType:   "managed",
+		CreationType: sqlc.CreationTypeCONFIG,
+		Syncable:     false,
+	})
+	require.NoError(t, err)
+
+	reg, err := queries.UpsertRegistry(ctx, sqlc.UpsertRegistryParams{
+		Name:         "test-skills-registry",
+		CreationType: sqlc.CreationTypeCONFIG,
+		CreatedAt:    &now,
+		UpdatedAt:    &now,
+	})
+	require.NoError(t, err)
+
+	err = queries.LinkRegistrySource(ctx, sqlc.LinkRegistrySourceParams{
+		RegistryID: reg.ID,
+		SourceID:   src.ID,
+		Position:   0,
+	})
+	require.NoError(t, err)
+
+	for _, name := range skills {
+		_, err := svc.PublishSkill(ctx, &service.Skill{
+			Name:      name,
+			Namespace: "com.example",
+			Version:   "1.0.0",
+			Title:     name,
+		})
+		require.NoError(t, err)
+	}
+}
+
+func TestListSkills(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		setupFunc    func(*testing.T, *dbService)
+		options      []service.Option
+		validateFunc func(*testing.T, *service.ListSkillsResult)
+	}{
+		{
+			name: "list all skills returns all published",
+			//nolint:thelper // We want to see these lines in the test output
+			setupFunc: func(t *testing.T, svc *dbService) {
+				setupSkillTestData(t, svc, []string{"skill-a", "skill-b"})
+			},
+			options: []service.Option{
+				service.WithRegistryName("test-skills-registry"),
+				service.WithNamespace("com.example"),
+				service.WithLimit(10),
+			},
+			//nolint:thelper // We want to see these lines in the test output
+			validateFunc: func(t *testing.T, result *service.ListSkillsResult) {
+				require.Len(t, result.Skills, 2)
+				names := make([]string, len(result.Skills))
+				for i, s := range result.Skills {
+					names[i] = s.Name
+				}
+				require.Contains(t, names, "skill-a")
+				require.Contains(t, names, "skill-b")
+			},
+		},
+		{
+			name: "app-level filter keeps only skill-a",
+			//nolint:thelper // We want to see these lines in the test output
+			setupFunc: func(t *testing.T, svc *dbService) {
+				setupSkillTestData(t, svc, []string{"skill-a", "skill-b"})
+			},
+			options: []service.Option{
+				service.WithRegistryName("test-skills-registry"),
+				service.WithNamespace("com.example"),
+				service.WithLimit(10),
+				service.WithFilter(service.RecordFilter(func(_ context.Context, record any) (bool, error) {
+					row, ok := record.(sqlc.ListSkillsRow)
+					if !ok {
+						return false, nil
+					}
+					return row.Name == "skill-a", nil
+				})),
+			},
+			//nolint:thelper // We want to see these lines in the test output
+			validateFunc: func(t *testing.T, result *service.ListSkillsResult) {
+				require.Len(t, result.Skills, 1)
+				require.Equal(t, "skill-a", result.Skills[0].Name)
+			},
+		},
+		{
+			name: "app-level filter drops all returns empty list",
+			//nolint:thelper // We want to see these lines in the test output
+			setupFunc: func(t *testing.T, svc *dbService) {
+				setupSkillTestData(t, svc, []string{"skill-a", "skill-b"})
+			},
+			options: []service.Option{
+				service.WithRegistryName("test-skills-registry"),
+				service.WithNamespace("com.example"),
+				service.WithLimit(10),
+				service.WithFilter(service.RecordFilter(func(context.Context, any) (bool, error) {
+					return false, nil
+				})),
+			},
+			//nolint:thelper // We want to see these lines in the test output
+			validateFunc: func(t *testing.T, result *service.ListSkillsResult) {
+				require.Len(t, result.Skills, 0)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			svc, cleanup := setupTestService(t)
+			defer cleanup()
+
+			tt.setupFunc(t, svc)
+
+			result, err := svc.ListSkills(context.Background(), tt.options...)
+
+			if tt.validateFunc == nil {
+				require.Error(t, err)
+				require.Nil(t, result)
+				return
+			}
+
+			require.NoError(t, err)
+			tt.validateFunc(t, result)
+		})
+	}
+}
+
+func TestGetSkillVersion(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		setupFunc    func(*testing.T, *dbService)
+		options      []service.Option
+		validateFunc func(*testing.T, *service.Skill)
+	}{
+		{
+			name: "get existing skill version",
+			//nolint:thelper // We want to see these lines in the test output
+			setupFunc: func(t *testing.T, svc *dbService) {
+				setupSkillTestData(t, svc, []string{"skill-a"})
+			},
+			options: []service.Option{
+				service.WithRegistryName("test-skills-registry"),
+				service.WithNamespace("com.example"),
+				service.WithName("skill-a"),
+				service.WithVersion("1.0.0"),
+			},
+			//nolint:thelper // We want to see these lines in the test output
+			validateFunc: func(t *testing.T, skill *service.Skill) {
+				require.NotNil(t, skill)
+				require.Equal(t, "skill-a", skill.Name)
+				require.Equal(t, "1.0.0", skill.Version)
+				require.Equal(t, "com.example", skill.Namespace)
+			},
+		},
+		{
+			name: "filter rejects record returns ErrNotFound",
+			//nolint:thelper // We want to see these lines in the test output
+			setupFunc: func(t *testing.T, svc *dbService) {
+				setupSkillTestData(t, svc, []string{"skill-a"})
+			},
+			options: []service.Option{
+				service.WithRegistryName("test-skills-registry"),
+				service.WithNamespace("com.example"),
+				service.WithName("skill-a"),
+				service.WithVersion("1.0.0"),
+				service.WithFilter(service.RecordFilter(func(context.Context, any) (bool, error) {
+					return false, nil
+				})),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			svc, cleanup := setupTestService(t)
+			defer cleanup()
+
+			tt.setupFunc(t, svc)
+
+			skill, err := svc.GetSkillVersion(context.Background(), tt.options...)
+
+			if tt.validateFunc == nil {
+				require.Error(t, err)
+				require.True(t, errors.Is(err, service.ErrNotFound))
+				require.Nil(t, skill)
+				return
+			}
+
+			require.NoError(t, err)
+			tt.validateFunc(t, skill)
 		})
 	}
 }

--- a/internal/service/db/types.go
+++ b/internal/service/db/types.go
@@ -40,26 +40,6 @@ type helper struct {
 	Position            int32
 }
 
-// deduplicateHelpers removes duplicate entries at the entry name level, keeping
-// all versions from the highest-priority source (lowest position value).
-func deduplicateHelpers(helpers []helper) []helper {
-	// Pass 1: determine winning position per entry name (lowest position wins)
-	winningPosition := make(map[string]int32, len(helpers))
-	for _, h := range helpers {
-		if pos, ok := winningPosition[h.Name]; !ok || h.Position < pos {
-			winningPosition[h.Name] = h.Position
-		}
-	}
-	// Pass 2: keep only versions from the winning source (by position)
-	result := make([]helper, 0, len(helpers))
-	for _, h := range helpers {
-		if h.Position == winningPosition[h.Name] {
-			result = append(result, h)
-		}
-	}
-	return result
-}
-
 func listServersRowToHelper(
 	dbServer sqlc.ListServersRow,
 ) helper {

--- a/internal/service/db/types_test.go
+++ b/internal/service/db/types_test.go
@@ -244,7 +244,7 @@ func TestSerializePublisherProvidedMeta(t *testing.T) {
 	}
 }
 
-func TestDeduplicateHelpers(t *testing.T) {
+func TestNewDeduplicatingFilter(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -280,7 +280,7 @@ func TestDeduplicateHelpers(t *testing.T) {
 			},
 		},
 		{
-			name: "same entry name from two sources keeps only lowest position",
+			name: "same entry name from two sources keeps only first-seen position",
 			input: []helper{
 				{Name: "server-a", Version: "1.0.0", Position: 1},
 				{Name: "server-a", Version: "2.0.0", Position: 1},
@@ -293,14 +293,14 @@ func TestDeduplicateHelpers(t *testing.T) {
 			},
 		},
 		{
-			name: "multiple entry names independently resolved",
+			name: "multiple entry names independently resolved with position-ascending input",
 			input: []helper{
 				{Name: "server-a", Version: "1.0.0", Position: 3},
 				{Name: "server-a", Version: "2.0.0", Position: 3},
+				{Name: "server-b", Version: "1.0.0", Position: 3},
 				{Name: "server-a", Version: "1.0.0", Position: 7},
 				{Name: "server-b", Version: "1.0.0", Position: 7},
 				{Name: "server-b", Version: "2.0.0", Position: 7},
-				{Name: "server-b", Version: "1.0.0", Position: 3},
 			},
 			expect: []helper{
 				{Name: "server-a", Version: "1.0.0", Position: 3},
@@ -309,13 +309,13 @@ func TestDeduplicateHelpers(t *testing.T) {
 			},
 		},
 		{
-			name: "lowest position wins regardless of input order",
+			name: "first-seen position wins with position-ascending input",
 			input: []helper{
-				{Name: "server-x", Version: "old", Position: 10},
-				{Name: "server-x", Version: "newer", Position: 10},
 				{Name: "server-x", Version: "best", Position: 2},
 				{Name: "server-x", Version: "also-best", Position: 2},
 				{Name: "server-x", Version: "mid", Position: 5},
+				{Name: "server-x", Version: "old", Position: 10},
+				{Name: "server-x", Version: "newer", Position: 10},
 			},
 			expect: []helper{
 				{Name: "server-x", Version: "best", Position: 2},
@@ -341,7 +341,19 @@ func TestDeduplicateHelpers(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			got := deduplicateHelpers(tt.input)
+			filter := newDeduplicatingFilter()
+			var got []helper
+			for _, h := range tt.input {
+				keep, err := filter(t.Context(), h)
+				require.NoError(t, err)
+				if keep {
+					got = append(got, h)
+				}
+			}
+			// Normalize nil to empty slice for comparison
+			if got == nil {
+				got = []helper{}
+			}
 
 			assert.Equal(t, tt.expect, got)
 		})

--- a/internal/service/filter.go
+++ b/internal/service/filter.go
@@ -1,0 +1,8 @@
+package service
+
+import "context"
+
+// RecordFilter is a predicate applied to records after they are fetched from
+// the database. Return true to keep the record, false to drop it.
+// An error aborts the listing operation.
+type RecordFilter func(ctx context.Context, record any) (bool, error)

--- a/internal/service/options.go
+++ b/internal/service/options.go
@@ -54,6 +54,10 @@ type claimsOption interface {
 	setClaims(claims map[string]any) error
 }
 
+type filterOption interface {
+	setFilter(filter RecordFilter) error
+}
+
 // WithCursor sets the cursor for the ListServers operation
 func WithCursor(cursor string) Option {
 	return func(o any) error {
@@ -208,6 +212,18 @@ func WithClaims(claims map[string]any) Option {
 		switch o := o.(type) {
 		case claimsOption:
 			return o.setClaims(claims)
+		default:
+			return fmt.Errorf("invalid option type: %T", o)
+		}
+	}
+}
+
+// WithFilter sets a filter predicate for ListServers or ListSkills operations.
+func WithFilter(filter RecordFilter) Option {
+	return func(o any) error {
+		switch o := o.(type) {
+		case filterOption:
+			return o.setFilter(filter)
 		default:
 			return fmt.Errorf("invalid option type: %T", o)
 		}

--- a/internal/service/options_mcp.go
+++ b/internal/service/options_mcp.go
@@ -14,6 +14,13 @@ type ListServersOptions struct {
 	Search       string
 	UpdatedSince time.Time
 	Version      string
+	Filter       RecordFilter
+}
+
+//nolint:unparam
+func (o *ListServersOptions) setFilter(filter RecordFilter) error {
+	o.Filter = filter
+	return nil
 }
 
 //nolint:unparam
@@ -57,6 +64,13 @@ type ListServerVersionsOptions struct {
 	RegistryName *string
 	Name         string
 	Limit        int
+	Filter       RecordFilter
+}
+
+//nolint:unparam
+func (o *ListServerVersionsOptions) setFilter(filter RecordFilter) error {
+	o.Filter = filter
+	return nil
 }
 
 //nolint:unparam
@@ -83,6 +97,13 @@ type GetServerVersionOptions struct {
 	SourceName   string
 	Name         string
 	Version      string
+	Filter       RecordFilter
+}
+
+//nolint:unparam
+func (o *GetServerVersionOptions) setFilter(filter RecordFilter) error {
+	o.Filter = filter
+	return nil
 }
 
 //nolint:unparam

--- a/internal/service/options_skills.go
+++ b/internal/service/options_skills.go
@@ -21,6 +21,13 @@ type ListSkillsOptions struct {
 	Search       *string
 	Limit        int
 	Cursor       *string
+	Filter       RecordFilter
+}
+
+//nolint:unparam
+func (o *ListSkillsOptions) setFilter(filter RecordFilter) error {
+	o.Filter = filter
+	return nil
 }
 
 //nolint:unparam
@@ -72,6 +79,13 @@ type GetSkillVersionOptions struct {
 	Namespace    string
 	Name         string
 	Version      string
+	Filter       RecordFilter
+}
+
+//nolint:unparam
+func (o *GetSkillVersionOptions) setFilter(filter RecordFilter) error {
+	o.Filter = filter
+	return nil
 }
 
 //nolint:unparam

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -1,6 +1,7 @@
 package service_test
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -9,6 +10,11 @@ import (
 
 	"github.com/stacklok/toolhive-registry-server/internal/service"
 )
+
+// alwaysKeepFilter is a simple RecordFilter that keeps every record.
+var alwaysKeepFilter service.RecordFilter = func(context.Context, any) (bool, error) {
+	return true, nil
+}
 
 func TestWithCursor(t *testing.T) {
 	t.Parallel()
@@ -530,6 +536,80 @@ func TestWithLimitListServerVersions(t *testing.T) {
 
 			require.NoError(t, err)
 			assert.Equal(t, tt.expectedValue, opts.Limit)
+		})
+	}
+}
+
+func TestWithFilter(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		opts    any
+		wantErr bool
+		check   func(t *testing.T, opts any)
+	}{
+		{
+			name: "sets filter on ListServersOptions",
+			opts: &service.ListServersOptions{},
+			check: func(t *testing.T, opts any) {
+				t.Helper()
+				assert.NotNil(t, opts.(*service.ListServersOptions).Filter)
+			},
+		},
+		{
+			name: "sets filter on ListServerVersionsOptions",
+			opts: &service.ListServerVersionsOptions{},
+			check: func(t *testing.T, opts any) {
+				t.Helper()
+				assert.NotNil(t, opts.(*service.ListServerVersionsOptions).Filter)
+			},
+		},
+		{
+			name: "sets filter on GetServerVersionOptions",
+			opts: &service.GetServerVersionOptions{},
+			check: func(t *testing.T, opts any) {
+				t.Helper()
+				assert.NotNil(t, opts.(*service.GetServerVersionOptions).Filter)
+			},
+		},
+		{
+			name: "sets filter on ListSkillsOptions",
+			opts: &service.ListSkillsOptions{},
+			check: func(t *testing.T, opts any) {
+				t.Helper()
+				assert.NotNil(t, opts.(*service.ListSkillsOptions).Filter)
+			},
+		},
+		{
+			name: "sets filter on GetSkillVersionOptions",
+			opts: &service.GetSkillVersionOptions{},
+			check: func(t *testing.T, opts any) {
+				t.Helper()
+				assert.NotNil(t, opts.(*service.GetSkillVersionOptions).Filter)
+			},
+		},
+		{
+			name:    "returns error for incompatible type",
+			opts:    &service.PublishServerVersionOptions{},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			opt := service.WithFilter(alwaysKeepFilter)
+			err := opt(tt.opts)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			tt.check(t, tt.opts)
 		})
 	}
 }


### PR DESCRIPTION
This change adds app-level filter pipeline to routines fetching records for MCP servers and Skills to support caller-defined record predicates, replacing the batch deduplication approach with a stateful streaming filter that re-fetches from the database until the page is full or the source is exhausted.

References #444