### PR TITLE
Fix docs follow-up for #634

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -42,6 +42,10 @@ sources:
     file:
       path: /data/registry.json
 
+registries:
+  - name: default
+    sources: ["default"]
+
 database:
   host: localhost
   port: 5432

--- a/docs/database.md
+++ b/docs/database.md
@@ -203,7 +203,7 @@ docker run -d --name postgres \
   -e POSTGRES_PASSWORD=devpassword \
   -e POSTGRES_DB=toolhive_registry \
   -p 5432:5432 \
-  postgres:18
+  postgres:18-alpine
 
 # 2. Create pgpass file with credentials
 cat > ~/.pgpass <<EOF


### PR DESCRIPTION
The following PR:
- Add missing registries: block to the minimal configuration example in docs/configuration.md (required field, omitting it causes a startup error)
- Fix postgres:18 to postgres:18-alpine in docs/database.md to match docker-compose.yaml