### PR TITLE
Check claim when reading records

### DIFF
--- a/database/queries/servers.sql
+++ b/database/queries/servers.sql
@@ -20,6 +20,7 @@ SELECT src.source_type as registry_type,
        s.repository_id,
        s.repository_subfolder,
        s.repository_type,
+       e.claims,
        -- Sources not linked to the requested registry have no position; default to max int16
        -- so they sort after all explicitly positioned sources (lower position = higher priority).
        COALESCE(rs.position, 32767)::integer AS position
@@ -54,6 +55,10 @@ SELECT src.source_type as registry_type,
  LIMIT sqlc.arg(size)::bigint;
 
 -- name: GetServerVersion :many
+-- Despite the name, this query returns multiple rows. The careful reader will
+-- note that there is no limit clause, which might seem a bug, but the actual
+-- number of records is bounded by the number of sources that provide the same
+-- name and version, which we currently don't expect to be more than a few.
 SELECT src.source_type as registry_type,
        v.id,
        e.name,
@@ -70,6 +75,7 @@ SELECT src.source_type as registry_type,
        s.repository_id,
        s.repository_subfolder,
        s.repository_type,
+       e.claims,
        -- Sources not linked to the requested registry have no position; default to max int16
        -- so they sort after all explicitly positioned sources (lower position = higher priority).
        COALESCE(rs.position, 32767)::integer AS position

--- a/database/queries/skills.sql
+++ b/database/queries/skills.sql
@@ -21,6 +21,7 @@ SELECT src.source_type AS registry_type,
        s.icons,
        s.metadata,
        s.extension_meta,
+       e.claims,
        -- Sources not linked to the requested registry have no position; default to max int16
        -- so they sort after all explicitly positioned sources (lower position = higher priority).
        COALESCE(rs.position, 32767)::integer AS position
@@ -48,6 +49,10 @@ SELECT src.source_type AS registry_type,
  LIMIT sqlc.arg(size)::bigint;
 
 -- name: GetSkillVersion :many
+-- Despite the name, this query returns multiple rows. The careful reader will
+-- note that there is no limit clause, which might seem a bug, but the actual
+-- number of records is bounded by the number of sources that provide the same
+-- name and version, which we currently don't expect to be more than a few.
 SELECT src.source_type AS registry_type,
        v.id,
        e.name,
@@ -67,6 +72,7 @@ SELECT src.source_type AS registry_type,
        s.icons,
        s.metadata,
        s.extension_meta,
+       e.claims,
        -- Sources not linked to the requested registry have no position; default to max int16
        -- so they sort after all explicitly positioned sources (lower position = higher priority).
        COALESCE(rs.position, 32767)::integer AS position

--- a/internal/api/registry/v01/routes.go
+++ b/internal/api/registry/v01/routes.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/stacklok/toolhive-registry-server/internal/api/common"
 	"github.com/stacklok/toolhive-registry-server/internal/api/x/skills"
+	"github.com/stacklok/toolhive-registry-server/internal/auth"
 	"github.com/stacklok/toolhive-registry-server/internal/service"
 )
 
@@ -111,6 +112,9 @@ func (routes *Routes) handleListServers(w http.ResponseWriter, r *http.Request, 
 	if registryName != "" {
 		opts = append(opts, service.WithRegistryName(registryName))
 	}
+	if jwtClaims := auth.ClaimsFromContext(r.Context()); jwtClaims != nil {
+		opts = append(opts, service.WithClaims(map[string]any(jwtClaims)))
+	}
 
 	listResult, err := routes.service.ListServers(r.Context(), opts...)
 	if err != nil {
@@ -194,6 +198,9 @@ func (routes *Routes) handleListVersions(w http.ResponseWriter, r *http.Request,
 	}
 	if serverName != "" {
 		opts = append(opts, service.WithName(serverName))
+	}
+	if jwtClaims := auth.ClaimsFromContext(r.Context()); jwtClaims != nil {
+		opts = append(opts, service.WithClaims(map[string]any(jwtClaims)))
 	}
 
 	versions, err := routes.service.ListServerVersions(r.Context(), opts...)
@@ -279,6 +286,9 @@ func (routes *Routes) handleGetVersion(w http.ResponseWriter, r *http.Request, r
 	}
 	if version != "" {
 		opts = append(opts, service.WithVersion(version))
+	}
+	if jwtClaims := auth.ClaimsFromContext(r.Context()); jwtClaims != nil {
+		opts = append(opts, service.WithClaims(map[string]any(jwtClaims)))
 	}
 
 	server, err := routes.service.GetServerVersion(r.Context(), opts...)

--- a/internal/api/x/skills/routes.go
+++ b/internal/api/x/skills/routes.go
@@ -13,6 +13,7 @@ import (
 	thvregistry "github.com/stacklok/toolhive-core/registry/types"
 
 	"github.com/stacklok/toolhive-registry-server/internal/api/common"
+	"github.com/stacklok/toolhive-registry-server/internal/auth"
 	"github.com/stacklok/toolhive-registry-server/internal/service"
 )
 
@@ -79,6 +80,9 @@ func (routes *Routes) listSkills(w http.ResponseWriter, r *http.Request) {
 	if query.Cursor != "" {
 		opts = append(opts, service.WithCursor(query.Cursor))
 	}
+	if jwtClaims := auth.ClaimsFromContext(r.Context()); jwtClaims != nil {
+		opts = append(opts, service.WithClaims(map[string]any(jwtClaims)))
+	}
 
 	result, err := routes.service.ListSkills(r.Context(), opts...)
 	if err != nil {
@@ -130,12 +134,17 @@ func (routes *Routes) getLatestVersion(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	skill, err := routes.service.GetSkillVersion(r.Context(),
+	skillOpts := []service.Option{
 		service.WithRegistryName(registryName),
 		service.WithNamespace(namespace),
 		service.WithName(name),
 		service.WithVersion("latest"),
-	)
+	}
+	if jwtClaims := auth.ClaimsFromContext(r.Context()); jwtClaims != nil {
+		skillOpts = append(skillOpts, service.WithClaims(map[string]any(jwtClaims)))
+	}
+
+	skill, err := routes.service.GetSkillVersion(r.Context(), skillOpts...)
 	if err != nil {
 		writeServiceError(w, err)
 		return
@@ -177,11 +186,16 @@ func (routes *Routes) listVersions(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	result, err := routes.service.ListSkills(r.Context(),
+	listOpts := []service.Option{
 		service.WithRegistryName(registryName),
 		service.WithNamespace(namespace),
 		service.WithName(name),
-	)
+	}
+	if jwtClaims := auth.ClaimsFromContext(r.Context()); jwtClaims != nil {
+		listOpts = append(listOpts, service.WithClaims(map[string]any(jwtClaims)))
+	}
+
+	result, err := routes.service.ListSkills(r.Context(), listOpts...)
 	if err != nil {
 		writeServiceError(w, err)
 		return
@@ -237,12 +251,17 @@ func (routes *Routes) getVersion(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	skill, err := routes.service.GetSkillVersion(r.Context(),
+	versionOpts := []service.Option{
 		service.WithRegistryName(registryName),
 		service.WithNamespace(namespace),
 		service.WithName(name),
 		service.WithVersion(version),
-	)
+	}
+	if jwtClaims := auth.ClaimsFromContext(r.Context()); jwtClaims != nil {
+		versionOpts = append(versionOpts, service.WithClaims(map[string]any(jwtClaims)))
+	}
+
+	skill, err := routes.service.GetSkillVersion(r.Context(), versionOpts...)
 	if err != nil {
 		writeServiceError(w, err)
 		return

--- a/internal/db/sqlc/querier.go
+++ b/internal/db/sqlc/querier.go
@@ -60,7 +60,15 @@ type Querier interface {
 	GetRegistryByName(ctx context.Context, name string) (Registry, error)
 	GetRegistryEntryByName(ctx context.Context, arg GetRegistryEntryByNameParams) (GetRegistryEntryByNameRow, error)
 	GetServerIDsByRegistryNameVersion(ctx context.Context, sourceID uuid.UUID) ([]GetServerIDsByRegistryNameVersionRow, error)
+	// Despite the name, this query returns multiple rows. The careful reader will
+	// note that there is no limit clause, which might seem a bug, but the actual
+	// number of records is bounded by the number of sources that provide the same
+	// name and version, which we currently don't expect to be more than a few.
 	GetServerVersion(ctx context.Context, arg GetServerVersionParams) ([]GetServerVersionRow, error)
+	// Despite the name, this query returns multiple rows. The careful reader will
+	// note that there is no limit clause, which might seem a bug, but the actual
+	// number of records is bounded by the number of sources that provide the same
+	// name and version, which we currently don't expect to be more than a few.
 	GetSkillVersion(ctx context.Context, arg GetSkillVersionParams) ([]GetSkillVersionRow, error)
 	GetSource(ctx context.Context, id uuid.UUID) (GetSourceRow, error)
 	GetSourceByName(ctx context.Context, name string) (GetSourceByNameRow, error)

--- a/internal/db/sqlc/servers.sql.go
+++ b/internal/db/sqlc/servers.sql.go
@@ -132,6 +132,7 @@ SELECT src.source_type as registry_type,
        s.repository_id,
        s.repository_subfolder,
        s.repository_type,
+       e.claims,
        -- Sources not linked to the requested registry have no position; default to max int16
        -- so they sort after all explicitly positioned sources (lower position = higher priority).
        COALESCE(rs.position, 32767)::integer AS position
@@ -176,9 +177,14 @@ type GetServerVersionRow struct {
 	RepositoryID        *string    `json:"repository_id"`
 	RepositorySubfolder *string    `json:"repository_subfolder"`
 	RepositoryType      *string    `json:"repository_type"`
+	Claims              []byte     `json:"claims"`
 	Position            int32      `json:"position"`
 }
 
+// Despite the name, this query returns multiple rows. The careful reader will
+// note that there is no limit clause, which might seem a bug, but the actual
+// number of records is bounded by the number of sources that provide the same
+// name and version, which we currently don't expect to be more than a few.
 func (q *Queries) GetServerVersion(ctx context.Context, arg GetServerVersionParams) ([]GetServerVersionRow, error) {
 	rows, err := q.db.Query(ctx, getServerVersion,
 		arg.RegistryName,
@@ -210,6 +216,7 @@ func (q *Queries) GetServerVersion(ctx context.Context, arg GetServerVersionPara
 			&i.RepositoryID,
 			&i.RepositorySubfolder,
 			&i.RepositoryType,
+			&i.Claims,
 			&i.Position,
 		); err != nil {
 			return nil, err
@@ -575,6 +582,7 @@ SELECT src.source_type as registry_type,
        s.repository_id,
        s.repository_subfolder,
        s.repository_type,
+       e.claims,
        -- Sources not linked to the requested registry have no position; default to max int16
        -- so they sort after all explicitly positioned sources (lower position = higher priority).
        COALESCE(rs.position, 32767)::integer AS position
@@ -637,6 +645,7 @@ type ListServersRow struct {
 	RepositoryID        *string    `json:"repository_id"`
 	RepositorySubfolder *string    `json:"repository_subfolder"`
 	RepositoryType      *string    `json:"repository_type"`
+	Claims              []byte     `json:"claims"`
 	Position            int32      `json:"position"`
 }
 
@@ -680,6 +689,7 @@ func (q *Queries) ListServers(ctx context.Context, arg ListServersParams) ([]Lis
 			&i.RepositoryID,
 			&i.RepositorySubfolder,
 			&i.RepositoryType,
+			&i.Claims,
 			&i.Position,
 		); err != nil {
 			return nil, err

--- a/internal/db/sqlc/skills.sql.go
+++ b/internal/db/sqlc/skills.sql.go
@@ -71,6 +71,7 @@ SELECT src.source_type AS registry_type,
        s.icons,
        s.metadata,
        s.extension_meta,
+       e.claims,
        -- Sources not linked to the requested registry have no position; default to max int16
        -- so they sort after all explicitly positioned sources (lower position = higher priority).
        COALESCE(rs.position, 32767)::integer AS position
@@ -119,9 +120,14 @@ type GetSkillVersionRow struct {
 	Icons          []byte      `json:"icons"`
 	Metadata       []byte      `json:"metadata"`
 	ExtensionMeta  []byte      `json:"extension_meta"`
+	Claims         []byte      `json:"claims"`
 	Position       int32       `json:"position"`
 }
 
+// Despite the name, this query returns multiple rows. The careful reader will
+// note that there is no limit clause, which might seem a bug, but the actual
+// number of records is bounded by the number of sources that provide the same
+// name and version, which we currently don't expect to be more than a few.
 func (q *Queries) GetSkillVersion(ctx context.Context, arg GetSkillVersionParams) ([]GetSkillVersionRow, error) {
 	rows, err := q.db.Query(ctx, getSkillVersion,
 		arg.RegistryName,
@@ -157,6 +163,7 @@ func (q *Queries) GetSkillVersion(ctx context.Context, arg GetSkillVersionParams
 			&i.Icons,
 			&i.Metadata,
 			&i.ExtensionMeta,
+			&i.Claims,
 			&i.Position,
 		); err != nil {
 			return nil, err
@@ -446,6 +453,7 @@ SELECT src.source_type AS registry_type,
        s.icons,
        s.metadata,
        s.extension_meta,
+       e.claims,
        -- Sources not linked to the requested registry have no position; default to max int16
        -- so they sort after all explicitly positioned sources (lower position = higher priority).
        COALESCE(rs.position, 32767)::integer AS position
@@ -503,6 +511,7 @@ type ListSkillsRow struct {
 	Icons         []byte      `json:"icons"`
 	Metadata      []byte      `json:"metadata"`
 	ExtensionMeta []byte      `json:"extension_meta"`
+	Claims        []byte      `json:"claims"`
 	Position      int32       `json:"position"`
 }
 
@@ -547,6 +556,7 @@ func (q *Queries) ListSkills(ctx context.Context, arg ListSkillsParams) ([]ListS
 			&i.Icons,
 			&i.Metadata,
 			&i.ExtensionMeta,
+			&i.Claims,
 			&i.Position,
 		); err != nil {
 			return nil, err

--- a/internal/service/db/claims_filter.go
+++ b/internal/service/db/claims_filter.go
@@ -1,0 +1,54 @@
+package database
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/stacklok/toolhive-registry-server/internal/service"
+)
+
+// newClaimsFilterWith builds a RecordFilter that keeps a record only when the
+// caller's claims are non-empty, the record has stored claims, and they match.
+// extract retrieves the raw claims JSON from a record; returning ok=false
+// causes the filter to reject the record with a type error.
+// Returns nil when callerClaims is nil or empty so the caller can skip
+// filtering entirely.
+func newClaimsFilterWith(
+	callerClaims map[string]any,
+	extract func(record any) (claims []byte, ok bool),
+) service.RecordFilter {
+	callerJSON := marshalClaims(callerClaims)
+	if callerJSON == nil {
+		return nil
+	}
+	return func(_ context.Context, record any) (bool, error) {
+		recordJSON, ok := extract(record)
+		if !ok {
+			return false, fmt.Errorf("unexpected record type: %T", record)
+		}
+		return checkClaims(callerJSON, recordJSON), nil
+	}
+}
+
+// marshalClaims serializes callerClaims to JSON. Returns nil if the map is nil
+// or empty, or if serialization fails (treated as "no claims").
+func marshalClaims(callerClaims map[string]any) []byte {
+	if len(callerClaims) == 0 {
+		return nil
+	}
+	b, err := json.Marshal(callerClaims)
+	if err != nil {
+		return nil
+	}
+	return b
+}
+
+// checkClaims returns true only when both callerJSON and recordJSON are
+// non-empty and represent the same JSON object.
+func checkClaims(callerJSON, recordJSON []byte) bool {
+	if len(callerJSON) == 0 || len(recordJSON) == 0 {
+		return false
+	}
+	return claimsMatch(callerJSON, recordJSON)
+}

--- a/internal/service/db/claims_filter_test.go
+++ b/internal/service/db/claims_filter_test.go
@@ -1,0 +1,209 @@
+package database
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewClaimsFilterWith(t *testing.T) {
+	t.Parallel()
+
+	// extract is a simple stand-in that treats the record as []byte directly.
+	extract := func(record any) ([]byte, bool) {
+		b, ok := record.([]byte)
+		return b, ok
+	}
+
+	tests := []struct {
+		name         string
+		callerClaims map[string]any
+		record       any
+		wantKeep     bool
+		wantErr      bool
+		wantNilFn    bool
+	}{
+		{
+			name:         "nil caller claims returns nil filter",
+			callerClaims: nil,
+			wantNilFn:    true,
+		},
+		{
+			name:         "empty caller claims returns nil filter",
+			callerClaims: map[string]any{},
+			wantNilFn:    true,
+		},
+		{
+			name:         "record with nil claims is dropped",
+			callerClaims: map[string]any{"sub": "user1"},
+			record:       []byte(nil),
+			wantKeep:     false,
+		},
+		{
+			name:         "record with empty claims is dropped",
+			callerClaims: map[string]any{"sub": "user1"},
+			record:       []byte{},
+			wantKeep:     false,
+		},
+		{
+			name:         "matching claims keeps record",
+			callerClaims: map[string]any{"sub": "user1"},
+			record:       mustMarshal(t, map[string]any{"sub": "user1"}),
+			wantKeep:     true,
+		},
+		{
+			name:         "non-matching claims drops record",
+			callerClaims: map[string]any{"sub": "user1"},
+			record:       mustMarshal(t, map[string]any{"sub": "user2"}),
+			wantKeep:     false,
+		},
+		{
+			name:         "wrong record type returns error",
+			callerClaims: map[string]any{"sub": "user1"},
+			record:       "not-bytes",
+			wantErr:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			filter := newClaimsFilterWith(tt.callerClaims, extract)
+
+			if tt.wantNilFn {
+				assert.Nil(t, filter)
+				return
+			}
+
+			require.NotNil(t, filter)
+			keep, err := filter(t.Context(), tt.record)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantKeep, keep)
+		})
+	}
+}
+
+func TestCheckClaims(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		callerJSON []byte
+		recordJSON []byte
+		want       bool
+	}{
+		{
+			name:       "both nil returns false",
+			callerJSON: nil,
+			recordJSON: nil,
+			want:       false,
+		},
+		{
+			name:       "caller nil record non-nil returns false",
+			callerJSON: nil,
+			recordJSON: []byte(`{"sub":"user1"}`),
+			want:       false,
+		},
+		{
+			name:       "caller non-nil record nil returns false",
+			callerJSON: []byte(`{"sub":"user1"}`),
+			recordJSON: nil,
+			want:       false,
+		},
+		{
+			name:       "both empty returns false",
+			callerJSON: []byte{},
+			recordJSON: []byte{},
+			want:       false,
+		},
+		{
+			name:       "matching JSON returns true",
+			callerJSON: []byte(`{"sub":"user1"}`),
+			recordJSON: []byte(`{"sub":"user1"}`),
+			want:       true,
+		},
+		{
+			name:       "non-matching JSON returns false",
+			callerJSON: []byte(`{"sub":"user1"}`),
+			recordJSON: []byte(`{"sub":"user2"}`),
+			want:       false,
+		},
+		{
+			name:       "invalid caller JSON returns false",
+			callerJSON: []byte(`{invalid`),
+			recordJSON: []byte(`{"sub":"user1"}`),
+			want:       false,
+		},
+		{
+			name:       "invalid record JSON returns false",
+			callerJSON: []byte(`{"sub":"user1"}`),
+			recordJSON: []byte(`{invalid`),
+			want:       false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := checkClaims(tt.callerJSON, tt.recordJSON)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestMarshalClaims(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		claims map[string]any
+		isNil  bool
+	}{
+		{
+			name:   "nil map returns nil",
+			claims: nil,
+			isNil:  true,
+		},
+		{
+			name:   "empty map returns nil",
+			claims: map[string]any{},
+			isNil:  true,
+		},
+		{
+			name:   "non-empty map returns non-nil",
+			claims: map[string]any{"sub": "user1"},
+			isNil:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := marshalClaims(tt.claims)
+			if tt.isNil {
+				assert.Nil(t, got)
+			} else {
+				assert.NotNil(t, got)
+			}
+		})
+	}
+}
+
+// mustMarshal is a test helper that marshals v to JSON or fails the test.
+func mustMarshal(t *testing.T, v any) []byte {
+	t.Helper()
+	b, err := json.Marshal(v)
+	require.NoError(t, err)
+	return b
+}

--- a/internal/service/db/impl_mcp.go
+++ b/internal/service/db/impl_mcp.go
@@ -115,7 +115,14 @@ func (s *dbService) ListServers(
 		return helpers, nil
 	}
 
-	results, lastCursor, err := s.sharedListServersWithCursor(ctx, querierFunc, options.Limit, options.Filter)
+	claimsFilter := newClaimsFilterWith(
+		options.Claims,
+		func(record any) ([]byte, bool) {
+			h, ok := record.(helper)
+			return h.Claims, ok
+		},
+	)
+	results, lastCursor, err := s.sharedListServersWithCursor(ctx, querierFunc, options.Limit, claimsFilter)
 	if err != nil {
 		otel.RecordError(span, err)
 		return nil, err
@@ -200,7 +207,14 @@ func (s *dbService) ListServerVersions(
 		return helpers, nil
 	}
 
-	results, err := s.sharedListServers(ctx, querierFunc, options.Filter)
+	claimsFilter := newClaimsFilterWith(
+		options.Claims,
+		func(record any) ([]byte, bool) {
+			h, ok := record.(helper)
+			return h.Claims, ok
+		},
+	)
+	results, err := s.sharedListServers(ctx, querierFunc, claimsFilter)
 	if err != nil {
 		otel.RecordError(span, err)
 		return nil, err
@@ -275,11 +289,23 @@ func (s *dbService) GetServerVersion(
 			return nil, fmt.Errorf("%w: %s %s", service.ErrNotFound, options.Name, options.Version)
 		}
 
-		// Return only the first row (highest priority by position)
-		return []helper{getServerVersionRowToHelper(servers[0])}, nil
+		// Return all rows ordered by position so the claims filter can promote
+		// lower-priority sources when higher-priority ones fail the claims check.
+		helpers := make([]helper, len(servers))
+		for i, sv := range servers {
+			helpers[i] = getServerVersionRowToHelper(sv)
+		}
+		return helpers, nil
 	}
 
-	res, err := s.sharedListServers(ctx, querierFunc, options.Filter)
+	claimsFilter := newClaimsFilterWith(
+		options.Claims,
+		func(record any) ([]byte, bool) {
+			h, ok := record.(helper)
+			return h.Claims, ok
+		},
+	)
+	res, err := s.sharedListServers(ctx, querierFunc, claimsFilter)
 	if err != nil {
 		otel.RecordError(span, err)
 		return nil, err

--- a/internal/service/db/impl_skills.go
+++ b/internal/service/db/impl_skills.go
@@ -79,7 +79,14 @@ func (s *dbService) ListSkills(
 		params.CursorVersion = &cursorVersion
 	}
 
-	listRows, nextCursor, err := streamSkillRows(ctx, querier, params, options.Filter, options.Limit)
+	claimsFilter := newClaimsFilterWith(
+		options.Claims,
+		func(record any) ([]byte, bool) {
+			r, ok := record.(sqlc.ListSkillsRow)
+			return r.Claims, ok
+		},
+	)
+	listRows, nextCursor, err := streamSkillRows(ctx, querier, params, claimsFilter, options.Limit)
 	if err != nil {
 		otel.RecordError(span, err)
 		return nil, err
@@ -196,18 +203,21 @@ func (s *dbService) GetSkillVersion(
 		return nil, fmt.Errorf("%w: %s %s", service.ErrNotFound, options.Name, options.Version)
 	}
 
-	// Pick the first row (ordered by position ascending = highest priority source)
-	row := rows[0]
-
-	if options.Filter != nil {
-		keep, err := options.Filter(ctx, row)
-		if err != nil {
-			otel.RecordError(span, err)
-			return nil, err
+	// Iterate rows in priority order (position ascending) and pick the first
+	// one that passes the claims check, promoting lower-priority sources when
+	// higher-priority ones fail.
+	callerJSON := marshalClaims(options.Claims)
+	var row sqlc.GetSkillVersionRow
+	found := false
+	for _, r := range rows {
+		if callerJSON == nil || checkClaims(callerJSON, r.Claims) {
+			row = r
+			found = true
+			break
 		}
-		if !keep {
-			return nil, fmt.Errorf("%w: %s %s", service.ErrNotFound, options.Name, options.Version)
-		}
+	}
+	if !found {
+		return nil, fmt.Errorf("%w: %s %s", service.ErrNotFound, options.Name, options.Version)
 	}
 
 	ociPackages, err := querier.ListSkillOciPackages(ctx, []uuid.UUID{row.SkillVersionID})

--- a/internal/service/db/impl_test.go
+++ b/internal/service/db/impl_test.go
@@ -432,47 +432,6 @@ func TestListServers(t *testing.T) {
 				require.Equal(t, "2.0.0", result.Servers[0].Version)
 			},
 		},
-		{
-			name: "app-level filter keeps only server-1 records",
-			//nolint:thelper // We want to see these lines in the test output
-			setupFunc: func(t *testing.T, pool *pgxpool.Pool) {
-				setupTestData(t, pool)
-			},
-			options: []service.Option{
-				service.WithLimit(10),
-				service.WithFilter(service.RecordFilter(func(_ context.Context, record any) (bool, error) {
-					h, ok := record.(helper)
-					if !ok {
-						return false, nil
-					}
-					return h.Name == "com.example/test-server-1", nil
-				})),
-			},
-			//nolint:thelper // We want to see these lines in the test output
-			validateFunc: func(t *testing.T, result *service.ListServersResult) {
-				require.Len(t, result.Servers, 3)
-				for _, server := range result.Servers {
-					require.Equal(t, "com.example/test-server-1", server.Name)
-				}
-			},
-		},
-		{
-			name: "app-level filter drops all records returns empty list",
-			//nolint:thelper // We want to see these lines in the test output
-			setupFunc: func(t *testing.T, pool *pgxpool.Pool) {
-				setupTestData(t, pool)
-			},
-			options: []service.Option{
-				service.WithLimit(10),
-				service.WithFilter(service.RecordFilter(func(context.Context, any) (bool, error) {
-					return false, nil
-				})),
-			},
-			//nolint:thelper // We want to see these lines in the test output
-			validateFunc: func(t *testing.T, result *service.ListServersResult) {
-				require.Len(t, result.Servers, 0)
-			},
-		},
 	}
 
 	for _, tt := range tests {
@@ -904,20 +863,6 @@ func TestGetServerVersion(t *testing.T) {
 				service.WithName("com.example/test-server-1"),
 				service.WithVersion("1.0.0"),
 				service.WithRegistryName("non-existent-registry"),
-			},
-		},
-		{
-			name: "filter rejects record returns error",
-			//nolint:thelper // We want to see these lines in the test output
-			setupFunc: func(t *testing.T, pool *pgxpool.Pool) {
-				setupTestData(t, pool)
-			},
-			options: []service.Option{
-				service.WithName("com.example/test-server-1"),
-				service.WithVersion("1.0.0"),
-				service.WithFilter(service.RecordFilter(func(context.Context, any) (bool, error) {
-					return false, nil
-				})),
 			},
 		},
 	}
@@ -2974,49 +2919,6 @@ func TestListSkills(t *testing.T) {
 				require.Contains(t, names, "skill-b")
 			},
 		},
-		{
-			name: "app-level filter keeps only skill-a",
-			//nolint:thelper // We want to see these lines in the test output
-			setupFunc: func(t *testing.T, svc *dbService) {
-				setupSkillTestData(t, svc, []string{"skill-a", "skill-b"})
-			},
-			options: []service.Option{
-				service.WithRegistryName("test-skills-registry"),
-				service.WithNamespace("com.example"),
-				service.WithLimit(10),
-				service.WithFilter(service.RecordFilter(func(_ context.Context, record any) (bool, error) {
-					row, ok := record.(sqlc.ListSkillsRow)
-					if !ok {
-						return false, nil
-					}
-					return row.Name == "skill-a", nil
-				})),
-			},
-			//nolint:thelper // We want to see these lines in the test output
-			validateFunc: func(t *testing.T, result *service.ListSkillsResult) {
-				require.Len(t, result.Skills, 1)
-				require.Equal(t, "skill-a", result.Skills[0].Name)
-			},
-		},
-		{
-			name: "app-level filter drops all returns empty list",
-			//nolint:thelper // We want to see these lines in the test output
-			setupFunc: func(t *testing.T, svc *dbService) {
-				setupSkillTestData(t, svc, []string{"skill-a", "skill-b"})
-			},
-			options: []service.Option{
-				service.WithRegistryName("test-skills-registry"),
-				service.WithNamespace("com.example"),
-				service.WithLimit(10),
-				service.WithFilter(service.RecordFilter(func(context.Context, any) (bool, error) {
-					return false, nil
-				})),
-			},
-			//nolint:thelper // We want to see these lines in the test output
-			validateFunc: func(t *testing.T, result *service.ListSkillsResult) {
-				require.Len(t, result.Skills, 0)
-			},
-		},
 	}
 
 	for _, tt := range tests {
@@ -3069,22 +2971,6 @@ func TestGetSkillVersion(t *testing.T) {
 				require.Equal(t, "skill-a", skill.Name)
 				require.Equal(t, "1.0.0", skill.Version)
 				require.Equal(t, "com.example", skill.Namespace)
-			},
-		},
-		{
-			name: "filter rejects record returns ErrNotFound",
-			//nolint:thelper // We want to see these lines in the test output
-			setupFunc: func(t *testing.T, svc *dbService) {
-				setupSkillTestData(t, svc, []string{"skill-a"})
-			},
-			options: []service.Option{
-				service.WithRegistryName("test-skills-registry"),
-				service.WithNamespace("com.example"),
-				service.WithName("skill-a"),
-				service.WithVersion("1.0.0"),
-				service.WithFilter(service.RecordFilter(func(context.Context, any) (bool, error) {
-					return false, nil
-				})),
 			},
 		},
 	}

--- a/internal/service/db/shadowing_get_server_version_test.go
+++ b/internal/service/db/shadowing_get_server_version_test.go
@@ -1,0 +1,192 @@
+package database
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/aws/smithy-go/ptr"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stacklok/toolhive-registry-server/internal/db/sqlc"
+	"github.com/stacklok/toolhive-registry-server/internal/service"
+)
+
+// TestGetServerVersionClaimsVisibility checks that GetServerVersion applies
+// claims-based promotion across all sources in priority order, mirroring the
+// behaviour of the List functions. If the highest-priority source (source-A)
+// fails the claims check, the next source in line (B, then C) is tried.
+func TestGetServerVersionClaimsVisibility(t *testing.T) {
+	t.Parallel()
+
+	const (
+		entryName    = "com.claims/the-entry"
+		descFromSrcA = "from source-A"
+		descFromSrcB = "from source-B"
+		descFromSrcC = "from source-C"
+	)
+
+	callerClaims := map[string]any{"sub": "claims-test-user"}
+	callerClaimsJSON, err := json.Marshal(callerClaims)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name          string
+		srcAHasClaims bool
+		srcBHasClaims bool
+		srcCHasClaims bool
+		expectVisible bool   // false → expect errors.Is(err, service.ErrNotFound)
+		expectDesc    string // which source won; only checked when expectVisible is true
+	}{
+		{
+			name:          "no source has claims - ErrNotFound",
+			srcAHasClaims: false,
+			srcBHasClaims: false,
+			srcCHasClaims: false,
+			expectVisible: false,
+		},
+		{
+			// A and B filtered; C promoted.
+			name:          "only source-C matches - source-C promoted",
+			srcAHasClaims: false,
+			srcBHasClaims: false,
+			srcCHasClaims: true,
+			expectVisible: true,
+			expectDesc:    descFromSrcC,
+		},
+		{
+			// A filtered; B promoted; C shadowed by B.
+			name:          "only source-B matches - source-B promoted",
+			srcAHasClaims: false,
+			srcBHasClaims: true,
+			srcCHasClaims: false,
+			expectVisible: true,
+			expectDesc:    descFromSrcB,
+		},
+		{
+			// A filtered; B promoted; C shadowed by B even though C also matches.
+			name:          "source-B and source-C match - source-B promoted, source-C shadowed",
+			srcAHasClaims: false,
+			srcBHasClaims: true,
+			srcCHasClaims: true,
+			expectVisible: true,
+			expectDesc:    descFromSrcB,
+		},
+
+		// source-A HAS claims → always visible from source-A.
+		{
+			name:          "only source-A matches - visible from source-A",
+			srcAHasClaims: true,
+			srcBHasClaims: false,
+			srcCHasClaims: false,
+			expectVisible: true,
+			expectDesc:    descFromSrcA,
+		},
+		{
+			name:          "source-A and source-C match - visible from source-A",
+			srcAHasClaims: true,
+			srcBHasClaims: false,
+			srcCHasClaims: true,
+			expectVisible: true,
+			expectDesc:    descFromSrcA,
+		},
+		{
+			name:          "source-A and source-B match - visible from source-A",
+			srcAHasClaims: true,
+			srcBHasClaims: true,
+			srcCHasClaims: false,
+			expectVisible: true,
+			expectDesc:    descFromSrcA,
+		},
+		{
+			name:          "all sources match - visible from source-A",
+			srcAHasClaims: true,
+			srcBHasClaims: true,
+			srcCHasClaims: true,
+			expectVisible: true,
+			expectDesc:    descFromSrcA,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			svc, cleanup := setupTestService(t)
+			defer cleanup()
+
+			ctx := context.Background()
+			queries := sqlc.New(svc.pool)
+			now := time.Now().UTC()
+
+			srcA, srcB, srcC := setupShadowingRegistry(t, svc)
+
+			// insertEntry creates a minimal MCP server entry under the given source.
+			// desc is stored as the entry's description so tests can identify which
+			// source's copy survived dedup. claims is nil for an unclaimed entry.
+			insertEntry := func(src sqlc.Source, desc string, claims []byte) {
+				//nolint:thelper // We want to see these lines in the test output
+				entryID, err := queries.InsertRegistryEntry(ctx, sqlc.InsertRegistryEntryParams{
+					SourceID:  src.ID,
+					EntryType: sqlc.EntryTypeMCP,
+					Name:      entryName,
+					Claims:    claims,
+					CreatedAt: &now,
+					UpdatedAt: &now,
+				})
+				require.NoError(t, err)
+
+				versionID, err := queries.InsertEntryVersion(ctx, sqlc.InsertEntryVersionParams{
+					EntryID:     entryID,
+					Version:     "1.0.0",
+					Title:       ptr.String(entryName),
+					Description: ptr.String(desc),
+					CreatedAt:   &now,
+					UpdatedAt:   &now,
+				})
+				require.NoError(t, err)
+
+				_, err = queries.InsertServerVersion(ctx, sqlc.InsertServerVersionParams{
+					VersionID:    versionID,
+					UpstreamMeta: []byte(`{}`),
+					ServerMeta:   []byte(`{}`),
+				})
+				require.NoError(t, err)
+			}
+
+			// claimsFor returns callerClaimsJSON when hasClaims is true, nil otherwise.
+			// An entry with nil claims is invisible to any credentialed caller.
+			claimsFor := func(hasClaims bool) []byte {
+				if hasClaims {
+					return callerClaimsJSON
+				}
+				return nil
+			}
+
+			// All three entries share the same name; they shadow one another via dedup.
+			insertEntry(srcA, descFromSrcA, claimsFor(tt.srcAHasClaims))
+			insertEntry(srcB, descFromSrcB, claimsFor(tt.srcBHasClaims))
+			insertEntry(srcC, descFromSrcC, claimsFor(tt.srcCHasClaims))
+
+			result, err := svc.GetServerVersion(
+				ctx,
+				service.WithName(entryName),
+				service.WithVersion("1.0.0"),
+				service.WithRegistryName("claims-registry"),
+				service.WithClaims(callerClaims),
+			)
+
+			if !tt.expectVisible {
+				require.Error(t, err)
+				require.True(t, errors.Is(err, service.ErrNotFound))
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, entryName, result.Name)
+			require.Equal(t, tt.expectDesc, result.Description)
+		})
+	}
+}

--- a/internal/service/db/shadowing_get_skill_version_test.go
+++ b/internal/service/db/shadowing_get_skill_version_test.go
@@ -1,0 +1,197 @@
+package database
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/aws/smithy-go/ptr"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stacklok/toolhive-registry-server/internal/db/sqlc"
+	"github.com/stacklok/toolhive-registry-server/internal/service"
+)
+
+// TestGetSkillVersionClaimsVisibility checks that GetSkillVersion applies
+// claims-based promotion across all sources in priority order, mirroring the
+// behaviour of the List functions. If the highest-priority source (source-A)
+// fails the claims check, the next source in line (B, then C) is tried.
+func TestGetSkillVersionClaimsVisibility(t *testing.T) {
+	t.Parallel()
+
+	const (
+		entryName    = "com.claims/the-entry"
+		descFromSrcA = "from source-A"
+		descFromSrcB = "from source-B"
+		descFromSrcC = "from source-C"
+	)
+
+	callerClaims := map[string]any{"sub": "claims-test-user"}
+	callerClaimsJSON, err := json.Marshal(callerClaims)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name          string
+		srcAHasClaims bool
+		srcBHasClaims bool
+		srcCHasClaims bool
+		expectVisible bool   // false → expect errors.Is(err, service.ErrNotFound)
+		expectDesc    string // which source won; only checked when expectVisible is true
+	}{
+		{
+			name:          "no source has claims - ErrNotFound",
+			srcAHasClaims: false,
+			srcBHasClaims: false,
+			srcCHasClaims: false,
+			expectVisible: false,
+		},
+		{
+			// A and B filtered; C promoted.
+			name:          "only source-C matches - source-C promoted",
+			srcAHasClaims: false,
+			srcBHasClaims: false,
+			srcCHasClaims: true,
+			expectVisible: true,
+			expectDesc:    descFromSrcC,
+		},
+		{
+			// A filtered; B promoted; C shadowed by B.
+			name:          "only source-B matches - source-B promoted",
+			srcAHasClaims: false,
+			srcBHasClaims: true,
+			srcCHasClaims: false,
+			expectVisible: true,
+			expectDesc:    descFromSrcB,
+		},
+		{
+			// A filtered; B promoted; C shadowed by B even though C also matches.
+			name:          "source-B and source-C match - source-B promoted, source-C shadowed",
+			srcAHasClaims: false,
+			srcBHasClaims: true,
+			srcCHasClaims: true,
+			expectVisible: true,
+			expectDesc:    descFromSrcB,
+		},
+
+		// source-A HAS claims → always visible from source-A.
+		{
+			name:          "only source-A matches - visible from source-A",
+			srcAHasClaims: true,
+			srcBHasClaims: false,
+			srcCHasClaims: false,
+			expectVisible: true,
+			expectDesc:    descFromSrcA,
+		},
+		{
+			name:          "source-A and source-C match - visible from source-A",
+			srcAHasClaims: true,
+			srcBHasClaims: false,
+			srcCHasClaims: true,
+			expectVisible: true,
+			expectDesc:    descFromSrcA,
+		},
+		{
+			name:          "source-A and source-B match - visible from source-A",
+			srcAHasClaims: true,
+			srcBHasClaims: true,
+			srcCHasClaims: false,
+			expectVisible: true,
+			expectDesc:    descFromSrcA,
+		},
+		{
+			name:          "all sources match - visible from source-A",
+			srcAHasClaims: true,
+			srcBHasClaims: true,
+			srcCHasClaims: true,
+			expectVisible: true,
+			expectDesc:    descFromSrcA,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			svc, cleanup := setupTestService(t)
+			defer cleanup()
+
+			ctx := context.Background()
+			queries := sqlc.New(svc.pool)
+			now := time.Now().UTC()
+
+			srcA, srcB, srcC := setupShadowingRegistry(t, svc)
+
+			// insertEntry creates a minimal skill entry under the given source.
+			// desc is stored as the entry's description so tests can identify which
+			// source's copy survived dedup. claims is nil for an unclaimed entry.
+			insertEntry := func(src sqlc.Source, desc string, claims []byte) {
+				//nolint:thelper // We want to see these lines in the test output
+				entryID, err := queries.InsertRegistryEntry(ctx, sqlc.InsertRegistryEntryParams{
+					SourceID:  src.ID,
+					EntryType: sqlc.EntryTypeSKILL,
+					Name:      entryName,
+					Claims:    claims,
+					CreatedAt: &now,
+					UpdatedAt: &now,
+				})
+				require.NoError(t, err)
+
+				versionID, err := queries.InsertEntryVersion(ctx, sqlc.InsertEntryVersionParams{
+					EntryID:     entryID,
+					Version:     "1.0.0",
+					Title:       ptr.String(entryName),
+					Description: ptr.String(desc),
+					CreatedAt:   &now,
+					UpdatedAt:   &now,
+				})
+				require.NoError(t, err)
+
+				_, err = queries.InsertSkillVersion(ctx, sqlc.InsertSkillVersionParams{
+					VersionID:     versionID,
+					Namespace:     "com.example",
+					Status:        sqlc.NullSkillStatus{},
+					AllowedTools:  nil,
+					Repository:    []byte("null"),
+					Icons:         []byte("null"),
+					Metadata:      []byte("null"),
+					ExtensionMeta: []byte("null"),
+				})
+				require.NoError(t, err)
+			}
+
+			// claimsFor returns callerClaimsJSON when hasClaims is true, nil otherwise.
+			// An entry with nil claims is invisible to any credentialed caller.
+			claimsFor := func(hasClaims bool) []byte {
+				if hasClaims {
+					return callerClaimsJSON
+				}
+				return nil
+			}
+
+			// All three entries share the same name; they shadow one another via dedup.
+			insertEntry(srcA, descFromSrcA, claimsFor(tt.srcAHasClaims))
+			insertEntry(srcB, descFromSrcB, claimsFor(tt.srcBHasClaims))
+			insertEntry(srcC, descFromSrcC, claimsFor(tt.srcCHasClaims))
+
+			result, err := svc.GetSkillVersion(
+				ctx,
+				service.WithName(entryName),
+				service.WithVersion("1.0.0"),
+				service.WithNamespace("com.example"),
+				service.WithRegistryName("claims-registry"),
+				service.WithClaims(callerClaims),
+			)
+
+			if !tt.expectVisible {
+				require.Error(t, err)
+				require.True(t, errors.Is(err, service.ErrNotFound))
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tt.expectDesc, result.Description)
+		})
+	}
+}

--- a/internal/service/db/shadowing_helpers_test.go
+++ b/internal/service/db/shadowing_helpers_test.go
@@ -1,0 +1,73 @@
+package database
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stacklok/toolhive-registry-server/internal/db/sqlc"
+)
+
+// setupShadowingRegistry creates three CONFIG/git sources named "claims-src-a",
+// "claims-src-b", and "claims-src-c", a CONFIG registry named
+// "claims-registry", and links the three sources at positions 0, 1, 2. It
+// returns the three sources in priority order (A, B, C).
+func setupShadowingRegistry(t *testing.T, svc *dbService) (sqlc.Source, sqlc.Source, sqlc.Source) {
+	t.Helper()
+
+	ctx := context.Background()
+	queries := sqlc.New(svc.pool)
+	now := time.Now().UTC()
+
+	srcA, err := queries.InsertSource(ctx, sqlc.InsertSourceParams{
+		Name:         "claims-src-a",
+		CreationType: sqlc.CreationTypeCONFIG,
+		SourceType:   "git",
+		Syncable:     true,
+		CreatedAt:    &now,
+		UpdatedAt:    &now,
+	})
+	require.NoError(t, err)
+
+	srcB, err := queries.InsertSource(ctx, sqlc.InsertSourceParams{
+		Name:         "claims-src-b",
+		CreationType: sqlc.CreationTypeCONFIG,
+		SourceType:   "git",
+		Syncable:     true,
+		CreatedAt:    &now,
+		UpdatedAt:    &now,
+	})
+	require.NoError(t, err)
+
+	srcC, err := queries.InsertSource(ctx, sqlc.InsertSourceParams{
+		Name:         "claims-src-c",
+		CreationType: sqlc.CreationTypeCONFIG,
+		SourceType:   "git",
+		Syncable:     true,
+		CreatedAt:    &now,
+		UpdatedAt:    &now,
+	})
+	require.NoError(t, err)
+
+	reg, err := queries.UpsertRegistry(ctx, sqlc.UpsertRegistryParams{
+		Name:         "claims-registry",
+		CreationType: sqlc.CreationTypeCONFIG,
+		CreatedAt:    &now,
+		UpdatedAt:    &now,
+	})
+	require.NoError(t, err)
+
+	for i, srcID := range []uuid.UUID{srcA.ID, srcB.ID, srcC.ID} {
+		err = queries.LinkRegistrySource(ctx, sqlc.LinkRegistrySourceParams{
+			RegistryID: reg.ID,
+			SourceID:   srcID,
+			Position:   int32(i),
+		})
+		require.NoError(t, err)
+	}
+
+	return srcA, srcB, srcC
+}

--- a/internal/service/db/shadowing_list_server_versions_test.go
+++ b/internal/service/db/shadowing_list_server_versions_test.go
@@ -1,0 +1,200 @@
+package database
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/aws/smithy-go/ptr"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stacklok/toolhive-registry-server/internal/db/sqlc"
+	"github.com/stacklok/toolhive-registry-server/internal/service"
+)
+
+// TestListServerVersionsClaimsVisibility checks that three entries with the
+// same name — one each on source-A (position 0), source-B (position 1), and
+// source-C (position 2), all exposed via a single registry — shadow one
+// another correctly when claims filtering is applied. The caller always carries
+// claims, so the 8 test cases cover all 2^3 combinations of {srcAHasClaims,
+// srcBHasClaims, srcCHasClaims}.
+//
+// The claims filter runs before dedup: a higher-priority source whose entry
+// does not match the caller's claims is dropped, promoting the next source in
+// line. The cases demonstrate the full cascade: A filtered → B promoted; A and
+// B both filtered → C promoted; all filtered → entry invisible.
+func TestListServerVersionsClaimsVisibility(t *testing.T) {
+	t.Parallel()
+
+	const (
+		entryName    = "com.claims/the-entry"
+		descFromSrcA = "from source-A"
+		descFromSrcB = "from source-B"
+		descFromSrcC = "from source-C"
+	)
+
+	callerClaims := map[string]any{"sub": "claims-test-user"}
+	callerClaimsJSON, err := json.Marshal(callerClaims)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name          string
+		srcAHasClaims bool
+		srcBHasClaims bool
+		srcCHasClaims bool
+		// expectVisible is false when no entry survives the claims filter.
+		expectVisible bool
+		// expectDesc identifies which source won; only checked when expectVisible is true.
+		expectDesc string
+	}{
+		{
+			name:          "no source has claims - entry invisible",
+			srcAHasClaims: false,
+			srcBHasClaims: false,
+			srcCHasClaims: false,
+			expectVisible: false,
+		},
+		{
+			// A and B filtered; C, normally shadowed by both, is promoted.
+			name:          "only source-C matches - source-C promoted",
+			srcAHasClaims: false,
+			srcBHasClaims: false,
+			srcCHasClaims: true,
+			expectVisible: true,
+			expectDesc:    descFromSrcC,
+		},
+		{
+			// A filtered; B, normally shadowed by A, is promoted; C shadowed by B.
+			name:          "only source-B matches - source-B promoted",
+			srcAHasClaims: false,
+			srcBHasClaims: true,
+			srcCHasClaims: false,
+			expectVisible: true,
+			expectDesc:    descFromSrcB,
+		},
+		{
+			// A filtered; B promoted; C shadowed by B even though C also matches.
+			name:          "source-B and source-C match - source-B promoted, source-C shadowed",
+			srcAHasClaims: false,
+			srcBHasClaims: true,
+			srcCHasClaims: true,
+			expectVisible: true,
+			expectDesc:    descFromSrcB,
+		},
+		{
+			// A wins outright; B and C are shadowed.
+			name:          "only source-A matches - source-A wins",
+			srcAHasClaims: true,
+			srcBHasClaims: false,
+			srcCHasClaims: false,
+			expectVisible: true,
+			expectDesc:    descFromSrcA,
+		},
+		{
+			// A wins; C filtered; B shadowed by A even though B does not match.
+			name:          "source-A and source-C match - source-A wins, source-B and source-C shadowed",
+			srcAHasClaims: true,
+			srcBHasClaims: false,
+			srcCHasClaims: true,
+			expectVisible: true,
+			expectDesc:    descFromSrcA,
+		},
+		{
+			name:          "source-A and source-B match - source-A wins, source-B and source-C shadowed",
+			srcAHasClaims: true,
+			srcBHasClaims: true,
+			srcCHasClaims: false,
+			expectVisible: true,
+			expectDesc:    descFromSrcA,
+		},
+		{
+			name:          "all sources match - source-A wins via dedup, source-B and source-C shadowed",
+			srcAHasClaims: true,
+			srcBHasClaims: true,
+			srcCHasClaims: true,
+			expectVisible: true,
+			expectDesc:    descFromSrcA,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			svc, cleanup := setupTestService(t)
+			defer cleanup()
+
+			ctx := context.Background()
+			queries := sqlc.New(svc.pool)
+			now := time.Now().UTC()
+
+			srcA, srcB, srcC := setupShadowingRegistry(t, svc)
+
+			// insertEntry creates a minimal MCP server entry under the given source.
+			// desc is stored as the entry's description so tests can identify which
+			// source's copy survived dedup. claims is nil for an unclaimed entry.
+			insertEntry := func(src sqlc.Source, desc string, claims []byte) {
+				//nolint:thelper // We want to see these lines in the test output
+				entryID, err := queries.InsertRegistryEntry(ctx, sqlc.InsertRegistryEntryParams{
+					SourceID:  src.ID,
+					EntryType: sqlc.EntryTypeMCP,
+					Name:      entryName,
+					Claims:    claims,
+					CreatedAt: &now,
+					UpdatedAt: &now,
+				})
+				require.NoError(t, err)
+
+				versionID, err := queries.InsertEntryVersion(ctx, sqlc.InsertEntryVersionParams{
+					EntryID:     entryID,
+					Version:     "1.0.0",
+					Title:       ptr.String(entryName),
+					Description: ptr.String(desc),
+					CreatedAt:   &now,
+					UpdatedAt:   &now,
+				})
+				require.NoError(t, err)
+
+				_, err = queries.InsertServerVersion(ctx, sqlc.InsertServerVersionParams{
+					VersionID:    versionID,
+					UpstreamMeta: []byte(`{}`),
+					ServerMeta:   []byte(`{}`),
+				})
+				require.NoError(t, err)
+			}
+
+			// claimsFor returns callerClaimsJSON when hasClaims is true, nil otherwise.
+			// An entry with nil claims is invisible to any credentialed caller.
+			claimsFor := func(hasClaims bool) []byte {
+				if hasClaims {
+					return callerClaimsJSON
+				}
+				return nil
+			}
+
+			// All three entries share the same name; they shadow one another via dedup.
+			insertEntry(srcA, descFromSrcA, claimsFor(tt.srcAHasClaims))
+			insertEntry(srcB, descFromSrcB, claimsFor(tt.srcBHasClaims))
+			insertEntry(srcC, descFromSrcC, claimsFor(tt.srcCHasClaims))
+
+			result, err := svc.ListServerVersions(
+				ctx,
+				service.WithName(entryName),
+				service.WithRegistryName("claims-registry"),
+				service.WithClaims(callerClaims),
+				service.WithLimit(10),
+			)
+			require.NoError(t, err)
+
+			if !tt.expectVisible {
+				require.Empty(t, result)
+				return
+			}
+
+			require.Len(t, result, 1)
+			require.Equal(t, entryName, result[0].Name)
+			require.Equal(t, tt.expectDesc, result[0].Description)
+		})
+	}
+}

--- a/internal/service/db/shadowing_list_servers_test.go
+++ b/internal/service/db/shadowing_list_servers_test.go
@@ -1,0 +1,247 @@
+package database
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/aws/smithy-go/ptr"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stacklok/toolhive-registry-server/internal/db/sqlc"
+	"github.com/stacklok/toolhive-registry-server/internal/service"
+)
+
+// TestListServersClaimsVisibility checks that three entries with the same name —
+// one each on source-A (position 0), source-B (position 1), and source-C
+// (position 2), all exposed via a single registry — shadow one another
+// correctly when claims filtering is applied. The caller always carries claims,
+// so the 8 test cases cover all 2^3 combinations of {srcAHasClaims,
+// srcBHasClaims, srcCHasClaims}.
+//
+// The claims filter runs before dedup: a higher-priority source whose entry
+// does not match the caller's claims is dropped, promoting the next source in
+// line. The cases demonstrate the full cascade: A filtered → B promoted; A and
+// B both filtered → C promoted; all filtered → entry invisible.
+func TestListServersClaimsVisibility(t *testing.T) {
+	t.Parallel()
+
+	const (
+		entryName    = "com.claims/the-entry"
+		descFromSrcA = "from source-A"
+		descFromSrcB = "from source-B"
+		descFromSrcC = "from source-C"
+	)
+
+	callerClaims := map[string]any{"sub": "claims-test-user"}
+	callerClaimsJSON, err := json.Marshal(callerClaims)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name          string
+		srcAHasClaims bool
+		srcBHasClaims bool
+		srcCHasClaims bool
+		// expectVisible is false when no entry survives the claims filter.
+		expectVisible bool
+		// expectDesc identifies which source won; only checked when expectVisible is true.
+		expectDesc string
+	}{
+		{
+			name:          "no source has claims - entry invisible",
+			srcAHasClaims: false,
+			srcBHasClaims: false,
+			srcCHasClaims: false,
+			expectVisible: false,
+		},
+		{
+			// A and B filtered; C, normally shadowed by both, is promoted.
+			name:          "only source-C matches - source-C promoted",
+			srcAHasClaims: false,
+			srcBHasClaims: false,
+			srcCHasClaims: true,
+			expectVisible: true,
+			expectDesc:    descFromSrcC,
+		},
+		{
+			// A filtered; B, normally shadowed by A, is promoted; C shadowed by B.
+			name:          "only source-B matches - source-B promoted",
+			srcAHasClaims: false,
+			srcBHasClaims: true,
+			srcCHasClaims: false,
+			expectVisible: true,
+			expectDesc:    descFromSrcB,
+		},
+		{
+			// A filtered; B promoted; C shadowed by B even though C also matches.
+			name:          "source-B and source-C match - source-B promoted, source-C shadowed",
+			srcAHasClaims: false,
+			srcBHasClaims: true,
+			srcCHasClaims: true,
+			expectVisible: true,
+			expectDesc:    descFromSrcB,
+		},
+		{
+			// A wins outright; B and C are shadowed.
+			name:          "only source-A matches - source-A wins",
+			srcAHasClaims: true,
+			srcBHasClaims: false,
+			srcCHasClaims: false,
+			expectVisible: true,
+			expectDesc:    descFromSrcA,
+		},
+		{
+			// A wins; C filtered; B shadowed by A even though B does not match.
+			name:          "source-A and source-C match - source-A wins, source-B and source-C shadowed",
+			srcAHasClaims: true,
+			srcBHasClaims: false,
+			srcCHasClaims: true,
+			expectVisible: true,
+			expectDesc:    descFromSrcA,
+		},
+		{
+			name:          "source-A and source-B match - source-A wins, source-B and source-C shadowed",
+			srcAHasClaims: true,
+			srcBHasClaims: true,
+			srcCHasClaims: false,
+			expectVisible: true,
+			expectDesc:    descFromSrcA,
+		},
+		{
+			name:          "all sources match - source-A wins via dedup, source-B and source-C shadowed",
+			srcAHasClaims: true,
+			srcBHasClaims: true,
+			srcCHasClaims: true,
+			expectVisible: true,
+			expectDesc:    descFromSrcA,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			svc, cleanup := setupTestService(t)
+			defer cleanup()
+
+			ctx := context.Background()
+			queries := sqlc.New(svc.pool)
+			now := time.Now().UTC()
+
+			// Create three sources.
+			srcA, err := queries.InsertSource(ctx, sqlc.InsertSourceParams{
+				Name:         "claims-src-a",
+				CreationType: sqlc.CreationTypeCONFIG,
+				SourceType:   "git",
+				Syncable:     true,
+				CreatedAt:    &now,
+				UpdatedAt:    &now,
+			})
+			require.NoError(t, err)
+
+			srcB, err := queries.InsertSource(ctx, sqlc.InsertSourceParams{
+				Name:         "claims-src-b",
+				CreationType: sqlc.CreationTypeCONFIG,
+				SourceType:   "git",
+				Syncable:     true,
+				CreatedAt:    &now,
+				UpdatedAt:    &now,
+			})
+			require.NoError(t, err)
+
+			srcC, err := queries.InsertSource(ctx, sqlc.InsertSourceParams{
+				Name:         "claims-src-c",
+				CreationType: sqlc.CreationTypeCONFIG,
+				SourceType:   "git",
+				Syncable:     true,
+				CreatedAt:    &now,
+				UpdatedAt:    &now,
+			})
+			require.NoError(t, err)
+
+			// Create a single registry linked to all three sources.
+			reg, err := queries.UpsertRegistry(ctx, sqlc.UpsertRegistryParams{
+				Name:         "claims-registry",
+				CreationType: sqlc.CreationTypeCONFIG,
+				CreatedAt:    &now,
+				UpdatedAt:    &now,
+			})
+			require.NoError(t, err)
+
+			for i, srcID := range []uuid.UUID{srcA.ID, srcB.ID, srcC.ID} {
+				err = queries.LinkRegistrySource(ctx, sqlc.LinkRegistrySourceParams{
+					RegistryID: reg.ID,
+					SourceID:   srcID,
+					Position:   int32(i),
+				})
+				require.NoError(t, err)
+			}
+
+			// insertEntry creates a minimal MCP server entry under the given source.
+			// desc is stored as the entry's description so tests can identify which
+			// source's copy survived dedup. claims is nil for an unclaimed entry.
+			insertEntry := func(src sqlc.Source, desc string, claims []byte) {
+				//nolint:thelper // We want to see these lines in the test output
+				entryID, err := queries.InsertRegistryEntry(ctx, sqlc.InsertRegistryEntryParams{
+					SourceID:  src.ID,
+					EntryType: sqlc.EntryTypeMCP,
+					Name:      entryName,
+					Claims:    claims,
+					CreatedAt: &now,
+					UpdatedAt: &now,
+				})
+				require.NoError(t, err)
+
+				versionID, err := queries.InsertEntryVersion(ctx, sqlc.InsertEntryVersionParams{
+					EntryID:     entryID,
+					Version:     "1.0.0",
+					Title:       ptr.String(entryName),
+					Description: ptr.String(desc),
+					CreatedAt:   &now,
+					UpdatedAt:   &now,
+				})
+				require.NoError(t, err)
+
+				_, err = queries.InsertServerVersion(ctx, sqlc.InsertServerVersionParams{
+					VersionID:    versionID,
+					UpstreamMeta: []byte(`{}`),
+					ServerMeta:   []byte(`{}`),
+				})
+				require.NoError(t, err)
+			}
+
+			// claimsFor returns callerClaimsJSON when hasClaims is true, nil otherwise.
+			// An entry with nil claims is invisible to any credentialed caller.
+			claimsFor := func(hasClaims bool) []byte {
+				if hasClaims {
+					return callerClaimsJSON
+				}
+				return nil
+			}
+
+			// All three entries share the same name; they shadow one another via dedup.
+			insertEntry(srcA, descFromSrcA, claimsFor(tt.srcAHasClaims))
+			insertEntry(srcB, descFromSrcB, claimsFor(tt.srcBHasClaims))
+			insertEntry(srcC, descFromSrcC, claimsFor(tt.srcCHasClaims))
+
+			result, err := svc.ListServers(
+				ctx,
+				service.WithRegistryName("claims-registry"),
+				service.WithClaims(callerClaims),
+				service.WithLimit(10),
+			)
+			require.NoError(t, err)
+
+			if !tt.expectVisible {
+				require.Empty(t, result.Servers)
+				return
+			}
+
+			require.Len(t, result.Servers, 1)
+			require.Equal(t, entryName, result.Servers[0].Name)
+			require.Equal(t, tt.expectDesc, result.Servers[0].Description)
+		})
+	}
+}

--- a/internal/service/db/shadowing_list_skills_test.go
+++ b/internal/service/db/shadowing_list_skills_test.go
@@ -1,0 +1,204 @@
+package database
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/aws/smithy-go/ptr"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stacklok/toolhive-registry-server/internal/db/sqlc"
+	"github.com/stacklok/toolhive-registry-server/internal/service"
+)
+
+// TestListSkillsClaimsVisibility checks that three skill entries with the same
+// name — one each on source-A (position 0), source-B (position 1), and
+// source-C (position 2), all exposed via a single registry — shadow one
+// another correctly when claims filtering is applied. The caller always carries
+// claims, so the 8 test cases cover all 2^3 combinations of {srcAHasClaims,
+// srcBHasClaims, srcCHasClaims}.
+//
+// The claims filter runs before dedup: a higher-priority source whose entry
+// does not match the caller's claims is dropped, promoting the next source in
+// line. The cases demonstrate the full cascade: A filtered → B promoted; A and
+// B both filtered → C promoted; all filtered → entry invisible.
+func TestListSkillsClaimsVisibility(t *testing.T) {
+	t.Parallel()
+
+	const (
+		entryName    = "com.claims/the-entry"
+		descFromSrcA = "from source-A"
+		descFromSrcB = "from source-B"
+		descFromSrcC = "from source-C"
+	)
+
+	callerClaims := map[string]any{"sub": "claims-test-user"}
+	callerClaimsJSON, err := json.Marshal(callerClaims)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name          string
+		srcAHasClaims bool
+		srcBHasClaims bool
+		srcCHasClaims bool
+		// expectVisible is false when no entry survives the claims filter.
+		expectVisible bool
+		// expectDesc identifies which source won; only checked when expectVisible is true.
+		expectDesc string
+	}{
+		{
+			name:          "no source has claims - entry invisible",
+			srcAHasClaims: false,
+			srcBHasClaims: false,
+			srcCHasClaims: false,
+			expectVisible: false,
+		},
+		{
+			// A and B filtered; C, normally shadowed by both, is promoted.
+			name:          "only source-C matches - source-C promoted",
+			srcAHasClaims: false,
+			srcBHasClaims: false,
+			srcCHasClaims: true,
+			expectVisible: true,
+			expectDesc:    descFromSrcC,
+		},
+		{
+			// A filtered; B, normally shadowed by A, is promoted; C shadowed by B.
+			name:          "only source-B matches - source-B promoted",
+			srcAHasClaims: false,
+			srcBHasClaims: true,
+			srcCHasClaims: false,
+			expectVisible: true,
+			expectDesc:    descFromSrcB,
+		},
+		{
+			// A filtered; B promoted; C shadowed by B even though C also matches.
+			name:          "source-B and source-C match - source-B promoted, source-C shadowed",
+			srcAHasClaims: false,
+			srcBHasClaims: true,
+			srcCHasClaims: true,
+			expectVisible: true,
+			expectDesc:    descFromSrcB,
+		},
+		{
+			// A wins outright; B and C are shadowed.
+			name:          "only source-A matches - source-A wins",
+			srcAHasClaims: true,
+			srcBHasClaims: false,
+			srcCHasClaims: false,
+			expectVisible: true,
+			expectDesc:    descFromSrcA,
+		},
+		{
+			// A wins; C filtered; B shadowed by A even though B does not match.
+			name:          "source-A and source-C match - source-A wins, source-B and source-C shadowed",
+			srcAHasClaims: true,
+			srcBHasClaims: false,
+			srcCHasClaims: true,
+			expectVisible: true,
+			expectDesc:    descFromSrcA,
+		},
+		{
+			name:          "source-A and source-B match - source-A wins, source-B and source-C shadowed",
+			srcAHasClaims: true,
+			srcBHasClaims: true,
+			srcCHasClaims: false,
+			expectVisible: true,
+			expectDesc:    descFromSrcA,
+		},
+		{
+			name:          "all sources match - source-A wins via dedup, source-B and source-C shadowed",
+			srcAHasClaims: true,
+			srcBHasClaims: true,
+			srcCHasClaims: true,
+			expectVisible: true,
+			expectDesc:    descFromSrcA,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			svc, cleanup := setupTestService(t)
+			defer cleanup()
+
+			ctx := context.Background()
+			queries := sqlc.New(svc.pool)
+			now := time.Now().UTC()
+
+			srcA, srcB, srcC := setupShadowingRegistry(t, svc)
+
+			// insertEntry creates a minimal skill entry under the given source.
+			// desc is stored as the entry's description so tests can identify which
+			// source's copy survived dedup. claims is nil for an unclaimed entry.
+			insertEntry := func(src sqlc.Source, desc string, claims []byte) {
+				//nolint:thelper // We want to see these lines in the test output
+				entryID, err := queries.InsertRegistryEntry(ctx, sqlc.InsertRegistryEntryParams{
+					SourceID:  src.ID,
+					EntryType: sqlc.EntryTypeSKILL,
+					Name:      entryName,
+					Claims:    claims,
+					CreatedAt: &now,
+					UpdatedAt: &now,
+				})
+				require.NoError(t, err)
+
+				versionID, err := queries.InsertEntryVersion(ctx, sqlc.InsertEntryVersionParams{
+					EntryID:     entryID,
+					Version:     "1.0.0",
+					Title:       ptr.String(entryName),
+					Description: ptr.String(desc),
+					CreatedAt:   &now,
+					UpdatedAt:   &now,
+				})
+				require.NoError(t, err)
+
+				_, err = queries.InsertSkillVersion(ctx, sqlc.InsertSkillVersionParams{
+					VersionID:     versionID,
+					Namespace:     "com.example",
+					Status:        sqlc.NullSkillStatus{},
+					AllowedTools:  nil,
+					Repository:    []byte("null"),
+					Icons:         []byte("null"),
+					Metadata:      []byte("null"),
+					ExtensionMeta: []byte("null"),
+				})
+				require.NoError(t, err)
+			}
+
+			// claimsFor returns callerClaimsJSON when hasClaims is true, nil otherwise.
+			// An entry with nil claims is invisible to any credentialed caller.
+			claimsFor := func(hasClaims bool) []byte {
+				if hasClaims {
+					return callerClaimsJSON
+				}
+				return nil
+			}
+
+			// All three entries share the same name; they shadow one another via dedup.
+			insertEntry(srcA, descFromSrcA, claimsFor(tt.srcAHasClaims))
+			insertEntry(srcB, descFromSrcB, claimsFor(tt.srcBHasClaims))
+			insertEntry(srcC, descFromSrcC, claimsFor(tt.srcCHasClaims))
+
+			result, err := svc.ListSkills(
+				ctx,
+				service.WithRegistryName("claims-registry"),
+				service.WithNamespace("com.example"),
+				service.WithClaims(callerClaims),
+				service.WithLimit(10),
+			)
+			require.NoError(t, err)
+
+			if !tt.expectVisible {
+				require.Empty(t, result.Skills)
+				return
+			}
+
+			require.Len(t, result.Skills, 1)
+			require.Equal(t, tt.expectDesc, result.Skills[0].Description)
+		})
+	}
+}

--- a/internal/service/db/types.go
+++ b/internal/service/db/types.go
@@ -37,6 +37,7 @@ type helper struct {
 	RepositoryID        *string
 	RepositorySubfolder *string
 	RepositoryType      *string
+	Claims              []byte
 	Position            int32
 }
 
@@ -59,6 +60,7 @@ func listServersRowToHelper(
 		RepositoryID:        dbServer.RepositoryID,
 		RepositorySubfolder: dbServer.RepositorySubfolder,
 		RepositoryType:      dbServer.RepositoryType,
+		Claims:              dbServer.Claims,
 		Position:            dbServer.Position,
 	}
 }
@@ -82,6 +84,7 @@ func getServerVersionRowToHelper(
 		RepositoryID:        dbServer.RepositoryID,
 		RepositorySubfolder: dbServer.RepositorySubfolder,
 		RepositoryType:      dbServer.RepositoryType,
+		Claims:              dbServer.Claims,
 		Position:            dbServer.Position,
 	}
 }

--- a/internal/service/options.go
+++ b/internal/service/options.go
@@ -54,10 +54,6 @@ type claimsOption interface {
 	setClaims(claims map[string]any) error
 }
 
-type filterOption interface {
-	setFilter(filter RecordFilter) error
-}
-
 // WithCursor sets the cursor for the ListServers operation
 func WithCursor(cursor string) Option {
 	return func(o any) error {
@@ -212,18 +208,6 @@ func WithClaims(claims map[string]any) Option {
 		switch o := o.(type) {
 		case claimsOption:
 			return o.setClaims(claims)
-		default:
-			return fmt.Errorf("invalid option type: %T", o)
-		}
-	}
-}
-
-// WithFilter sets a filter predicate for ListServers or ListSkills operations.
-func WithFilter(filter RecordFilter) Option {
-	return func(o any) error {
-		switch o := o.(type) {
-		case filterOption:
-			return o.setFilter(filter)
 		default:
 			return fmt.Errorf("invalid option type: %T", o)
 		}

--- a/internal/service/options_mcp.go
+++ b/internal/service/options_mcp.go
@@ -14,13 +14,7 @@ type ListServersOptions struct {
 	Search       string
 	UpdatedSince time.Time
 	Version      string
-	Filter       RecordFilter
-}
-
-//nolint:unparam
-func (o *ListServersOptions) setFilter(filter RecordFilter) error {
-	o.Filter = filter
-	return nil
+	Claims       map[string]any
 }
 
 //nolint:unparam
@@ -59,18 +53,18 @@ func (o *ListServersOptions) setVersion(version string) error {
 	return nil
 }
 
+//nolint:unparam
+func (o *ListServersOptions) setClaims(claims map[string]any) error {
+	o.Claims = claims
+	return nil
+}
+
 // ListServerVersionsOptions is the options for the ListServerVersions operation
 type ListServerVersionsOptions struct {
 	RegistryName *string
 	Name         string
 	Limit        int
-	Filter       RecordFilter
-}
-
-//nolint:unparam
-func (o *ListServerVersionsOptions) setFilter(filter RecordFilter) error {
-	o.Filter = filter
-	return nil
+	Claims       map[string]any
 }
 
 //nolint:unparam
@@ -91,19 +85,19 @@ func (o *ListServerVersionsOptions) setLimit(limit int) error {
 	return nil
 }
 
+//nolint:unparam
+func (o *ListServerVersionsOptions) setClaims(claims map[string]any) error {
+	o.Claims = claims
+	return nil
+}
+
 // GetServerVersionOptions is the options for the GetServerVersion operation
 type GetServerVersionOptions struct {
 	RegistryName string
 	SourceName   string
 	Name         string
 	Version      string
-	Filter       RecordFilter
-}
-
-//nolint:unparam
-func (o *GetServerVersionOptions) setFilter(filter RecordFilter) error {
-	o.Filter = filter
-	return nil
+	Claims       map[string]any
 }
 
 //nolint:unparam
@@ -127,6 +121,12 @@ func (o *GetServerVersionOptions) setName(name string) error {
 //nolint:unparam
 func (o *GetServerVersionOptions) setVersion(version string) error {
 	o.Version = version
+	return nil
+}
+
+//nolint:unparam
+func (o *GetServerVersionOptions) setClaims(claims map[string]any) error {
+	o.Claims = claims
 	return nil
 }
 

--- a/internal/service/options_skills.go
+++ b/internal/service/options_skills.go
@@ -21,13 +21,7 @@ type ListSkillsOptions struct {
 	Search       *string
 	Limit        int
 	Cursor       *string
-	Filter       RecordFilter
-}
-
-//nolint:unparam
-func (o *ListSkillsOptions) setFilter(filter RecordFilter) error {
-	o.Filter = filter
-	return nil
+	Claims       map[string]any
 }
 
 //nolint:unparam
@@ -72,6 +66,12 @@ func (o *ListSkillsOptions) setCursor(cursor string) error {
 	return nil
 }
 
+//nolint:unparam
+func (o *ListSkillsOptions) setClaims(claims map[string]any) error {
+	o.Claims = claims
+	return nil
+}
+
 // GetSkillVersionOptions is the options for the GetSkillVersion operation.
 type GetSkillVersionOptions struct {
 	RegistryName string
@@ -79,13 +79,7 @@ type GetSkillVersionOptions struct {
 	Namespace    string
 	Name         string
 	Version      string
-	Filter       RecordFilter
-}
-
-//nolint:unparam
-func (o *GetSkillVersionOptions) setFilter(filter RecordFilter) error {
-	o.Filter = filter
-	return nil
+	Claims       map[string]any
 }
 
 //nolint:unparam
@@ -115,6 +109,12 @@ func (o *GetSkillVersionOptions) setName(name string) error {
 //nolint:unparam
 func (o *GetSkillVersionOptions) setVersion(version string) error {
 	o.Version = version
+	return nil
+}
+
+//nolint:unparam
+func (o *GetSkillVersionOptions) setClaims(claims map[string]any) error {
+	o.Claims = claims
 	return nil
 }
 

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -1,7 +1,6 @@
 package service_test
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -10,11 +9,6 @@ import (
 
 	"github.com/stacklok/toolhive-registry-server/internal/service"
 )
-
-// alwaysKeepFilter is a simple RecordFilter that keeps every record.
-var alwaysKeepFilter service.RecordFilter = func(context.Context, any) (bool, error) {
-	return true, nil
-}
 
 func TestWithCursor(t *testing.T) {
 	t.Parallel()
@@ -536,80 +530,6 @@ func TestWithLimitListServerVersions(t *testing.T) {
 
 			require.NoError(t, err)
 			assert.Equal(t, tt.expectedValue, opts.Limit)
-		})
-	}
-}
-
-func TestWithFilter(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name    string
-		opts    any
-		wantErr bool
-		check   func(t *testing.T, opts any)
-	}{
-		{
-			name: "sets filter on ListServersOptions",
-			opts: &service.ListServersOptions{},
-			check: func(t *testing.T, opts any) {
-				t.Helper()
-				assert.NotNil(t, opts.(*service.ListServersOptions).Filter)
-			},
-		},
-		{
-			name: "sets filter on ListServerVersionsOptions",
-			opts: &service.ListServerVersionsOptions{},
-			check: func(t *testing.T, opts any) {
-				t.Helper()
-				assert.NotNil(t, opts.(*service.ListServerVersionsOptions).Filter)
-			},
-		},
-		{
-			name: "sets filter on GetServerVersionOptions",
-			opts: &service.GetServerVersionOptions{},
-			check: func(t *testing.T, opts any) {
-				t.Helper()
-				assert.NotNil(t, opts.(*service.GetServerVersionOptions).Filter)
-			},
-		},
-		{
-			name: "sets filter on ListSkillsOptions",
-			opts: &service.ListSkillsOptions{},
-			check: func(t *testing.T, opts any) {
-				t.Helper()
-				assert.NotNil(t, opts.(*service.ListSkillsOptions).Filter)
-			},
-		},
-		{
-			name: "sets filter on GetSkillVersionOptions",
-			opts: &service.GetSkillVersionOptions{},
-			check: func(t *testing.T, opts any) {
-				t.Helper()
-				assert.NotNil(t, opts.(*service.GetSkillVersionOptions).Filter)
-			},
-		},
-		{
-			name:    "returns error for incompatible type",
-			opts:    &service.PublishServerVersionOptions{},
-			wantErr: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			opt := service.WithFilter(alwaysKeepFilter)
-			err := opt(tt.opts)
-
-			if tt.wantErr {
-				require.Error(t, err)
-				return
-			}
-
-			require.NoError(t, err)
-			tt.check(t, tt.opts)
 		})
 	}
 }


### PR DESCRIPTION
This change uses app-level filtering to ensure claims are respected. Most of the change is about tests pinning the expected shadowing behavior given specific sets of claims. This change is built on top of the recently added app-level filtering and is implemented as a very simple filter applied to a stream of records from the database, and the bulk of the change are tests pinning the expected behaviour for the various APIs returning records of the various kind.

Some effort was spent unifying the code paths, and further work should be done in future PRs.

Finally, `WithFilter` was removed from the Service interface because it did not really make sense to expose it at the API layer, at least for now.

References #444