### PR TITLE
feat(registry): add OIXA Protocol — AI agent marketplace MCP server

### DIFF
--- a/examples/toolhive-registry.json
+++ b/examples/toolhive-registry.json
@@ -1,952 +1,1000 @@
 {
-  "$schema": "https://raw.githubusercontent.com/stacklok/toolhive-core/main/registry/types/data/toolhive-legacy-registry.schema.json",
-  "version": "1.0.0",
-  "last_updated": "2025-11-26T00:27:46Z",
-  "servers": {
-    "adb-mysql-mcp-server": {
-      "description": "Official MCP server for AnalyticDB for MySQL of Alibaba Cloud",
-      "tier": "Official",
-      "status": "Active",
-      "transport": "stdio",
-      "tools": [
-        "execute_sql",
-        "get_query_plan",
-        "get_execution_plan"
-      ],
-      "metadata": {
-        "stars": 17,
-        "pulls": 0,
-        "last_updated": "2025-11-15T02:31:08Z"
-      },
-      "repository_url": "https://github.com/aliyun/alibabacloud-adb-mysql-mcp-server",
-      "tags": [
-        "database",
-        "mysql",
-        "analytics",
-        "sql",
-        "alibaba-cloud",
-        "data-warehouse"
-      ],
-      "image": "ghcr.io/stacklok/dockyard/uvx/adb-mysql-mcp-server:1.0.0",
-      "permissions": {
-        "network": {
-          "outbound": {
-            "insecure_allow_all": true
-          }
-        }
-      },
-      "env_vars": [
-        {
-          "name": "ADB_MYSQL_HOST",
-          "description": "AnalyticDB for MySQL host address",
-          "required": true
-        },
-        {
-          "name": "ADB_MYSQL_PORT",
-          "description": "AnalyticDB for MySQL port number",
-          "required": true
-        },
-        {
-          "name": "ADB_MYSQL_USER",
-          "description": "Database user for authentication",
-          "required": true
-        },
-        {
-          "name": "ADB_MYSQL_PASSWORD",
-          "description": "Database password for authentication",
-          "required": true,
-          "secret": true
-        },
-        {
-          "name": "ADB_MYSQL_DATABASE",
-          "description": "Database name to connect to",
-          "required": true
-        }
-      ],
-      "provenance": {
-        "sigstore_url": "tuf-repo-cdn.sigstore.dev",
-        "repository_uri": "https://github.com/stacklok/dockyard",
-        "signer_identity": "/.github/workflows/build-containers.yml",
-        "runner_environment": "github-hosted",
-        "cert_issuer": "https://token.actions.githubusercontent.com"
-      }
-    },
-    "apollo-mcp-server": {
-      "description": "Exposes GraphQL operations as MCP tools for AI-driven API orchestration with Apollo",
-      "tier": "Official",
-      "status": "Active",
-      "transport": "streamable-http",
-      "tools": [
-        "example_GetAstronautsCurrentlyInSpace"
-      ],
-      "metadata": {
-        "stars": 231,
-        "pulls": 0,
-        "last_updated": "2025-11-17T02:33:29Z"
-      },
-      "repository_url": "https://github.com/apollographql/apollo-mcp-server",
-      "tags": [
-        "graphql",
-        "api",
-        "orchestration",
-        "apollo",
-        "mcp"
-      ],
-      "image": "ghcr.io/apollographql/apollo-mcp-server:v1.2.1",
-      "target_port": 5000,
-      "permissions": {
-        "network": {
-          "outbound": {
-            "insecure_allow_all": true,
-            "allow_port": [
-              443
-            ]
-          }
-        }
-      },
-      "env_vars": [
-        {
-          "name": "APOLLO_GRAPH_REF",
-          "description": "Graph ref (graph ID and variant) used to fetch persisted queries or schema (required if no config file)",
-          "required": false
-        },
-        {
-          "name": "APOLLO_KEY",
-          "description": "Apollo Studio API key for the graph (required if no config file)",
-          "required": false,
-          "secret": true
-        }
-      ]
-    },
-    "arxiv-mcp-server": {
-      "description": "AI assistants search and access arXiv papers through MCP with persistent paper storage",
-      "tier": "Community",
-      "status": "Active",
-      "transport": "stdio",
-      "tools": [
-        "search_papers",
-        "download_paper",
-        "list_papers",
-        "read_paper"
-      ],
-      "metadata": {
-        "stars": 1895,
-        "pulls": 77,
-        "last_updated": "2025-11-24T02:36:20Z"
-      },
-      "repository_url": "https://github.com/blazickjp/arxiv-mcp-server",
-      "tags": [
-        "research",
-        "academic",
-        "papers",
-        "arxiv",
-        "search"
-      ],
-      "image": "ghcr.io/stacklok/dockyard/uvx/arxiv-mcp-server:0.3.1",
-      "permissions": {
-        "network": {
-          "outbound": {
-            "allow_host": [
-              "arxiv.org",
-              "export.arxiv.org"
+    "$schema": "https://raw.githubusercontent.com/stacklok/toolhive-core/main/registry/types/data/toolhive-legacy-registry.schema.json",
+    "version": "1.0.0",
+    "last_updated": "2025-11-26T00:27:46Z",
+    "servers": {
+        "adb-mysql-mcp-server": {
+            "description": "Official MCP server for AnalyticDB for MySQL of Alibaba Cloud",
+            "tier": "Official",
+            "status": "Active",
+            "transport": "stdio",
+            "tools": [
+                "execute_sql",
+                "get_query_plan",
+                "get_execution_plan"
             ],
-            "allow_port": [
-              443,
-              80
-            ]
-          }
-        }
-      },
-      "env_vars": [
-        {
-          "name": "ARXIV_STORAGE_PATH",
-          "description": "Directory path where downloaded papers will be stored",
-          "required": false,
-          "default": "/arxiv-papers"
-        }
-      ],
-      "args": [
-        "--storage-path",
-        "/arxiv-papers"
-      ],
-      "provenance": {
-        "sigstore_url": "tuf-repo-cdn.sigstore.dev",
-        "repository_uri": "https://github.com/stacklok/dockyard",
-        "signer_identity": "/.github/workflows/build-containers.yml",
-        "runner_environment": "github-hosted",
-        "cert_issuer": "https://token.actions.githubusercontent.com"
-      }
-    },
-    "aws-api": {
-      "description": "Enables AI assistants to interact with AWS services and resources through AWS CLI commands",
-      "tier": "Official",
-      "status": "Active",
-      "transport": "stdio",
-      "tools": [
-        "call_aws",
-        "suggest_aws_commands"
-      ],
-      "metadata": {
-        "stars": 6955,
-        "pulls": 0,
-        "last_updated": "2025-11-07T02:32:29Z"
-      },
-      "repository_url": "https://github.com/awslabs/mcp",
-      "tags": [
-        "aws",
-        "cli",
-        "cloud",
-        "infrastructure",
-        "api",
-        "devops"
-      ],
-      "image": "public.ecr.aws/awslabs-mcp/awslabs/aws-api-mcp-server:1.1.7",
-      "permissions": {
-        "network": {
-          "outbound": {
-            "allow_host": [
-              "aws.amazon.com",
-              ".amazonaws.com"
+            "metadata": {
+                "stars": 17,
+                "pulls": 0,
+                "last_updated": "2025-11-15T02:31:08Z"
+            },
+            "repository_url": "https://github.com/aliyun/alibabacloud-adb-mysql-mcp-server",
+            "tags": [
+                "database",
+                "mysql",
+                "analytics",
+                "sql",
+                "alibaba-cloud",
+                "data-warehouse"
             ],
-            "allow_port": [
-              443
-            ]
-          }
-        }
-      },
-      "env_vars": [
-        {
-          "name": "AWS_REGION",
-          "description": "Default AWS region for CLI commands unless a specific region is provided in the request",
-          "required": false,
-          "default": "us-east-1"
-        },
-        {
-          "name": "AWS_ACCESS_KEY_ID",
-          "description": "AWS access key ID for authentication",
-          "required": false,
-          "secret": true
-        },
-        {
-          "name": "AWS_SECRET_ACCESS_KEY",
-          "description": "AWS secret access key for authentication",
-          "required": false,
-          "secret": true
-        },
-        {
-          "name": "AWS_SESSION_TOKEN",
-          "description": "AWS session token for temporary credentials",
-          "required": false,
-          "secret": true
-        },
-        {
-          "name": "READ_OPERATIONS_ONLY",
-          "description": "When set to \"true\", restricts execution to read-only operations",
-          "required": false,
-          "default": "false"
-        },
-        {
-          "name": "REQUIRE_MUTATION_CONSENT",
-          "description": "When set to \"true\", asks explicit consent before executing non-read-only operations",
-          "required": false,
-          "default": "false"
-        },
-        {
-          "name": "AWS_API_MCP_WORKING_DIR",
-          "description": "Working directory path for MCP server operations (must be absolute path)",
-          "required": false
-        },
-        {
-          "name": "AWS_API_MCP_ALLOW_UNRESTRICTED_LOCAL_FILE_ACCESS",
-          "description": "When set to \"true\", enables system-wide file access (may cause unintended overwrites)",
-          "required": false,
-          "default": "false"
-        },
-        {
-          "name": "AWS_API_MCP_TELEMETRY",
-          "description": "Allow sending additional telemetry data to AWS related to server configuration",
-          "required": false,
-          "default": "true"
-        },
-        {
-          "name": "EXPERIMENTAL_AGENT_SCRIPTS",
-          "description": "When set to \"true\", enables experimental agent scripts functionality",
-          "required": false,
-          "default": "false"
-        },
-        {
-          "name": "AWS_API_MCP_AGENT_SCRIPTS_DIR",
-          "description": "Directory path containing custom user scripts for agent scripts functionality",
-          "required": false
-        }
-      ]
-    },
-    "browserbase": {
-      "description": "MCP server for cloud browser automation with Browserbase and Stagehand",
-      "tier": "Official",
-      "status": "Active",
-      "transport": "stdio",
-      "tools": [
-        "browserbase_screenshot",
-        "browserbase_session_close",
-        "browserbase_session_create",
-        "browserbase_stagehand_act",
-        "browserbase_stagehand_agent",
-        "browserbase_stagehand_extract",
-        "browserbase_stagehand_get_url",
-        "browserbase_stagehand_navigate",
-        "browserbase_stagehand_observe"
-      ],
-      "metadata": {
-        "stars": 2757,
-        "pulls": 133,
-        "last_updated": "2025-11-01T02:32:39Z"
-      },
-      "repository_url": "https://github.com/browserbase/mcp-server-browserbase",
-      "tags": [
-        "browser",
-        "automation",
-        "web-scraping",
-        "testing",
-        "stagehand"
-      ],
-      "image": "ghcr.io/stacklok/dockyard/npx/browserbase-mcp-server:2.4.1",
-      "permissions": {
-        "network": {
-          "outbound": {
-            "insecure_allow_all": true
-          }
-        }
-      },
-      "env_vars": [
-        {
-          "name": "BROWSERBASE_API_KEY",
-          "description": "Browserbase API key",
-          "required": true,
-          "secret": true
-        },
-        {
-          "name": "BROWSERBASE_PROJECT_ID",
-          "description": "Browserbase project ID",
-          "required": true
-        },
-        {
-          "name": "GEMINI_API_KEY",
-          "description": "Google Gemini API key for Stagehand",
-          "required": true,
-          "secret": true
-        }
-      ],
-      "provenance": {
-        "sigstore_url": "tuf-repo-cdn.sigstore.dev",
-        "repository_uri": "https://github.com/stacklok/dockyard",
-        "signer_identity": "/.github/workflows/build-containers.yml",
-        "runner_environment": "github-hosted",
-        "cert_issuer": "https://token.actions.githubusercontent.com"
-      }
-    },
-    "chrome-devtools-mcp": {
-      "description": "Control and inspect live Chrome browser from AI coding agents with full DevTools access",
-      "tier": "Official",
-      "status": "Active",
-      "transport": "stdio",
-      "tools": [
-        "click",
-        "drag",
-        "fill",
-        "fill_form",
-        "handle_dialog",
-        "hover",
-        "press_key",
-        "upload_file",
-        "close_page",
-        "list_pages",
-        "navigate_page",
-        "new_page",
-        "select_page",
-        "wait_for",
-        "emulate",
-        "resize_page",
-        "performance_analyze_insight",
-        "performance_start_trace",
-        "performance_stop_trace",
-        "get_network_request",
-        "list_network_requests",
-        "evaluate_script",
-        "get_console_message",
-        "list_console_messages",
-        "take_screenshot",
-        "take_snapshot"
-      ],
-      "metadata": {
-        "stars": 14453,
-        "pulls": 0,
-        "last_updated": "2025-11-12T00:00:00Z"
-      },
-      "repository_url": "https://github.com/ChromeDevTools/chrome-devtools-mcp",
-      "tags": [
-        "chrome",
-        "devtools",
-        "browser",
-        "automation",
-        "debugging",
-        "performance",
-        "puppeteer",
-        "testing"
-      ],
-      "image": "ghcr.io/stacklok/dockyard/npx/chrome-devtools-mcp:0.10.2",
-      "permissions": {
-        "network": {
-          "outbound": {
-            "insecure_allow_all": true,
-            "allow_port": [
-              443,
-              80
-            ]
-          }
-        }
-      },
-      "provenance": {
-        "sigstore_url": "tuf-repo-cdn.sigstore.dev",
-        "repository_uri": "https://github.com/stacklok/dockyard",
-        "signer_identity": "/.github/workflows/build-containers.yml",
-        "runner_environment": "github-hosted",
-        "cert_issuer": "https://token.actions.githubusercontent.com"
-      }
-    },
-    "crowdstrike-falcon": {
-      "description": "CrowdStrike Falcon integration for security analysis, detections, incidents, and threat intel",
-      "tier": "Official",
-      "status": "Active",
-      "transport": "streamable-http",
-      "tools": [
-        "falcon_check_connectivity",
-        "falcon_get_available_modules",
-        "falcon_search_detections",
-        "falcon_get_detection_details",
-        "falcon_show_crowd_score",
-        "falcon_search_incidents",
-        "falcon_get_incident_details",
-        "falcon_search_behaviors",
-        "falcon_get_behavior_details",
-        "falcon_search_actors",
-        "falcon_search_indicators",
-        "falcon_search_reports",
-        "falcon_search_hosts",
-        "falcon_get_host_details",
-        "falcon_search_vulnerabilities",
-        "falcon_search_kubernetes_containers",
-        "falcon_count_kubernetes_containers",
-        "falcon_search_images_vulnerabilities",
-        "idp_investigate_entity"
-      ],
-      "metadata": {
-        "stars": 73,
-        "pulls": 3771,
-        "last_updated": "2025-11-13T02:33:35Z"
-      },
-      "repository_url": "https://github.com/crowdstrike/falcon-mcp",
-      "tags": [
-        "crowdstrike",
-        "falcon",
-        "security",
-        "cybersecurity",
-        "threat-intelligence",
-        "detections",
-        "incidents",
-        "vulnerabilities",
-        "endpoint-security",
-        "threat-hunting",
-        "incident-response",
-        "malware-analysis",
-        "identity-protection",
-        "cloud-security"
-      ],
-      "image": "quay.io/crowdstrike/falcon-mcp:latest",
-      "target_port": 8000,
-      "permissions": {
-        "network": {
-          "outbound": {
-            "allow_host": [
-              "api.crowdstrike.com",
-              "api.us-2.crowdstrike.com",
-              "api.eu-1.crowdstrike.com",
-              "api.laggar.gcw.crowdstrike.com"
+            "image": "ghcr.io/stacklok/dockyard/uvx/adb-mysql-mcp-server:1.0.0",
+            "permissions": {
+                "network": {
+                    "outbound": {
+                        "insecure_allow_all": true
+                    }
+                }
+            },
+            "env_vars": [
+                {
+                    "name": "ADB_MYSQL_HOST",
+                    "description": "AnalyticDB for MySQL host address",
+                    "required": true
+                },
+                {
+                    "name": "ADB_MYSQL_PORT",
+                    "description": "AnalyticDB for MySQL port number",
+                    "required": true
+                },
+                {
+                    "name": "ADB_MYSQL_USER",
+                    "description": "Database user for authentication",
+                    "required": true
+                },
+                {
+                    "name": "ADB_MYSQL_PASSWORD",
+                    "description": "Database password for authentication",
+                    "required": true,
+                    "secret": true
+                },
+                {
+                    "name": "ADB_MYSQL_DATABASE",
+                    "description": "Database name to connect to",
+                    "required": true
+                }
             ],
-            "allow_port": [
-              443
-            ]
-          }
-        }
-      },
-      "env_vars": [
-        {
-          "name": "FALCON_CLIENT_ID",
-          "description": "CrowdStrike API client ID",
-          "required": true,
-          "secret": true
+            "provenance": {
+                "sigstore_url": "tuf-repo-cdn.sigstore.dev",
+                "repository_uri": "https://github.com/stacklok/dockyard",
+                "signer_identity": "/.github/workflows/build-containers.yml",
+                "runner_environment": "github-hosted",
+                "cert_issuer": "https://token.actions.githubusercontent.com"
+            }
         },
-        {
-          "name": "FALCON_CLIENT_SECRET",
-          "description": "CrowdStrike API client secret",
-          "required": true,
-          "secret": true
-        },
-        {
-          "name": "FALCON_BASE_URL",
-          "description": "CrowdStrike API base URL (e.g., https://api.crowdstrike.com, https://api.us-2.crowdstrike.com, https://api.eu-1.crowdstrike.com)",
-          "required": true
-        },
-        {
-          "name": "FALCON_MCP_MODULES",
-          "description": "Comma-separated list of modules to enable (detections,incidents,intel,hosts,spotlight,cloud,idp). If not set, all modules are enabled.",
-          "required": false
-        },
-        {
-          "name": "FALCON_MCP_DEBUG",
-          "description": "Enable debug logging - true or false (default: false)",
-          "required": false
-        }
-      ],
-      "args": [
-        "--transport",
-        "streamable-http",
-        "--host",
-        "0.0.0.0",
-        "--port",
-        "8000"
-      ]
-    },
-    "fetch": {
-      "description": "Allows you to fetch content from the web",
-      "tier": "Community",
-      "status": "Active",
-      "transport": "streamable-http",
-      "tools": [
-        "fetch"
-      ],
-      "metadata": {
-        "stars": 20,
-        "pulls": 12390,
-        "last_updated": "2025-11-13T02:33:35Z"
-      },
-      "repository_url": "https://github.com/stackloklabs/gofetch",
-      "tags": [
-        "content",
-        "html",
-        "markdown",
-        "fetch",
-        "fetching",
-        "get",
-        "wget",
-        "json",
-        "curl",
-        "modelcontextprotocol"
-      ],
-      "image": "ghcr.io/stackloklabs/gofetch/server:1.0.1",
-      "target_port": 8080,
-      "permissions": {
-        "network": {
-          "outbound": {
-            "insecure_allow_all": true,
-            "allow_port": [
-              443
-            ]
-          }
-        }
-      },
-      "provenance": {
-        "sigstore_url": "tuf-repo-cdn.sigstore.dev",
-        "repository_uri": "https://github.com/StacklokLabs/gofetch",
-        "signer_identity": "/.github/workflows/release.yml",
-        "runner_environment": "github-hosted",
-        "cert_issuer": "https://token.actions.githubusercontent.com"
-      }
-    },
-    "filesystem": {
-      "description": "Allows you to do filesystem operations. Mount paths under /projects using --volume.",
-      "tier": "Community",
-      "status": "Active",
-      "transport": "stdio",
-      "tools": [
-        "read_file",
-        "read_multiple_files",
-        "write_file",
-        "edit_file",
-        "create_directory",
-        "list_directory",
-        "directory_tree",
-        "move_file",
-        "search_files",
-        "get_file_info",
-        "list_allowed_directories"
-      ],
-      "metadata": {
-        "stars": 71855,
-        "pulls": 20619,
-        "last_updated": "2025-11-04T02:32:45Z"
-      },
-      "repository_url": "https://github.com/modelcontextprotocol/servers",
-      "tags": [
-        "create_directory",
-        "edit_file",
-        "filesystem",
-        "get_file_info",
-        "implementing",
-        "list_allowed_directories",
-        "list_directory",
-        "move_file",
-        "node",
-        "operations"
-      ],
-      "image": "docker.io/mcp/filesystem:latest",
-      "permissions": {
-        "network": {
-          "outbound": {}
-        }
-      },
-      "args": [
-        "/projects"
-      ]
-    },
-    "genai-toolbox": {
-      "description": "Will be removed soon. Please use database-toolbox instead.",
-      "tier": "Official",
-      "status": "Deprecated",
-      "transport": "sse",
-      "tools": [
-        "set_during_runtime"
-      ],
-      "metadata": {
-        "stars": 11251,
-        "pulls": 2408,
-        "last_updated": "2025-11-02T02:34:09Z"
-      },
-      "repository_url": "https://github.com/googleapis/genai-toolbox",
-      "tags": [
-        "database",
-        "sql",
-        "postgresql",
-        "mysql",
-        "sqlite",
-        "mongodb",
-        "redis",
-        "connection-pooling",
-        "authentication",
-        "observability",
-        "toolbox",
-        "genai",
-        "mcp-server"
-      ],
-      "image": "us-central1-docker.pkg.dev/database-toolbox/toolbox/toolbox:0.21.0",
-      "target_port": 5000,
-      "permissions": {
-        "network": {
-          "outbound": {
-            "insecure_allow_all": true
-          }
-        }
-      }
-    },
-    "github": {
-      "description": "Provides integration with GitHub's APIs",
-      "tier": "Official",
-      "status": "Active",
-      "transport": "stdio",
-      "tools": [
-        "add_comment_to_pending_review",
-        "add_issue_comment",
-        "assign_copilot_to_issue",
-        "create_branch",
-        "create_or_update_file",
-        "create_pull_request",
-        "create_repository",
-        "delete_file",
-        "fork_repository",
-        "get_commit",
-        "get_file_contents",
-        "get_label",
-        "get_latest_release",
-        "get_me",
-        "get_release_by_tag",
-        "get_tag",
-        "get_team_members",
-        "get_teams",
-        "issue_read",
-        "issue_write",
-        "list_branches",
-        "list_commits",
-        "list_issue_types",
-        "list_issues",
-        "list_pull_requests",
-        "list_releases",
-        "list_tags",
-        "merge_pull_request",
-        "pull_request_read",
-        "pull_request_review_write",
-        "push_files",
-        "request_copilot_review",
-        "search_code",
-        "search_issues",
-        "search_pull_requests",
-        "search_repositories",
-        "search_users",
-        "sub_issue_write",
-        "update_pull_request",
-        "update_pull_request_branch"
-      ],
-      "metadata": {
-        "stars": 24254,
-        "pulls": 5000,
-        "last_updated": "2025-11-06T02:33:26Z"
-      },
-      "repository_url": "https://github.com/github/github-mcp-server",
-      "tags": [
-        "api",
-        "create",
-        "fork",
-        "github",
-        "list",
-        "pull-request",
-        "push",
-        "repository",
-        "search",
-        "update",
-        "issues"
-      ],
-      "image": "ghcr.io/github/github-mcp-server:v0.22.0",
-      "permissions": {
-        "network": {
-          "outbound": {
-            "allow_host": [
-              ".github.com",
-              ".githubusercontent.com"
+        "apollo-mcp-server": {
+            "description": "Exposes GraphQL operations as MCP tools for AI-driven API orchestration with Apollo",
+            "tier": "Official",
+            "status": "Active",
+            "transport": "streamable-http",
+            "tools": [
+                "example_GetAstronautsCurrentlyInSpace"
             ],
-            "allow_port": [
-              443
-            ]
-          }
-        }
-      },
-      "env_vars": [
-        {
-          "name": "GITHUB_PERSONAL_ACCESS_TOKEN",
-          "description": "GitHub personal access token with appropriate permissions",
-          "required": true,
-          "secret": true
-        },
-        {
-          "name": "GITHUB_HOST",
-          "description": "GitHub Enterprise Server hostname (optional)",
-          "required": false
-        },
-        {
-          "name": "GITHUB_TOOLSETS",
-          "description": "Comma-separated list of toolsets to enable (e.g., 'repos,issues,pull_requests'). If not set, all toolsets are enabled. See the README for available toolsets.",
-          "required": false
-        },
-        {
-          "name": "GITHUB_DYNAMIC_TOOLSETS",
-          "description": "Set to '1' to enable dynamic toolset discovery",
-          "required": false
-        },
-        {
-          "name": "GITHUB_READ_ONLY",
-          "description": "Set to '1' to enable read-only mode, preventing any modifications to GitHub resources",
-          "required": false
-        }
-      ],
-      "provenance": {
-        "sigstore_url": "tuf-repo-cdn.sigstore.dev",
-        "repository_uri": "https://github.com/github/github-mcp-server",
-        "signer_identity": "/.github/workflows/docker-publish.yml",
-        "runner_environment": "github-hosted",
-        "cert_issuer": "https://token.actions.githubusercontent.com"
-      }
-    },
-    "gitlab": {
-      "description": "Provides integration with a GitLab instance to manage projects, issues, merge requests, and more.",
-      "tier": "Community",
-      "status": "Active",
-      "transport": "streamable-http",
-      "tools": [
-        "merge_merge_request",
-        "create_or_update_file",
-        "search_repositories",
-        "create_repository",
-        "get_file_contents",
-        "push_files",
-        "create_issue",
-        "create_merge_request",
-        "fork_repository",
-        "create_branch",
-        "get_merge_request",
-        "get_merge_request_diffs",
-        "list_merge_request_diffs",
-        "get_branch_diffs",
-        "update_merge_request",
-        "create_note",
-        "create_merge_request_thread",
-        "mr_discussions",
-        "update_merge_request_note",
-        "create_merge_request_note",
-        "get_draft_note",
-        "list_draft_notes",
-        "create_draft_note",
-        "update_draft_note",
-        "delete_draft_note",
-        "publish_draft_note",
-        "bulk_publish_draft_notes",
-        "update_issue_note",
-        "create_issue_note",
-        "list_issues",
-        "my_issues",
-        "get_issue",
-        "update_issue",
-        "delete_issue",
-        "list_issue_links",
-        "list_issue_discussions",
-        "get_issue_link",
-        "create_issue_link",
-        "delete_issue_link",
-        "list_namespaces",
-        "get_namespace",
-        "verify_namespace",
-        "get_project",
-        "list_projects",
-        "list_project_members",
-        "list_labels",
-        "get_label",
-        "create_label",
-        "update_label",
-        "delete_label",
-        "list_group_projects",
-        "list_wiki_pages",
-        "get_wiki_page",
-        "create_wiki_page",
-        "update_wiki_page",
-        "delete_wiki_page",
-        "get_repository_tree",
-        "list_pipelines",
-        "get_pipeline",
-        "list_pipeline_jobs",
-        "list_pipeline_trigger_jobs",
-        "get_pipeline_job",
-        "get_pipeline_job_output",
-        "create_pipeline",
-        "retry_pipeline",
-        "cancel_pipeline",
-        "list_merge_requests",
-        "list_milestones",
-        "get_milestone",
-        "create_milestone",
-        "edit_milestone",
-        "delete_milestone",
-        "get_milestone_issue",
-        "get_milestone_merge_requests",
-        "promote_milestone",
-        "get_milestone_burndown_events",
-        "get_users",
-        "list_commits",
-        "get_commit",
-        "get_commit_diff",
-        "list_group_iterations",
-        "upload_markdown",
-        "download_attachment"
-      ],
-      "metadata": {
-        "stars": 743,
-        "pulls": 34542,
-        "last_updated": "2025-11-17T02:33:29Z"
-      },
-      "repository_url": "https://github.com/zereight/gitlab-mcp",
-      "tags": [
-        "gitlab",
-        "version-control",
-        "repository",
-        "issues",
-        "merge-requests",
-        "wiki",
-        "milestones",
-        "pipelines"
-      ],
-      "image": "iwakitakuma/gitlab-mcp:2.0.13",
-      "target_port": 3002,
-      "permissions": {
-        "network": {
-          "outbound": {
-            "allow_host": [
-              ".gitlab.com",
-              ".gitlab-static.net",
-              ".gitlab.io",
-              ".gitlab.net"
+            "metadata": {
+                "stars": 231,
+                "pulls": 0,
+                "last_updated": "2025-11-17T02:33:29Z"
+            },
+            "repository_url": "https://github.com/apollographql/apollo-mcp-server",
+            "tags": [
+                "graphql",
+                "api",
+                "orchestration",
+                "apollo",
+                "mcp"
             ],
-            "allow_port": [
-              443
+            "image": "ghcr.io/apollographql/apollo-mcp-server:v1.2.1",
+            "target_port": 5000,
+            "permissions": {
+                "network": {
+                    "outbound": {
+                        "insecure_allow_all": true,
+                        "allow_port": [
+                            443
+                        ]
+                    }
+                }
+            },
+            "env_vars": [
+                {
+                    "name": "APOLLO_GRAPH_REF",
+                    "description": "Graph ref (graph ID and variant) used to fetch persisted queries or schema (required if no config file)",
+                    "required": false
+                },
+                {
+                    "name": "APOLLO_KEY",
+                    "description": "Apollo Studio API key for the graph (required if no config file)",
+                    "required": false,
+                    "secret": true
+                }
             ]
-          }
+        },
+        "arxiv-mcp-server": {
+            "description": "AI assistants search and access arXiv papers through MCP with persistent paper storage",
+            "tier": "Community",
+            "status": "Active",
+            "transport": "stdio",
+            "tools": [
+                "search_papers",
+                "download_paper",
+                "list_papers",
+                "read_paper"
+            ],
+            "metadata": {
+                "stars": 1895,
+                "pulls": 77,
+                "last_updated": "2025-11-24T02:36:20Z"
+            },
+            "repository_url": "https://github.com/blazickjp/arxiv-mcp-server",
+            "tags": [
+                "research",
+                "academic",
+                "papers",
+                "arxiv",
+                "search"
+            ],
+            "image": "ghcr.io/stacklok/dockyard/uvx/arxiv-mcp-server:0.3.1",
+            "permissions": {
+                "network": {
+                    "outbound": {
+                        "allow_host": [
+                            "arxiv.org",
+                            "export.arxiv.org"
+                        ],
+                        "allow_port": [
+                            443,
+                            80
+                        ]
+                    }
+                }
+            },
+            "env_vars": [
+                {
+                    "name": "ARXIV_STORAGE_PATH",
+                    "description": "Directory path where downloaded papers will be stored",
+                    "required": false,
+                    "default": "/arxiv-papers"
+                }
+            ],
+            "args": [
+                "--storage-path",
+                "/arxiv-papers"
+            ],
+            "provenance": {
+                "sigstore_url": "tuf-repo-cdn.sigstore.dev",
+                "repository_uri": "https://github.com/stacklok/dockyard",
+                "signer_identity": "/.github/workflows/build-containers.yml",
+                "runner_environment": "github-hosted",
+                "cert_issuer": "https://token.actions.githubusercontent.com"
+            }
+        },
+        "aws-api": {
+            "description": "Enables AI assistants to interact with AWS services and resources through AWS CLI commands",
+            "tier": "Official",
+            "status": "Active",
+            "transport": "stdio",
+            "tools": [
+                "call_aws",
+                "suggest_aws_commands"
+            ],
+            "metadata": {
+                "stars": 6955,
+                "pulls": 0,
+                "last_updated": "2025-11-07T02:32:29Z"
+            },
+            "repository_url": "https://github.com/awslabs/mcp",
+            "tags": [
+                "aws",
+                "cli",
+                "cloud",
+                "infrastructure",
+                "api",
+                "devops"
+            ],
+            "image": "public.ecr.aws/awslabs-mcp/awslabs/aws-api-mcp-server:1.1.7",
+            "permissions": {
+                "network": {
+                    "outbound": {
+                        "allow_host": [
+                            "aws.amazon.com",
+                            ".amazonaws.com"
+                        ],
+                        "allow_port": [
+                            443
+                        ]
+                    }
+                }
+            },
+            "env_vars": [
+                {
+                    "name": "AWS_REGION",
+                    "description": "Default AWS region for CLI commands unless a specific region is provided in the request",
+                    "required": false,
+                    "default": "us-east-1"
+                },
+                {
+                    "name": "AWS_ACCESS_KEY_ID",
+                    "description": "AWS access key ID for authentication",
+                    "required": false,
+                    "secret": true
+                },
+                {
+                    "name": "AWS_SECRET_ACCESS_KEY",
+                    "description": "AWS secret access key for authentication",
+                    "required": false,
+                    "secret": true
+                },
+                {
+                    "name": "AWS_SESSION_TOKEN",
+                    "description": "AWS session token for temporary credentials",
+                    "required": false,
+                    "secret": true
+                },
+                {
+                    "name": "READ_OPERATIONS_ONLY",
+                    "description": "When set to \"true\", restricts execution to read-only operations",
+                    "required": false,
+                    "default": "false"
+                },
+                {
+                    "name": "REQUIRE_MUTATION_CONSENT",
+                    "description": "When set to \"true\", asks explicit consent before executing non-read-only operations",
+                    "required": false,
+                    "default": "false"
+                },
+                {
+                    "name": "AWS_API_MCP_WORKING_DIR",
+                    "description": "Working directory path for MCP server operations (must be absolute path)",
+                    "required": false
+                },
+                {
+                    "name": "AWS_API_MCP_ALLOW_UNRESTRICTED_LOCAL_FILE_ACCESS",
+                    "description": "When set to \"true\", enables system-wide file access (may cause unintended overwrites)",
+                    "required": false,
+                    "default": "false"
+                },
+                {
+                    "name": "AWS_API_MCP_TELEMETRY",
+                    "description": "Allow sending additional telemetry data to AWS related to server configuration",
+                    "required": false,
+                    "default": "true"
+                },
+                {
+                    "name": "EXPERIMENTAL_AGENT_SCRIPTS",
+                    "description": "When set to \"true\", enables experimental agent scripts functionality",
+                    "required": false,
+                    "default": "false"
+                },
+                {
+                    "name": "AWS_API_MCP_AGENT_SCRIPTS_DIR",
+                    "description": "Directory path containing custom user scripts for agent scripts functionality",
+                    "required": false
+                }
+            ]
+        },
+        "browserbase": {
+            "description": "MCP server for cloud browser automation with Browserbase and Stagehand",
+            "tier": "Official",
+            "status": "Active",
+            "transport": "stdio",
+            "tools": [
+                "browserbase_screenshot",
+                "browserbase_session_close",
+                "browserbase_session_create",
+                "browserbase_stagehand_act",
+                "browserbase_stagehand_agent",
+                "browserbase_stagehand_extract",
+                "browserbase_stagehand_get_url",
+                "browserbase_stagehand_navigate",
+                "browserbase_stagehand_observe"
+            ],
+            "metadata": {
+                "stars": 2757,
+                "pulls": 133,
+                "last_updated": "2025-11-01T02:32:39Z"
+            },
+            "repository_url": "https://github.com/browserbase/mcp-server-browserbase",
+            "tags": [
+                "browser",
+                "automation",
+                "web-scraping",
+                "testing",
+                "stagehand"
+            ],
+            "image": "ghcr.io/stacklok/dockyard/npx/browserbase-mcp-server:2.4.1",
+            "permissions": {
+                "network": {
+                    "outbound": {
+                        "insecure_allow_all": true
+                    }
+                }
+            },
+            "env_vars": [
+                {
+                    "name": "BROWSERBASE_API_KEY",
+                    "description": "Browserbase API key",
+                    "required": true,
+                    "secret": true
+                },
+                {
+                    "name": "BROWSERBASE_PROJECT_ID",
+                    "description": "Browserbase project ID",
+                    "required": true
+                },
+                {
+                    "name": "GEMINI_API_KEY",
+                    "description": "Google Gemini API key for Stagehand",
+                    "required": true,
+                    "secret": true
+                }
+            ],
+            "provenance": {
+                "sigstore_url": "tuf-repo-cdn.sigstore.dev",
+                "repository_uri": "https://github.com/stacklok/dockyard",
+                "signer_identity": "/.github/workflows/build-containers.yml",
+                "runner_environment": "github-hosted",
+                "cert_issuer": "https://token.actions.githubusercontent.com"
+            }
+        },
+        "chrome-devtools-mcp": {
+            "description": "Control and inspect live Chrome browser from AI coding agents with full DevTools access",
+            "tier": "Official",
+            "status": "Active",
+            "transport": "stdio",
+            "tools": [
+                "click",
+                "drag",
+                "fill",
+                "fill_form",
+                "handle_dialog",
+                "hover",
+                "press_key",
+                "upload_file",
+                "close_page",
+                "list_pages",
+                "navigate_page",
+                "new_page",
+                "select_page",
+                "wait_for",
+                "emulate",
+                "resize_page",
+                "performance_analyze_insight",
+                "performance_start_trace",
+                "performance_stop_trace",
+                "get_network_request",
+                "list_network_requests",
+                "evaluate_script",
+                "get_console_message",
+                "list_console_messages",
+                "take_screenshot",
+                "take_snapshot"
+            ],
+            "metadata": {
+                "stars": 14453,
+                "pulls": 0,
+                "last_updated": "2025-11-12T00:00:00Z"
+            },
+            "repository_url": "https://github.com/ChromeDevTools/chrome-devtools-mcp",
+            "tags": [
+                "chrome",
+                "devtools",
+                "browser",
+                "automation",
+                "debugging",
+                "performance",
+                "puppeteer",
+                "testing"
+            ],
+            "image": "ghcr.io/stacklok/dockyard/npx/chrome-devtools-mcp:0.10.2",
+            "permissions": {
+                "network": {
+                    "outbound": {
+                        "insecure_allow_all": true,
+                        "allow_port": [
+                            443,
+                            80
+                        ]
+                    }
+                }
+            },
+            "provenance": {
+                "sigstore_url": "tuf-repo-cdn.sigstore.dev",
+                "repository_uri": "https://github.com/stacklok/dockyard",
+                "signer_identity": "/.github/workflows/build-containers.yml",
+                "runner_environment": "github-hosted",
+                "cert_issuer": "https://token.actions.githubusercontent.com"
+            }
+        },
+        "crowdstrike-falcon": {
+            "description": "CrowdStrike Falcon integration for security analysis, detections, incidents, and threat intel",
+            "tier": "Official",
+            "status": "Active",
+            "transport": "streamable-http",
+            "tools": [
+                "falcon_check_connectivity",
+                "falcon_get_available_modules",
+                "falcon_search_detections",
+                "falcon_get_detection_details",
+                "falcon_show_crowd_score",
+                "falcon_search_incidents",
+                "falcon_get_incident_details",
+                "falcon_search_behaviors",
+                "falcon_get_behavior_details",
+                "falcon_search_actors",
+                "falcon_search_indicators",
+                "falcon_search_reports",
+                "falcon_search_hosts",
+                "falcon_get_host_details",
+                "falcon_search_vulnerabilities",
+                "falcon_search_kubernetes_containers",
+                "falcon_count_kubernetes_containers",
+                "falcon_search_images_vulnerabilities",
+                "idp_investigate_entity"
+            ],
+            "metadata": {
+                "stars": 73,
+                "pulls": 3771,
+                "last_updated": "2025-11-13T02:33:35Z"
+            },
+            "repository_url": "https://github.com/crowdstrike/falcon-mcp",
+            "tags": [
+                "crowdstrike",
+                "falcon",
+                "security",
+                "cybersecurity",
+                "threat-intelligence",
+                "detections",
+                "incidents",
+                "vulnerabilities",
+                "endpoint-security",
+                "threat-hunting",
+                "incident-response",
+                "malware-analysis",
+                "identity-protection",
+                "cloud-security"
+            ],
+            "image": "quay.io/crowdstrike/falcon-mcp:latest",
+            "target_port": 8000,
+            "permissions": {
+                "network": {
+                    "outbound": {
+                        "allow_host": [
+                            "api.crowdstrike.com",
+                            "api.us-2.crowdstrike.com",
+                            "api.eu-1.crowdstrike.com",
+                            "api.laggar.gcw.crowdstrike.com"
+                        ],
+                        "allow_port": [
+                            443
+                        ]
+                    }
+                }
+            },
+            "env_vars": [
+                {
+                    "name": "FALCON_CLIENT_ID",
+                    "description": "CrowdStrike API client ID",
+                    "required": true,
+                    "secret": true
+                },
+                {
+                    "name": "FALCON_CLIENT_SECRET",
+                    "description": "CrowdStrike API client secret",
+                    "required": true,
+                    "secret": true
+                },
+                {
+                    "name": "FALCON_BASE_URL",
+                    "description": "CrowdStrike API base URL (e.g., https://api.crowdstrike.com, https://api.us-2.crowdstrike.com, https://api.eu-1.crowdstrike.com)",
+                    "required": true
+                },
+                {
+                    "name": "FALCON_MCP_MODULES",
+                    "description": "Comma-separated list of modules to enable (detections,incidents,intel,hosts,spotlight,cloud,idp). If not set, all modules are enabled.",
+                    "required": false
+                },
+                {
+                    "name": "FALCON_MCP_DEBUG",
+                    "description": "Enable debug logging - true or false (default: false)",
+                    "required": false
+                }
+            ],
+            "args": [
+                "--transport",
+                "streamable-http",
+                "--host",
+                "0.0.0.0",
+                "--port",
+                "8000"
+            ]
+        },
+        "fetch": {
+            "description": "Allows you to fetch content from the web",
+            "tier": "Community",
+            "status": "Active",
+            "transport": "streamable-http",
+            "tools": [
+                "fetch"
+            ],
+            "metadata": {
+                "stars": 20,
+                "pulls": 12390,
+                "last_updated": "2025-11-13T02:33:35Z"
+            },
+            "repository_url": "https://github.com/stackloklabs/gofetch",
+            "tags": [
+                "content",
+                "html",
+                "markdown",
+                "fetch",
+                "fetching",
+                "get",
+                "wget",
+                "json",
+                "curl",
+                "modelcontextprotocol"
+            ],
+            "image": "ghcr.io/stackloklabs/gofetch/server:1.0.1",
+            "target_port": 8080,
+            "permissions": {
+                "network": {
+                    "outbound": {
+                        "insecure_allow_all": true,
+                        "allow_port": [
+                            443
+                        ]
+                    }
+                }
+            },
+            "provenance": {
+                "sigstore_url": "tuf-repo-cdn.sigstore.dev",
+                "repository_uri": "https://github.com/StacklokLabs/gofetch",
+                "signer_identity": "/.github/workflows/release.yml",
+                "runner_environment": "github-hosted",
+                "cert_issuer": "https://token.actions.githubusercontent.com"
+            }
+        },
+        "filesystem": {
+            "description": "Allows you to do filesystem operations. Mount paths under /projects using --volume.",
+            "tier": "Community",
+            "status": "Active",
+            "transport": "stdio",
+            "tools": [
+                "read_file",
+                "read_multiple_files",
+                "write_file",
+                "edit_file",
+                "create_directory",
+                "list_directory",
+                "directory_tree",
+                "move_file",
+                "search_files",
+                "get_file_info",
+                "list_allowed_directories"
+            ],
+            "metadata": {
+                "stars": 71855,
+                "pulls": 20619,
+                "last_updated": "2025-11-04T02:32:45Z"
+            },
+            "repository_url": "https://github.com/modelcontextprotocol/servers",
+            "tags": [
+                "create_directory",
+                "edit_file",
+                "filesystem",
+                "get_file_info",
+                "implementing",
+                "list_allowed_directories",
+                "list_directory",
+                "move_file",
+                "node",
+                "operations"
+            ],
+            "image": "docker.io/mcp/filesystem:latest",
+            "permissions": {
+                "network": {
+                    "outbound": {}
+                }
+            },
+            "args": [
+                "/projects"
+            ]
+        },
+        "genai-toolbox": {
+            "description": "Will be removed soon. Please use database-toolbox instead.",
+            "tier": "Official",
+            "status": "Deprecated",
+            "transport": "sse",
+            "tools": [
+                "set_during_runtime"
+            ],
+            "metadata": {
+                "stars": 11251,
+                "pulls": 2408,
+                "last_updated": "2025-11-02T02:34:09Z"
+            },
+            "repository_url": "https://github.com/googleapis/genai-toolbox",
+            "tags": [
+                "database",
+                "sql",
+                "postgresql",
+                "mysql",
+                "sqlite",
+                "mongodb",
+                "redis",
+                "connection-pooling",
+                "authentication",
+                "observability",
+                "toolbox",
+                "genai",
+                "mcp-server"
+            ],
+            "image": "us-central1-docker.pkg.dev/database-toolbox/toolbox/toolbox:0.21.0",
+            "target_port": 5000,
+            "permissions": {
+                "network": {
+                    "outbound": {
+                        "insecure_allow_all": true
+                    }
+                }
+            }
+        },
+        "github": {
+            "description": "Provides integration with GitHub's APIs",
+            "tier": "Official",
+            "status": "Active",
+            "transport": "stdio",
+            "tools": [
+                "add_comment_to_pending_review",
+                "add_issue_comment",
+                "assign_copilot_to_issue",
+                "create_branch",
+                "create_or_update_file",
+                "create_pull_request",
+                "create_repository",
+                "delete_file",
+                "fork_repository",
+                "get_commit",
+                "get_file_contents",
+                "get_label",
+                "get_latest_release",
+                "get_me",
+                "get_release_by_tag",
+                "get_tag",
+                "get_team_members",
+                "get_teams",
+                "issue_read",
+                "issue_write",
+                "list_branches",
+                "list_commits",
+                "list_issue_types",
+                "list_issues",
+                "list_pull_requests",
+                "list_releases",
+                "list_tags",
+                "merge_pull_request",
+                "pull_request_read",
+                "pull_request_review_write",
+                "push_files",
+                "request_copilot_review",
+                "search_code",
+                "search_issues",
+                "search_pull_requests",
+                "search_repositories",
+                "search_users",
+                "sub_issue_write",
+                "update_pull_request",
+                "update_pull_request_branch"
+            ],
+            "metadata": {
+                "stars": 24254,
+                "pulls": 5000,
+                "last_updated": "2025-11-06T02:33:26Z"
+            },
+            "repository_url": "https://github.com/github/github-mcp-server",
+            "tags": [
+                "api",
+                "create",
+                "fork",
+                "github",
+                "list",
+                "pull-request",
+                "push",
+                "repository",
+                "search",
+                "update",
+                "issues"
+            ],
+            "image": "ghcr.io/github/github-mcp-server:v0.22.0",
+            "permissions": {
+                "network": {
+                    "outbound": {
+                        "allow_host": [
+                            ".github.com",
+                            ".githubusercontent.com"
+                        ],
+                        "allow_port": [
+                            443
+                        ]
+                    }
+                }
+            },
+            "env_vars": [
+                {
+                    "name": "GITHUB_PERSONAL_ACCESS_TOKEN",
+                    "description": "GitHub personal access token with appropriate permissions",
+                    "required": true,
+                    "secret": true
+                },
+                {
+                    "name": "GITHUB_HOST",
+                    "description": "GitHub Enterprise Server hostname (optional)",
+                    "required": false
+                },
+                {
+                    "name": "GITHUB_TOOLSETS",
+                    "description": "Comma-separated list of toolsets to enable (e.g., 'repos,issues,pull_requests'). If not set, all toolsets are enabled. See the README for available toolsets.",
+                    "required": false
+                },
+                {
+                    "name": "GITHUB_DYNAMIC_TOOLSETS",
+                    "description": "Set to '1' to enable dynamic toolset discovery",
+                    "required": false
+                },
+                {
+                    "name": "GITHUB_READ_ONLY",
+                    "description": "Set to '1' to enable read-only mode, preventing any modifications to GitHub resources",
+                    "required": false
+                }
+            ],
+            "provenance": {
+                "sigstore_url": "tuf-repo-cdn.sigstore.dev",
+                "repository_uri": "https://github.com/github/github-mcp-server",
+                "signer_identity": "/.github/workflows/docker-publish.yml",
+                "runner_environment": "github-hosted",
+                "cert_issuer": "https://token.actions.githubusercontent.com"
+            }
+        },
+        "gitlab": {
+            "description": "Provides integration with a GitLab instance to manage projects, issues, merge requests, and more.",
+            "tier": "Community",
+            "status": "Active",
+            "transport": "streamable-http",
+            "tools": [
+                "merge_merge_request",
+                "create_or_update_file",
+                "search_repositories",
+                "create_repository",
+                "get_file_contents",
+                "push_files",
+                "create_issue",
+                "create_merge_request",
+                "fork_repository",
+                "create_branch",
+                "get_merge_request",
+                "get_merge_request_diffs",
+                "list_merge_request_diffs",
+                "get_branch_diffs",
+                "update_merge_request",
+                "create_note",
+                "create_merge_request_thread",
+                "mr_discussions",
+                "update_merge_request_note",
+                "create_merge_request_note",
+                "get_draft_note",
+                "list_draft_notes",
+                "create_draft_note",
+                "update_draft_note",
+                "delete_draft_note",
+                "publish_draft_note",
+                "bulk_publish_draft_notes",
+                "update_issue_note",
+                "create_issue_note",
+                "list_issues",
+                "my_issues",
+                "get_issue",
+                "update_issue",
+                "delete_issue",
+                "list_issue_links",
+                "list_issue_discussions",
+                "get_issue_link",
+                "create_issue_link",
+                "delete_issue_link",
+                "list_namespaces",
+                "get_namespace",
+                "verify_namespace",
+                "get_project",
+                "list_projects",
+                "list_project_members",
+                "list_labels",
+                "get_label",
+                "create_label",
+                "update_label",
+                "delete_label",
+                "list_group_projects",
+                "list_wiki_pages",
+                "get_wiki_page",
+                "create_wiki_page",
+                "update_wiki_page",
+                "delete_wiki_page",
+                "get_repository_tree",
+                "list_pipelines",
+                "get_pipeline",
+                "list_pipeline_jobs",
+                "list_pipeline_trigger_jobs",
+                "get_pipeline_job",
+                "get_pipeline_job_output",
+                "create_pipeline",
+                "retry_pipeline",
+                "cancel_pipeline",
+                "list_merge_requests",
+                "list_milestones",
+                "get_milestone",
+                "create_milestone",
+                "edit_milestone",
+                "delete_milestone",
+                "get_milestone_issue",
+                "get_milestone_merge_requests",
+                "promote_milestone",
+                "get_milestone_burndown_events",
+                "get_users",
+                "list_commits",
+                "get_commit",
+                "get_commit_diff",
+                "list_group_iterations",
+                "upload_markdown",
+                "download_attachment"
+            ],
+            "metadata": {
+                "stars": 743,
+                "pulls": 34542,
+                "last_updated": "2025-11-17T02:33:29Z"
+            },
+            "repository_url": "https://github.com/zereight/gitlab-mcp",
+            "tags": [
+                "gitlab",
+                "version-control",
+                "repository",
+                "issues",
+                "merge-requests",
+                "wiki",
+                "milestones",
+                "pipelines"
+            ],
+            "image": "iwakitakuma/gitlab-mcp:2.0.13",
+            "target_port": 3002,
+            "permissions": {
+                "network": {
+                    "outbound": {
+                        "allow_host": [
+                            ".gitlab.com",
+                            ".gitlab-static.net",
+                            ".gitlab.io",
+                            ".gitlab.net"
+                        ],
+                        "allow_port": [
+                            443
+                        ]
+                    }
+                }
+            },
+            "env_vars": [
+                {
+                    "name": "GITLAB_PERSONAL_ACCESS_TOKEN",
+                    "description": "Your GitLab personal access token.",
+                    "required": true,
+                    "secret": true
+                },
+                {
+                    "name": "GITLAB_API_URL",
+                    "description": "Your GitLab API URL.",
+                    "required": false,
+                    "default": "https://gitlab.com/api/v4"
+                },
+                {
+                    "name": "GITLAB_PROJECT_ID",
+                    "description": "Default project ID. If set, overwrite this value when making an API request.",
+                    "required": false
+                },
+                {
+                    "name": "GITLAB_ALLOWED_PROJECT_IDS",
+                    "description": "Optional comma-separated list of allowed project IDs. When set with a single value, acts as a default project.",
+                    "required": false
+                },
+                {
+                    "name": "GITLAB_READ_ONLY_MODE",
+                    "description": "When set to 'true', restricts the server to only expose read-only operations.",
+                    "required": false
+                },
+                {
+                    "name": "USE_GITLAB_WIKI",
+                    "description": "When set to 'true', enables the wiki-related tools. By default, wiki features are disabled.",
+                    "required": false
+                },
+                {
+                    "name": "USE_MILESTONE",
+                    "description": "When set to 'true', enables the milestone-related tools. By default, milestone features are disabled.",
+                    "required": false
+                },
+                {
+                    "name": "USE_PIPELINE",
+                    "description": "When set to 'true', enables the pipeline-related tools. By default, pipeline features are disabled.",
+                    "required": false
+                },
+                {
+                    "name": "GITLAB_AUTH_COOKIE_PATH",
+                    "description": "Path to an authentication cookie file for GitLab instances that require cookie-based authentication.",
+                    "required": false
+                },
+                {
+                    "name": "SSE",
+                    "description": "When set to 'true', enables the Server-Sent Events transport.",
+                    "required": false
+                },
+                {
+                    "name": "STREAMABLE_HTTP",
+                    "description": "When set to 'true', enables the Streamable HTTP transport. If both SSE and STREAMABLE_HTTP are set to 'true', Streamable HTTP is used.",
+                    "required": false,
+                    "default": "true"
+                }
+            ]
+        },
+        "oixa-protocol": {
+            "description": "OIXA Protocol \u2014 AI agent marketplace. AI agents earn real USDC by participating in reverse auctions. Register capabilities, bid on tasks, deliver work, get paid automatically via Base escrow.",
+            "tier": "Community",
+            "status": "Active",
+            "transport": "http",
+            "tools": [
+                "find_work",
+                "bid_on_task",
+                "hire_agent",
+                "receive_payment",
+                "register_capabilities",
+                "spot_compute_buy",
+                "spot_compute_sell",
+                "market_intelligence"
+            ],
+            "metadata": {
+                "stars": 0,
+                "pulls": 0,
+                "last_updated": "2026-03-26T00:00:00Z"
+            },
+            "repository_url": "https://github.com/ivoshemi-sys/oixa-protocol",
+            "homepage": "https://oixa.io",
+            "tags": [
+                "agent-marketplace",
+                "usdc-payments",
+                "reverse-auction",
+                "ai-agents",
+                "base-blockchain",
+                "a2a",
+                "mcp",
+                "earn-usdc"
+            ],
+            "mcp_endpoint": "https://oixa.io/mcp",
+            "permissions": {
+                "network": {
+                    "outbound": {
+                        "insecure_allow_all": true
+                    }
+                }
+            },
+            "env_vars": [
+                {
+                    "name": "OIXA_BASE_URL",
+                    "description": "OIXA Protocol API base URL (default: https://oixa.io)",
+                    "required": false
+                }
+            ]
         }
-      },
-      "env_vars": [
-        {
-          "name": "GITLAB_PERSONAL_ACCESS_TOKEN",
-          "description": "Your GitLab personal access token.",
-          "required": true,
-          "secret": true
-        },
-        {
-          "name": "GITLAB_API_URL",
-          "description": "Your GitLab API URL.",
-          "required": false,
-          "default": "https://gitlab.com/api/v4"
-        },
-        {
-          "name": "GITLAB_PROJECT_ID",
-          "description": "Default project ID. If set, overwrite this value when making an API request.",
-          "required": false
-        },
-        {
-          "name": "GITLAB_ALLOWED_PROJECT_IDS",
-          "description": "Optional comma-separated list of allowed project IDs. When set with a single value, acts as a default project.",
-          "required": false
-        },
-        {
-          "name": "GITLAB_READ_ONLY_MODE",
-          "description": "When set to 'true', restricts the server to only expose read-only operations.",
-          "required": false
-        },
-        {
-          "name": "USE_GITLAB_WIKI",
-          "description": "When set to 'true', enables the wiki-related tools. By default, wiki features are disabled.",
-          "required": false
-        },
-        {
-          "name": "USE_MILESTONE",
-          "description": "When set to 'true', enables the milestone-related tools. By default, milestone features are disabled.",
-          "required": false
-        },
-        {
-          "name": "USE_PIPELINE",
-          "description": "When set to 'true', enables the pipeline-related tools. By default, pipeline features are disabled.",
-          "required": false
-        },
-        {
-          "name": "GITLAB_AUTH_COOKIE_PATH",
-          "description": "Path to an authentication cookie file for GitLab instances that require cookie-based authentication.",
-          "required": false
-        },
-        {
-          "name": "SSE",
-          "description": "When set to 'true', enables the Server-Sent Events transport.",
-          "required": false
-        },
-        {
-          "name": "STREAMABLE_HTTP",
-          "description": "When set to 'true', enables the Streamable HTTP transport. If both SSE and STREAMABLE_HTTP are set to 'true', Streamable HTTP is used.",
-          "required": false,
-          "default": "true"
-        }
-      ]
     }
-  }
 }


### PR DESCRIPTION
## Summary

Adds OIXA Protocol to `examples/toolhive-registry.json` as a Community-tier MCP server.

**OIXA Protocol** is an open AI agent marketplace where agents earn real USDC:
- MCP endpoint: `https://oixa.io/mcp` (8 tools: find_work, bid_on_task, hire_agent, receive_payment, register_capabilities, spot_compute_buy, spot_compute_sell, market_intelligence)
- Transport: HTTP
- A2A compatible: `https://oixa.io/.well-known/agent.json`
- Open source (MIT): https://github.com/ivoshemi-sys/oixa-protocol

## Test plan
- [ ] Verify `examples/toolhive-registry.json` is valid JSON against schema
- [ ] Confirm MCP endpoint is reachable: `curl https://oixa.io/mcp/tools`