### PR TITLE
Fix claims containment check

### DIFF
--- a/internal/service/db/claims_filter.go
+++ b/internal/service/db/claims_filter.go
@@ -44,11 +44,18 @@ func marshalClaims(callerClaims map[string]any) []byte {
 	return b
 }
 
-// checkClaims returns true only when both callerJSON and recordJSON are
-// non-empty and represent the same JSON object.
+// checkClaims returns true only when callerJSON satisfies every claim in recordJSON.
+// The caller's claims must be a superset of the record's claims (containment, not equality).
 func checkClaims(callerJSON, recordJSON []byte) bool {
 	if len(callerJSON) == 0 || len(recordJSON) == 0 {
 		return false
 	}
-	return claimsMatch(callerJSON, recordJSON)
+	var caller, record map[string]any
+	if err := json.Unmarshal(callerJSON, &caller); err != nil {
+		return false
+	}
+	if err := json.Unmarshal(recordJSON, &record); err != nil {
+		return false
+	}
+	return claimsContain(caller, record)
 }

--- a/internal/service/db/claims_filter_test.go
+++ b/internal/service/db/claims_filter_test.go
@@ -60,6 +60,12 @@ func TestNewClaimsFilterWith(t *testing.T) {
 			wantKeep:     false,
 		},
 		{
+			name:         "caller superset of record claims keeps record",
+			callerClaims: map[string]any{"sub": "user1", "org": "acme"},
+			record:       mustMarshal(t, map[string]any{"sub": "user1"}),
+			wantKeep:     true,
+		},
+		{
 			name:         "wrong record type returns error",
 			callerClaims: map[string]any{"sub": "user1"},
 			record:       "not-bytes",
@@ -147,6 +153,42 @@ func TestCheckClaims(t *testing.T) {
 			name:       "invalid record JSON returns false",
 			callerJSON: []byte(`{"sub":"user1"}`),
 			recordJSON: []byte(`{invalid`),
+			want:       false,
+		},
+		{
+			name:       "caller superset keeps record",
+			callerJSON: []byte(`{"sub":"u1","org":"acme"}`),
+			recordJSON: []byte(`{"sub":"u1"}`),
+			want:       true,
+		},
+		{
+			name:       "caller missing required key drops record",
+			callerJSON: []byte(`{"org":"acme"}`),
+			recordJSON: []byte(`{"sub":"u1"}`),
+			want:       false,
+		},
+		{
+			name:       "record list subset of caller list",
+			callerJSON: []byte(`{"roles":["a","b","c"]}`),
+			recordJSON: []byte(`{"roles":["a","b"]}`),
+			want:       true,
+		},
+		{
+			name:       "record list not subset of caller list drops record",
+			callerJSON: []byte(`{"roles":["a"]}`),
+			recordJSON: []byte(`{"roles":["a","b"]}`),
+			want:       false,
+		},
+		{
+			name:       "record string caller list containing it",
+			callerJSON: []byte(`{"sub":["u1","u2"]}`),
+			recordJSON: []byte(`{"sub":"u1"}`),
+			want:       true,
+		},
+		{
+			name:       "record string caller list not containing it drops record",
+			callerJSON: []byte(`{"sub":["u2"]}`),
+			recordJSON: []byte(`{"sub":"u1"}`),
 			want:       false,
 		},
 	}

--- a/internal/service/db/impl_mcp.go
+++ b/internal/service/db/impl_mcp.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"reflect"
 	"time"
 
 	"github.com/go-chi/chi/v5/middleware"
@@ -379,7 +378,10 @@ func insertServerVersionData(
 		// Verify claim consistency: if both the existing entry and the new
 		// publish request carry claims, they must match.
 		if claimsJSON != nil && existing.Claims != nil {
-			if !claimsMatch(existing.Claims, claimsJSON) {
+			var existingClaims, incoming map[string]any
+			_ = json.Unmarshal(existing.Claims, &existingClaims)
+			_ = json.Unmarshal(claimsJSON, &incoming)
+			if !claimsContain(incoming, existingClaims) {
 				return uuid.Nil, fmt.Errorf("%w: claims do not match existing entry", service.ErrClaimsMismatch)
 			}
 		}
@@ -881,16 +883,43 @@ func cleanupOrphanedEntry(
 	return nil
 }
 
-// claimsMatch compares two JSONB claim values for equality.
-func claimsMatch(a, b []byte) bool {
-	var ma, mb map[string]any
-	if err := json.Unmarshal(a, &ma); err != nil {
-		return false
+// claimsContain reports whether callerClaims satisfies every claim in recordClaims.
+// For each key K in recordClaims the caller must have K, and every value required
+// by the record must appear in the caller's value(s) for K.
+// Both plain strings and []string values are supported.
+func claimsContain(caller, record map[string]any) bool {
+	for k, rv := range record {
+		cv, ok := caller[k]
+		if !ok {
+			return false
+		}
+		required := toStringSet(rv)
+		have := toStringSet(cv)
+		for v := range required {
+			if _, found := have[v]; !found {
+				return false
+			}
+		}
 	}
-	if err := json.Unmarshal(b, &mb); err != nil {
-		return false
+	return true
+}
+
+// toStringSet normalises a claim value (string or []any of strings) to a set.
+func toStringSet(v any) map[string]struct{} {
+	switch val := v.(type) {
+	case string:
+		return map[string]struct{}{val: {}}
+	case []any:
+		s := make(map[string]struct{}, len(val))
+		for _, elem := range val {
+			if str, ok := elem.(string); ok {
+				s[str] = struct{}{}
+			}
+		}
+		return s
+	default:
+		return map[string]struct{}{}
 	}
-	return reflect.DeepEqual(ma, mb)
 }
 
 // querierFunction is a function that uses the given querier object to run the

--- a/internal/service/db/impl_skills.go
+++ b/internal/service/db/impl_skills.go
@@ -381,7 +381,10 @@ func (s *dbService) executePublishSkillTransaction(
 		// Verify claim consistency: if both the existing entry and the new
 		// publish request carry claims, they must match.
 		if claimsJSON != nil && existing.Claims != nil {
-			if !claimsMatch(existing.Claims, claimsJSON) {
+			var existingClaims, incoming map[string]any
+			_ = json.Unmarshal(existing.Claims, &existingClaims)
+			_ = json.Unmarshal(claimsJSON, &incoming)
+			if !claimsContain(incoming, existingClaims) {
 				return "", fmt.Errorf("%w: claims do not match existing entry", service.ErrClaimsMismatch)
 			}
 		}


### PR DESCRIPTION
Replace `claimsMatch` (`reflect.DeepEqual`) with `claimsContain`, which verifies that the caller's claims are a superset of the record's required claims. This applies at both read time (`checkClaims` in `claims_filter.go`) and write time (upsert consistency in `impl_mcp.go` and `impl_skills.go`). Both plain `string` and `[]string` claim values are supported. `claimsMatch` and its `reflect` import are removed.

References #444