### PR TITLE
Fix ORDER BY clauses in listing queries

### DIFF
--- a/database/queries/registry_entries.sql
+++ b/database/queries/registry_entries.sql
@@ -93,7 +93,7 @@ SELECT e.entry_type,
   FROM registry_entry e
   JOIN entry_version v ON v.entry_id = e.id
  WHERE e.source_id = sqlc.arg(source_id)
- ORDER BY e.name ASC, v.version ASC;
+ ORDER BY v.name ASC, v.version ASC;
 
 -- name: ListEntriesByRegistry :many
 SELECT e.entry_type,
@@ -106,4 +106,4 @@ SELECT e.entry_type,
   JOIN registry_entry e ON e.source_id = rs.source_id
   JOIN entry_version v ON v.entry_id = e.id
  WHERE rs.registry_id = sqlc.arg(registry_id)
- ORDER BY rs.position ASC, e.name ASC, v.version ASC;
+ ORDER BY v.name ASC, v.version ASC, rs.position ASC;

--- a/internal/db/sqlc/registry_entries.sql.go
+++ b/internal/db/sqlc/registry_entries.sql.go
@@ -219,7 +219,7 @@ SELECT e.entry_type,
   JOIN registry_entry e ON e.source_id = rs.source_id
   JOIN entry_version v ON v.entry_id = e.id
  WHERE rs.registry_id = $1
- ORDER BY rs.position ASC, e.name ASC, v.version ASC
+ ORDER BY v.name ASC, v.version ASC, rs.position ASC
 `
 
 type ListEntriesByRegistryRow struct {
@@ -268,7 +268,7 @@ SELECT e.entry_type,
   FROM registry_entry e
   JOIN entry_version v ON v.entry_id = e.id
  WHERE e.source_id = $1
- ORDER BY e.name ASC, v.version ASC
+ ORDER BY v.name ASC, v.version ASC
 `
 
 type ListEntriesBySourceRow struct {


### PR DESCRIPTION
## Summary
- Addresses review feedback from #639
- Use `v.name` instead of `e.name` for ordering in `ListEntriesBySource`
- Reorder columns in `ListEntriesByRegistry` ORDER BY to prioritize `v.name` and `v.version` over `rs.position`

## Test plan
- [x] `task test` passes
- [x] `task lint-fix` clean
- [x] sqlc regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)