### PR TITLE
Part 1: Add registry access gate and publish/delete claim validation

### DIFF
--- a/internal/api/registry/v01/routes.go
+++ b/internal/api/registry/v01/routes.go
@@ -54,6 +54,8 @@ func registryRouter(routes *Routes) http.Handler {
 }
 
 // handleListServers is a shared helper that handles listing servers with a registry name.
+//
+//nolint:gocyclo // complexity driven by many optional query parameters
 func (routes *Routes) handleListServers(w http.ResponseWriter, r *http.Request, registryName string) {
 	// Parse query parameters
 	query := r.URL.Query()
@@ -118,6 +120,10 @@ func (routes *Routes) handleListServers(w http.ResponseWriter, r *http.Request, 
 
 	listResult, err := routes.service.ListServers(r.Context(), opts...)
 	if err != nil {
+		if errors.Is(err, service.ErrClaimsInsufficient) {
+			common.WriteErrorResponse(w, "forbidden: insufficient claims for registry", http.StatusForbidden)
+			return
+		}
 		if errors.Is(err, service.ErrRegistryNotFound) {
 			common.WriteErrorResponse(w, err.Error(), http.StatusNotFound)
 			return
@@ -205,6 +211,10 @@ func (routes *Routes) handleListVersions(w http.ResponseWriter, r *http.Request,
 
 	versions, err := routes.service.ListServerVersions(r.Context(), opts...)
 	if err != nil {
+		if errors.Is(err, service.ErrClaimsInsufficient) {
+			common.WriteErrorResponse(w, "forbidden: insufficient claims for registry", http.StatusForbidden)
+			return
+		}
 		if errors.Is(err, service.ErrRegistryNotFound) {
 			common.WriteErrorResponse(w, err.Error(), http.StatusNotFound)
 			return
@@ -293,6 +303,10 @@ func (routes *Routes) handleGetVersion(w http.ResponseWriter, r *http.Request, r
 
 	server, err := routes.service.GetServerVersion(r.Context(), opts...)
 	if err != nil {
+		if errors.Is(err, service.ErrClaimsInsufficient) {
+			common.WriteErrorResponse(w, "forbidden: insufficient claims for registry", http.StatusForbidden)
+			return
+		}
 		if errors.Is(err, service.ErrRegistryNotFound) || errors.Is(err, service.ErrNotFound) {
 			common.WriteErrorResponse(w, err.Error(), http.StatusNotFound)
 			return

--- a/internal/api/registry/v01/routes_test.go
+++ b/internal/api/registry/v01/routes_test.go
@@ -130,6 +130,18 @@ func TestListServers(t *testing.T) {
 			wantStatus: http.StatusBadRequest,
 		},
 		{
+			name: "list servers with registry name - insufficient claims",
+			path: "/gated/v0.1/servers",
+			setupMocks: func(m *mocks.MockRegistryService) {
+				m.EXPECT().ListServers(gomock.Any(), gomock.Any()).
+					Return(nil, service.ErrClaimsInsufficient)
+			},
+			setupRouter: func(mockSvc *mocks.MockRegistryService) http.Handler {
+				return Router(mockSvc)
+			},
+			wantStatus: http.StatusForbidden,
+		},
+		{
 			name: "list servers with registry name - registry not found",
 			path: "/nonexistent/v0.1/servers",
 			setupMocks: func(m *mocks.MockRegistryService) {
@@ -209,6 +221,18 @@ func TestListVersions(t *testing.T) {
 				return Router(mockSvc)
 			},
 			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name: "list versions with registry name - insufficient claims",
+			path: "/gated/v0.1/servers/com.example%2Ftest-server/versions",
+			setupMocks: func(m *mocks.MockRegistryService) {
+				m.EXPECT().ListServerVersions(gomock.Any(), gomock.Any()).
+					Return(nil, service.ErrClaimsInsufficient)
+			},
+			setupRouter: func(mockSvc *mocks.MockRegistryService) http.Handler {
+				return Router(mockSvc)
+			},
+			wantStatus: http.StatusForbidden,
 		},
 		{
 			name: "list versions with registry name - registry not found",
@@ -319,6 +343,18 @@ func TestGetVersion(t *testing.T) {
 				return Router(mockSvc)
 			},
 			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name: "get version with registry name - insufficient claims",
+			path: "/gated/v0.1/servers/com.example%2Ftest-server/versions/1.0.0",
+			setupMocks: func(m *mocks.MockRegistryService) {
+				m.EXPECT().GetServerVersion(gomock.Any(), gomock.Any()).
+					Return(nil, service.ErrClaimsInsufficient)
+			},
+			setupRouter: func(mockSvc *mocks.MockRegistryService) http.Handler {
+				return Router(mockSvc)
+			},
+			wantStatus: http.StatusForbidden,
 		},
 		{
 			name: "get version with registry name - registry not found",

--- a/internal/api/v1/entries.go
+++ b/internal/api/v1/entries.go
@@ -9,6 +9,7 @@ import (
 	upstreamv0 "github.com/modelcontextprotocol/registry/pkg/api/v0"
 
 	"github.com/stacklok/toolhive-registry-server/internal/api/common"
+	"github.com/stacklok/toolhive-registry-server/internal/auth"
 	"github.com/stacklok/toolhive-registry-server/internal/service"
 )
 
@@ -47,8 +48,14 @@ func (routes *Routes) publishEntry(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Extract JWT claims for authorization (subset validation)
+	var jwtOpts []service.Option
+	if jwtClaims := auth.ClaimsFromContext(r.Context()); jwtClaims != nil {
+		jwtOpts = append(jwtOpts, service.WithJWTClaims(map[string]any(jwtClaims)))
+	}
+
 	if req.Server != nil {
-		opts := []service.Option{service.WithServerData(req.Server)}
+		opts := append([]service.Option{service.WithServerData(req.Server)}, jwtOpts...)
 		if req.Claims != nil {
 			opts = append(opts, service.WithClaims(req.Claims))
 		}
@@ -62,7 +69,7 @@ func (routes *Routes) publishEntry(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if req.Skill != nil {
-		var opts []service.Option
+		opts := append([]service.Option{}, jwtOpts...)
 		if req.Claims != nil {
 			opts = append(opts, service.WithClaims(req.Claims))
 		}
@@ -78,6 +85,10 @@ func (routes *Routes) publishEntry(w http.ResponseWriter, r *http.Request) {
 
 // writePublishError maps service-layer publish errors to HTTP responses.
 func writePublishError(w http.ResponseWriter, r *http.Request, err error) {
+	if errors.Is(err, service.ErrClaimsInsufficient) {
+		common.WriteErrorResponse(w, err.Error(), http.StatusForbidden)
+		return
+	}
 	if errors.Is(err, service.ErrVersionAlreadyExists) {
 		common.WriteErrorResponse(w, err.Error(), http.StatusConflict)
 		return
@@ -128,17 +139,27 @@ func (routes *Routes) deletePublishedEntry(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
+	// Build options with JWT claims for authorization
+	opts := []service.Option{service.WithName(name), service.WithVersion(version)}
+	if jwtClaims := auth.ClaimsFromContext(r.Context()); jwtClaims != nil {
+		opts = append(opts, service.WithJWTClaims(map[string]any(jwtClaims)))
+	}
+
 	switch entryType {
 	case "server":
-		err = routes.service.DeleteServerVersion(r.Context(), service.WithName(name), service.WithVersion(version))
+		err = routes.service.DeleteServerVersion(r.Context(), opts...)
 	case "skill":
-		err = routes.service.DeleteSkillVersion(r.Context(), service.WithName(name), service.WithVersion(version))
+		err = routes.service.DeleteSkillVersion(r.Context(), opts...)
 	default:
 		common.WriteErrorResponse(w, "unsupported entry type: must be 'server' or 'skill'", http.StatusBadRequest)
 		return
 	}
 
 	if err != nil {
+		if errors.Is(err, service.ErrClaimsInsufficient) {
+			common.WriteErrorResponse(w, err.Error(), http.StatusForbidden)
+			return
+		}
 		if errors.Is(err, service.ErrNotFound) {
 			common.WriteErrorResponse(w, err.Error(), http.StatusNotFound)
 			return

--- a/internal/api/x/skills/routes.go
+++ b/internal/api/x/skills/routes.go
@@ -297,6 +297,8 @@ func parseListSkillsQuery(r *http.Request) (*ListSkillsQuery, error) {
 // writeServiceError maps service-layer errors to HTTP responses.
 func writeServiceError(w http.ResponseWriter, err error) {
 	switch {
+	case errors.Is(err, service.ErrClaimsInsufficient):
+		common.WriteErrorResponse(w, "forbidden: insufficient claims for registry", http.StatusForbidden)
 	case errors.Is(err, service.ErrNotFound):
 		common.WriteErrorResponse(w, err.Error(), http.StatusNotFound)
 	case errors.Is(err, service.ErrRegistryNotFound):

--- a/internal/auth/authz_middleware.go
+++ b/internal/auth/authz_middleware.go
@@ -34,6 +34,10 @@ func RequireRole(role Role, authzCfg *config.AuthzConfig) func(http.Handler) htt
 			}
 
 			roles := ResolveRoles(claims, authzCfg)
+			// Store resolved roles in context for downstream authorization checks
+			// (e.g., super-admin bypass in claim validation).
+			r = r.WithContext(ContextWithRoles(r.Context(), roles))
+
 			if !HasRole(roles, role) {
 				common.WriteErrorResponse(w, "forbidden: insufficient permissions", http.StatusForbidden)
 				return

--- a/internal/auth/claims.go
+++ b/internal/auth/claims.go
@@ -10,6 +10,9 @@ import (
 // Uses a private type to prevent collisions with other packages.
 type claimsContextKey struct{}
 
+// rolesContextKey is the context key for storing resolved authorization roles.
+type rolesContextKey struct{}
+
 // ContextWithClaims returns a new context with the JWT claims stored.
 func ContextWithClaims(ctx context.Context, claims jwt.MapClaims) context.Context {
 	return context.WithValue(ctx, claimsContextKey{}, claims)
@@ -20,4 +23,21 @@ func ContextWithClaims(ctx context.Context, claims jwt.MapClaims) context.Contex
 func ClaimsFromContext(ctx context.Context) jwt.MapClaims {
 	claims, _ := ctx.Value(claimsContextKey{}).(jwt.MapClaims)
 	return claims
+}
+
+// ContextWithRoles returns a new context with the resolved roles stored.
+func ContextWithRoles(ctx context.Context, roles []Role) context.Context {
+	return context.WithValue(ctx, rolesContextKey{}, roles)
+}
+
+// RolesFromContext extracts resolved roles from the context.
+// Returns nil if no roles are present.
+func RolesFromContext(ctx context.Context) []Role {
+	roles, _ := ctx.Value(rolesContextKey{}).([]Role)
+	return roles
+}
+
+// IsSuperAdmin returns true if the context contains the superAdmin role.
+func IsSuperAdmin(ctx context.Context) bool {
+	return HasRole(RolesFromContext(ctx), RoleSuperAdmin)
 }

--- a/internal/service/db/claims_filter.go
+++ b/internal/service/db/claims_filter.go
@@ -5,8 +5,59 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/stacklok/toolhive-registry-server/internal/auth"
+	"github.com/stacklok/toolhive-registry-server/internal/db"
 	"github.com/stacklok/toolhive-registry-server/internal/service"
 )
+
+// ---------------------------------------------------------------------------
+// Write-path validation (gate checks, publish/delete authorization)
+// ---------------------------------------------------------------------------
+
+// validateClaimsSubset checks that callerClaims covers resourceClaims.
+// Returns nil if:
+//   - callerClaims is nil (anonymous mode — no auth enforcement)
+//   - resourceClaims is nil/empty (open resource — no restriction)
+//   - the caller is a super-admin (bypasses all claim checks)
+//   - callerClaims is a superset of resourceClaims
+//
+// Returns ErrClaimsInsufficient otherwise.
+func validateClaimsSubset(ctx context.Context, callerClaims, resourceClaims map[string]any) error {
+	if callerClaims == nil || len(resourceClaims) == 0 {
+		return nil
+	}
+	if auth.IsSuperAdmin(ctx) {
+		return nil
+	}
+	if !claimsContain(callerClaims, resourceClaims) {
+		return fmt.Errorf("%w: caller claims do not cover resource claims", service.ErrClaimsInsufficient)
+	}
+	return nil
+}
+
+// validateClaimsSubsetBytes is like validateClaimsSubset but accepts raw JSON
+// for resourceClaims. Nil or empty JSON is treated as an open resource.
+func validateClaimsSubsetBytes(ctx context.Context, callerClaims map[string]any, resourceClaimsJSON []byte) error {
+	if callerClaims == nil || len(resourceClaimsJSON) == 0 {
+		return nil
+	}
+	resourceClaims := db.DeserializeClaims(resourceClaimsJSON)
+	return validateClaimsSubset(ctx, callerClaims, resourceClaims)
+}
+
+// claimsFromCtx extracts JWT claims from the context as map[string]any.
+// Returns nil in anonymous mode (no claims present).
+func claimsFromCtx(ctx context.Context) map[string]any {
+	jwtClaims := auth.ClaimsFromContext(ctx)
+	if jwtClaims == nil {
+		return nil
+	}
+	return map[string]any(jwtClaims)
+}
+
+// ---------------------------------------------------------------------------
+// Read-path filtering (per-user entry visibility)
+// ---------------------------------------------------------------------------
 
 // newClaimsFilterWith builds a RecordFilter that keeps a record only when the
 // caller's claims are non-empty, the record has stored claims, and they match.
@@ -30,6 +81,10 @@ func newClaimsFilterWith(
 		return checkClaims(callerJSON, recordJSON), nil
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
 
 // marshalClaims serializes callerClaims to JSON. Returns nil if the map is nil
 // or empty, or if serialization fails (treated as "no claims").

--- a/internal/service/db/claims_filter_validate_test.go
+++ b/internal/service/db/claims_filter_validate_test.go
@@ -1,0 +1,209 @@
+package database
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stacklok/toolhive-registry-server/internal/auth"
+	"github.com/stacklok/toolhive-registry-server/internal/service"
+)
+
+func TestValidateClaimsSubset(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		callerClaims   map[string]any
+		resourceClaims map[string]any
+		superAdmin     bool
+		wantErr        error
+	}{
+		{
+			name:           "nil caller claims (anonymous) returns nil",
+			callerClaims:   nil,
+			resourceClaims: map[string]any{"sub": "user1"},
+			wantErr:        nil,
+		},
+		{
+			name:           "nil resource claims returns nil",
+			callerClaims:   map[string]any{"sub": "user1"},
+			resourceClaims: nil,
+			wantErr:        nil,
+		},
+		{
+			name:           "empty resource claims returns nil",
+			callerClaims:   map[string]any{"sub": "user1"},
+			resourceClaims: map[string]any{},
+			wantErr:        nil,
+		},
+		{
+			name:           "caller covers resource with exact match",
+			callerClaims:   map[string]any{"sub": "user1"},
+			resourceClaims: map[string]any{"sub": "user1"},
+			wantErr:        nil,
+		},
+		{
+			name:           "caller is superset of resource",
+			callerClaims:   map[string]any{"sub": "user1", "org": "acme"},
+			resourceClaims: map[string]any{"sub": "user1"},
+			wantErr:        nil,
+		},
+		{
+			name:           "caller missing required key returns ErrClaimsInsufficient",
+			callerClaims:   map[string]any{"org": "acme"},
+			resourceClaims: map[string]any{"sub": "user1"},
+			wantErr:        service.ErrClaimsInsufficient,
+		},
+		{
+			name:           "caller has wrong value returns ErrClaimsInsufficient",
+			callerClaims:   map[string]any{"sub": "user2"},
+			resourceClaims: map[string]any{"sub": "user1"},
+			wantErr:        service.ErrClaimsInsufficient,
+		},
+		{
+			name:           "super-admin bypasses claim checks",
+			callerClaims:   map[string]any{"sub": "admin"},
+			resourceClaims: map[string]any{"sub": "user1"},
+			superAdmin:     true,
+			wantErr:        nil,
+		},
+		{
+			name:           "array claim values caller covers resource",
+			callerClaims:   map[string]any{"roles": []any{"a", "b", "c"}},
+			resourceClaims: map[string]any{"roles": []any{"a", "b"}},
+			wantErr:        nil,
+		},
+		{
+			name:           "array claim values caller missing value returns ErrClaimsInsufficient",
+			callerClaims:   map[string]any{"roles": []any{"a"}},
+			resourceClaims: map[string]any{"roles": []any{"a", "b"}},
+			wantErr:        service.ErrClaimsInsufficient,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := t.Context()
+			if tt.superAdmin {
+				ctx = auth.ContextWithRoles(ctx, []auth.Role{auth.RoleSuperAdmin})
+			}
+
+			err := validateClaimsSubset(ctx, tt.callerClaims, tt.resourceClaims)
+
+			if tt.wantErr != nil {
+				require.Error(t, err)
+				assert.True(t, errors.Is(err, tt.wantErr), "expected %v, got %v", tt.wantErr, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestValidateClaimsSubsetBytes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		callerClaims map[string]any
+		resourceJSON []byte
+		wantErr      error
+	}{
+		{
+			name:         "nil caller claims returns nil",
+			callerClaims: nil,
+			resourceJSON: []byte(`{"sub":"user1"}`),
+			wantErr:      nil,
+		},
+		{
+			name:         "nil resource JSON returns nil",
+			callerClaims: map[string]any{"sub": "user1"},
+			resourceJSON: nil,
+			wantErr:      nil,
+		},
+		{
+			name:         "empty resource JSON returns nil",
+			callerClaims: map[string]any{"sub": "user1"},
+			resourceJSON: []byte{},
+			wantErr:      nil,
+		},
+		{
+			name:         "matching JSON returns nil",
+			callerClaims: map[string]any{"sub": "user1"},
+			resourceJSON: mustMarshalAuthz(t, map[string]any{"sub": "user1"}),
+			wantErr:      nil,
+		},
+		{
+			name:         "non-matching JSON returns ErrClaimsInsufficient",
+			callerClaims: map[string]any{"sub": "user1"},
+			resourceJSON: mustMarshalAuthz(t, map[string]any{"sub": "user2"}),
+			wantErr:      service.ErrClaimsInsufficient,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := t.Context()
+			err := validateClaimsSubsetBytes(ctx, tt.callerClaims, tt.resourceJSON)
+
+			if tt.wantErr != nil {
+				require.Error(t, err)
+				assert.True(t, errors.Is(err, tt.wantErr), "expected %v, got %v", tt.wantErr, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestClaimsFromCtx(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		claims jwt.MapClaims
+		want   map[string]any
+	}{
+		{
+			name:   "no claims in context returns nil",
+			claims: nil,
+			want:   nil,
+		},
+		{
+			name:   "claims in context returns map",
+			claims: jwt.MapClaims{"sub": "user1", "org": "acme"},
+			want:   map[string]any{"sub": "user1", "org": "acme"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := t.Context()
+			if tt.claims != nil {
+				ctx = auth.ContextWithClaims(ctx, tt.claims)
+			}
+
+			got := claimsFromCtx(ctx)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// mustMarshalAuthz is a test helper that marshals v to JSON or fails the test.
+func mustMarshalAuthz(t *testing.T, v any) []byte {
+	t.Helper()
+	b, err := json.Marshal(v)
+	require.NoError(t, err)
+	return b
+}

--- a/internal/service/db/impl_common.go
+++ b/internal/service/db/impl_common.go
@@ -22,9 +22,13 @@ func (s *dbService) CheckReadiness(ctx context.Context) error {
 	return nil
 }
 
-// lookupRegistryID returns the UUID for the registry with the given name.
-// Returns ErrRegistryNotFound if the registry does not exist.
-func lookupRegistryID(ctx context.Context, pool sqlc.DBTX, registryName string) (uuid.UUID, error) {
+// lookupRegistryIDWithGate returns the UUID for the registry with the given name
+// after verifying the caller's claims satisfy the registry's access gate.
+// Returns ErrClaimsInsufficient if the caller's JWT claims do not cover the
+// registry's claims. Returns ErrRegistryNotFound if the registry does not exist.
+func lookupRegistryIDWithGate(
+	ctx context.Context, pool sqlc.DBTX, registryName string, callerClaims map[string]any,
+) (uuid.UUID, error) {
 	querier := sqlc.New(pool)
 	row, err := querier.GetRegistryByName(ctx, registryName)
 	if err != nil {
@@ -33,7 +37,17 @@ func lookupRegistryID(ctx context.Context, pool sqlc.DBTX, registryName string) 
 		}
 		return uuid.Nil, err
 	}
+	if err := validateClaimsSubsetBytes(ctx, callerClaims, row.Claims); err != nil {
+		return uuid.Nil, err
+	}
 	return row.ID, nil
+}
+
+// checkRegistryExistsWithGate validates that a registry exists and the caller's
+// claims satisfy the registry's access gate.
+func checkRegistryExistsWithGate(ctx context.Context, pool sqlc.DBTX, registryName string, callerClaims map[string]any) error {
+	_, err := lookupRegistryIDWithGate(ctx, pool, registryName, callerClaims)
+	return err
 }
 
 // upsertLatestFunc is a callback used by rePointLatestVersionIfNeeded to update

--- a/internal/service/db/impl_mcp.go
+++ b/internal/service/db/impl_mcp.go
@@ -58,7 +58,7 @@ func (s *dbService) ListServers(
 	}
 	span.SetAttributes(otel.AttrRegistryName.String(options.RegistryName))
 
-	registryID, err := lookupRegistryID(ctx, s.pool, options.RegistryName)
+	registryID, err := lookupRegistryIDWithGate(ctx, s.pool, options.RegistryName, options.Claims)
 	if err != nil {
 		otel.RecordError(span, err)
 		return nil, err
@@ -182,7 +182,7 @@ func (s *dbService) ListServerVersions(
 	}
 	span.SetAttributes(otel.AttrRegistryName.String(options.RegistryName))
 
-	registryIDForVersions, err := lookupRegistryID(ctx, s.pool, options.RegistryName)
+	registryIDForVersions, err := lookupRegistryIDWithGate(ctx, s.pool, options.RegistryName, options.Claims)
 	if err != nil {
 		otel.RecordError(span, err)
 		return nil, err
@@ -261,7 +261,7 @@ func (s *dbService) GetServerVersion(
 		otel.AttrRegistryName.String(options.RegistryName),
 	)
 
-	registryID, err := lookupRegistryID(ctx, s.pool, options.RegistryName)
+	registryID, err := lookupRegistryIDWithGate(ctx, s.pool, options.RegistryName, options.Claims)
 	if err != nil {
 		otel.RecordError(span, err)
 		return nil, err
@@ -609,6 +609,12 @@ func (s *dbService) PublishServerVersion(
 		return nil, err
 	}
 
+	// Validate published claims are a subset of the publisher's JWT claims
+	if err := validateClaimsSubset(ctx, options.JWTClaims, options.Claims); err != nil {
+		otel.RecordError(span, err)
+		return nil, err
+	}
+
 	// Serialize claims to JSON for storage
 	var claimsJSON []byte
 	if options.Claims != nil {
@@ -839,6 +845,24 @@ func (s *dbService) executeDeleteTransaction(
 	source, err := getManagedSource(ctx, querier)
 	if err != nil {
 		return err
+	}
+
+	// Verify the caller's JWT claims cover the entry's claims before deleting
+	if options.JWTClaims != nil {
+		existing, err := querier.GetRegistryEntryByName(ctx, sqlc.GetRegistryEntryByNameParams{
+			SourceID:  source.ID,
+			EntryType: sqlc.EntryTypeMCP,
+			Name:      options.ServerName,
+		})
+		if err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				return fmt.Errorf("%w: %s@%s", service.ErrNotFound, options.ServerName, options.Version)
+			}
+			return fmt.Errorf("failed to look up registry entry: %w", err)
+		}
+		if err := validateClaimsSubsetBytes(ctx, options.JWTClaims, existing.Claims); err != nil {
+			return err
+		}
 	}
 
 	entryID, err := lookupAndDeleteEntryVersion(ctx, querier, source.ID, sqlc.EntryTypeMCP, options.ServerName, options.Version)

--- a/internal/service/db/impl_skills.go
+++ b/internal/service/db/impl_skills.go
@@ -49,7 +49,7 @@ func (s *dbService) ListSkills(
 		options.Limit = service.MaxPageSize
 	}
 
-	registryID, err := lookupRegistryID(ctx, s.pool, options.RegistryName)
+	registryID, err := lookupRegistryIDWithGate(ctx, s.pool, options.RegistryName, options.Claims)
 	if err != nil {
 		otel.RecordError(span, err)
 		return nil, err
@@ -174,7 +174,7 @@ func (s *dbService) GetSkillVersion(
 
 	span.SetAttributes(otel.AttrRegistryName.String(options.RegistryName))
 
-	registryID, err := lookupRegistryID(ctx, s.pool, options.RegistryName)
+	registryID, err := lookupRegistryIDWithGate(ctx, s.pool, options.RegistryName, options.Claims)
 	if err != nil {
 		otel.RecordError(span, err)
 		return nil, err
@@ -299,6 +299,12 @@ func (s *dbService) PublishSkill(
 	}
 	if skill.Namespace == "" || skill.Name == "" || skill.Version == "" {
 		return nil, fmt.Errorf("namespace, name, and version are required")
+	}
+
+	// Validate published claims are a subset of the publisher's JWT claims
+	if err := validateClaimsSubset(ctx, options.JWTClaims, options.Claims); err != nil {
+		otel.RecordError(span, err)
+		return nil, err
 	}
 
 	// Serialize claims to JSON for storage
@@ -642,6 +648,24 @@ func (s *dbService) executeDeleteSkillTransaction(
 	registry, err := getManagedSource(ctx, querier)
 	if err != nil {
 		return err
+	}
+
+	// Verify the caller's JWT claims cover the entry's claims before deleting
+	if options.JWTClaims != nil {
+		existing, err := querier.GetRegistryEntryByName(ctx, sqlc.GetRegistryEntryByNameParams{
+			SourceID:  registry.ID,
+			EntryType: sqlc.EntryTypeSKILL,
+			Name:      options.Name,
+		})
+		if err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				return fmt.Errorf("%w: %s@%s", service.ErrNotFound, options.Name, options.Version)
+			}
+			return fmt.Errorf("failed to look up registry entry: %w", err)
+		}
+		if err := validateClaimsSubsetBytes(ctx, options.JWTClaims, existing.Claims); err != nil {
+			return err
+		}
 	}
 
 	entryID, err := lookupAndDeleteEntryVersion(

--- a/internal/service/db/publish_claims_test.go
+++ b/internal/service/db/publish_claims_test.go
@@ -1,0 +1,381 @@
+package database
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	upstreamv0 "github.com/modelcontextprotocol/registry/pkg/api/v0"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stacklok/toolhive-registry-server/internal/db/sqlc"
+	"github.com/stacklok/toolhive-registry-server/internal/service"
+)
+
+// createManagedSource is a helper that creates a managed source for publish tests.
+func createManagedSource(t *testing.T, svc *dbService, name string) {
+	t.Helper()
+
+	ctx := context.Background()
+	queries := sqlc.New(svc.pool)
+
+	_, err := queries.InsertSource(ctx, sqlc.InsertSourceParams{
+		Name:         name,
+		CreationType: sqlc.CreationTypeCONFIG,
+		SourceType:   "managed",
+		Syncable:     false,
+	})
+	require.NoError(t, err)
+}
+
+// createManagedSourceWithRegistry creates a managed source and a registry linked to it.
+// This is needed for skill operations which require a registry.
+func createManagedSourceWithRegistry(t *testing.T, svc *dbService, name string) {
+	t.Helper()
+
+	ctx := context.Background()
+	queries := sqlc.New(svc.pool)
+
+	src, err := queries.InsertSource(ctx, sqlc.InsertSourceParams{
+		Name:         name,
+		CreationType: sqlc.CreationTypeCONFIG,
+		SourceType:   "managed",
+		Syncable:     false,
+	})
+	require.NoError(t, err)
+
+	now := time.Now()
+	reg, err := queries.UpsertRegistry(ctx, sqlc.UpsertRegistryParams{
+		Name:         name,
+		CreationType: sqlc.CreationTypeCONFIG,
+		CreatedAt:    &now,
+		UpdatedAt:    &now,
+	})
+	require.NoError(t, err)
+
+	err = queries.LinkRegistrySource(ctx, sqlc.LinkRegistrySourceParams{
+		RegistryID: reg.ID,
+		SourceID:   src.ID,
+		Position:   0,
+	})
+	require.NoError(t, err)
+}
+
+func TestPublishServerVersion_ClaimsSubset(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		serverSlug string
+		claims     map[string]any
+		jwtClaims  map[string]any
+		wantErr    error
+	}{
+		{
+			name:       "JWT superset of request claims succeeds",
+			serverSlug: "jwt-superset",
+			claims:     map[string]any{"org": "acme"},
+			jwtClaims:  map[string]any{"org": "acme", "team": "eng"},
+			wantErr:    nil,
+		},
+		{
+			name:       "JWT does not cover request claims returns ErrClaimsInsufficient",
+			serverSlug: "jwt-insufficient",
+			claims:     map[string]any{"org": "acme", "team": "eng"},
+			jwtClaims:  map[string]any{"org": "acme"},
+			wantErr:    service.ErrClaimsInsufficient,
+		},
+		{
+			name:       "nil JWT claims skips validation and succeeds",
+			serverSlug: "nil-jwt",
+			claims:     map[string]any{"org": "acme"},
+			jwtClaims:  nil,
+			wantErr:    nil,
+		},
+		{
+			name:       "nil request claims with any JWT succeeds",
+			serverSlug: "nil-req-claims",
+			claims:     nil,
+			jwtClaims:  map[string]any{"org": "acme", "team": "eng"},
+			wantErr:    nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			svc, cleanup := setupTestService(t)
+			defer cleanup()
+
+			sourceName := "pub-srv-" + tt.serverSlug
+			createManagedSource(t, svc, sourceName)
+
+			ctx := context.Background()
+
+			opts := []service.Option{
+				service.WithServerData(&upstreamv0.ServerJSON{
+					Name:    "com.test/pub-srv-" + tt.serverSlug,
+					Version: "1.0.0",
+				}),
+			}
+			if tt.claims != nil {
+				opts = append(opts, service.WithClaims(tt.claims))
+			}
+			if tt.jwtClaims != nil {
+				opts = append(opts, service.WithJWTClaims(tt.jwtClaims))
+			}
+
+			result, err := svc.PublishServerVersion(ctx, opts...)
+
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+				require.Nil(t, result)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, result)
+				require.Equal(t, "1.0.0", result.Version)
+			}
+		})
+	}
+}
+
+func TestPublishSkill_ClaimsSubset(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		claims    map[string]any
+		jwtClaims map[string]any
+		wantErr   error
+	}{
+		{
+			name:      "JWT superset of request claims succeeds",
+			claims:    map[string]any{"org": "acme"},
+			jwtClaims: map[string]any{"org": "acme", "team": "eng"},
+			wantErr:   nil,
+		},
+		{
+			name:      "JWT does not cover request claims returns ErrClaimsInsufficient",
+			claims:    map[string]any{"org": "acme", "team": "eng"},
+			jwtClaims: map[string]any{"org": "acme"},
+			wantErr:   service.ErrClaimsInsufficient,
+		},
+		{
+			name:      "nil JWT claims skips validation and succeeds",
+			claims:    map[string]any{"org": "acme"},
+			jwtClaims: nil,
+			wantErr:   nil,
+		},
+		{
+			name:      "nil request claims with any JWT succeeds",
+			claims:    nil,
+			jwtClaims: map[string]any{"org": "acme", "team": "eng"},
+			wantErr:   nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			svc, cleanup := setupTestService(t)
+			defer cleanup()
+
+			registryName := "pub-skill-claims-" + tt.name
+			createManagedSourceWithRegistry(t, svc, registryName)
+
+			ctx := context.Background()
+
+			skill := &service.Skill{
+				Namespace: "com.test",
+				Name:      "skill-" + tt.name,
+				Version:   "1.0.0",
+				Title:     "Test Skill",
+			}
+
+			opts := []service.Option{}
+			if tt.claims != nil {
+				opts = append(opts, service.WithClaims(tt.claims))
+			}
+			if tt.jwtClaims != nil {
+				opts = append(opts, service.WithJWTClaims(tt.jwtClaims))
+			}
+
+			result, err := svc.PublishSkill(ctx, skill, opts...)
+
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+				require.Nil(t, result)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, result)
+				require.Equal(t, "1.0.0", result.Version)
+			}
+		})
+	}
+}
+
+func TestDeleteServerVersion_ClaimsAuthorization(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		slug            string
+		publishClaims   map[string]any
+		deleteJWTClaims map[string]any
+		wantErr         error
+	}{
+		{
+			name:            "matching JWT covers stored claims and succeeds",
+			slug:            "jwt-match",
+			publishClaims:   map[string]any{"org": "acme"},
+			deleteJWTClaims: map[string]any{"org": "acme", "team": "eng"},
+			wantErr:         nil,
+		},
+		{
+			name:            "non-matching JWT returns ErrClaimsInsufficient",
+			slug:            "jwt-mismatch",
+			publishClaims:   map[string]any{"org": "acme"},
+			deleteJWTClaims: map[string]any{"org": "contoso"},
+			wantErr:         service.ErrClaimsInsufficient,
+		},
+		{
+			name:            "nil JWT claims skips validation and succeeds",
+			slug:            "nil-jwt",
+			publishClaims:   map[string]any{"org": "acme"},
+			deleteJWTClaims: nil,
+			wantErr:         nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			svc, cleanup := setupTestService(t)
+			defer cleanup()
+
+			sourceName := "del-srv-" + tt.slug
+			createManagedSource(t, svc, sourceName)
+
+			ctx := context.Background()
+			serverName := "com.test/del-srv-" + tt.slug
+
+			// Publish a server version with claims
+			publishOpts := []service.Option{
+				service.WithServerData(&upstreamv0.ServerJSON{
+					Name:    serverName,
+					Version: "1.0.0",
+				}),
+			}
+			if tt.publishClaims != nil {
+				publishOpts = append(publishOpts, service.WithClaims(tt.publishClaims))
+			}
+
+			_, err := svc.PublishServerVersion(ctx, publishOpts...)
+			require.NoError(t, err)
+
+			// Attempt to delete with the given JWT claims
+			deleteOpts := []service.Option{
+				service.WithName(serverName),
+				service.WithVersion("1.0.0"),
+			}
+			if tt.deleteJWTClaims != nil {
+				deleteOpts = append(deleteOpts, service.WithJWTClaims(tt.deleteJWTClaims))
+			}
+
+			deleteErr := svc.DeleteServerVersion(ctx, deleteOpts...)
+
+			if tt.wantErr != nil {
+				require.ErrorIs(t, deleteErr, tt.wantErr)
+			} else {
+				require.NoError(t, deleteErr)
+			}
+		})
+	}
+}
+
+func TestDeleteSkillVersion_ClaimsAuthorization(t *testing.T) {
+	t.Parallel()
+
+	const namespace = "com.test"
+
+	tests := []struct {
+		name            string
+		slug            string
+		publishClaims   map[string]any
+		deleteJWTClaims map[string]any
+		wantErr         error
+	}{
+		{
+			name:            "matching JWT covers stored claims and succeeds",
+			slug:            "jwt-match",
+			publishClaims:   map[string]any{"org": "acme"},
+			deleteJWTClaims: map[string]any{"org": "acme", "team": "eng"},
+			wantErr:         nil,
+		},
+		{
+			name:            "non-matching JWT returns ErrClaimsInsufficient",
+			slug:            "jwt-mismatch",
+			publishClaims:   map[string]any{"org": "acme"},
+			deleteJWTClaims: map[string]any{"org": "contoso"},
+			wantErr:         service.ErrClaimsInsufficient,
+		},
+		{
+			name:            "nil JWT claims skips validation and succeeds",
+			slug:            "nil-jwt",
+			publishClaims:   map[string]any{"org": "acme"},
+			deleteJWTClaims: nil,
+			wantErr:         nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			svc, cleanup := setupTestService(t)
+			defer cleanup()
+
+			registryName := "del-skill-" + tt.slug
+			createManagedSourceWithRegistry(t, svc, registryName)
+
+			ctx := context.Background()
+			skillName := "del-skill-" + tt.slug
+
+			// Publish a skill version with claims
+			skill := &service.Skill{
+				Namespace: namespace,
+				Name:      skillName,
+				Version:   "1.0.0",
+				Title:     "Test Skill",
+			}
+			publishOpts := []service.Option{}
+			if tt.publishClaims != nil {
+				publishOpts = append(publishOpts, service.WithClaims(tt.publishClaims))
+			}
+
+			_, err := svc.PublishSkill(ctx, skill, publishOpts...)
+			require.NoError(t, err)
+
+			// Attempt to delete with the given JWT claims
+			deleteOpts := []service.Option{
+				service.WithName(skillName),
+				service.WithVersion("1.0.0"),
+				service.WithNamespace(namespace),
+			}
+			if tt.deleteJWTClaims != nil {
+				deleteOpts = append(deleteOpts, service.WithJWTClaims(tt.deleteJWTClaims))
+			}
+
+			deleteErr := svc.DeleteSkillVersion(ctx, deleteOpts...)
+
+			if tt.wantErr != nil {
+				require.ErrorIs(t, deleteErr, tt.wantErr)
+			} else {
+				require.NoError(t, deleteErr)
+			}
+		})
+	}
+}

--- a/internal/service/db/registry_gate_test.go
+++ b/internal/service/db/registry_gate_test.go
@@ -1,0 +1,211 @@
+package database
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stacklok/toolhive-registry-server/internal/auth"
+	"github.com/stacklok/toolhive-registry-server/internal/db/sqlc"
+	"github.com/stacklok/toolhive-registry-server/internal/service"
+)
+
+// createRegistryWithClaims is a test helper that creates a registry with the
+// given name and JSON claims, links a source to it, and returns the registry ID.
+func createRegistryWithClaims(t *testing.T, svc *dbService, name string, claims []byte) uuid.UUID {
+	t.Helper()
+
+	ctx := t.Context()
+	queries := sqlc.New(svc.pool)
+	now := time.Now().UTC()
+
+	reg, err := queries.UpsertRegistry(ctx, sqlc.UpsertRegistryParams{
+		Name:         name,
+		Claims:       claims,
+		CreationType: sqlc.CreationTypeAPI,
+		CreatedAt:    &now,
+		UpdatedAt:    &now,
+	})
+	require.NoError(t, err)
+
+	srcID, err := queries.UpsertSource(ctx, sqlc.UpsertSourceParams{
+		Name:         name + "-source",
+		CreationType: sqlc.CreationTypeCONFIG,
+		SourceType:   "file",
+		Syncable:     false,
+	})
+	require.NoError(t, err)
+
+	err = queries.LinkRegistrySource(ctx, sqlc.LinkRegistrySourceParams{
+		RegistryID: reg.ID,
+		SourceID:   srcID,
+		Position:   0,
+	})
+	require.NoError(t, err)
+
+	return reg.ID
+}
+
+// mustMarshalGate is a test helper that marshals v to JSON or fails the test.
+func mustMarshalGate(t *testing.T, v any) []byte {
+	t.Helper()
+	b, err := json.Marshal(v)
+	require.NoError(t, err)
+	return b
+}
+
+func TestLookupRegistryIDWithGate(t *testing.T) {
+	t.Parallel()
+
+	svc, cleanup := setupTestService(t)
+	t.Cleanup(cleanup)
+
+	tests := []struct {
+		name         string
+		claims       []byte         // registry claims (nil = open)
+		callerClaims map[string]any // JWT claims (nil = anonymous)
+		superAdmin   bool
+		wantErr      error
+	}{
+		{
+			name:         "nil registry claims with caller claims passes",
+			claims:       nil,
+			callerClaims: map[string]any{"org": "acme"},
+			wantErr:      nil,
+		},
+		{
+			name:         "nil registry claims with nil caller claims passes",
+			claims:       nil,
+			callerClaims: nil,
+			wantErr:      nil,
+		},
+		{
+			name:         "matching claims passes",
+			claims:       mustMarshalGate(t, map[string]any{"org": "acme"}),
+			callerClaims: map[string]any{"org": "acme"},
+			wantErr:      nil,
+		},
+		{
+			name:         "non-matching claims returns ErrClaimsInsufficient",
+			claims:       mustMarshalGate(t, map[string]any{"org": "acme"}),
+			callerClaims: map[string]any{"org": "contoso"},
+			wantErr:      service.ErrClaimsInsufficient,
+		},
+		{
+			name:         "nil caller claims (anonymous) skips check",
+			claims:       mustMarshalGate(t, map[string]any{"org": "acme"}),
+			callerClaims: nil,
+			wantErr:      nil,
+		},
+		{
+			name:         "super-admin bypasses claim check",
+			claims:       mustMarshalGate(t, map[string]any{"org": "acme"}),
+			callerClaims: map[string]any{"org": "contoso"},
+			superAdmin:   true,
+			wantErr:      nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := t.Context()
+			regName := "gate-lookup-" + t.Name()
+
+			expectedID := createRegistryWithClaims(t, svc, regName, tt.claims)
+
+			if tt.superAdmin {
+				ctx = auth.ContextWithRoles(ctx, []auth.Role{auth.RoleSuperAdmin})
+			}
+
+			gotID, err := lookupRegistryIDWithGate(ctx, svc.pool, regName, tt.callerClaims)
+
+			if tt.wantErr != nil {
+				require.Error(t, err)
+				assert.True(t, errors.Is(err, tt.wantErr), "expected %v, got %v", tt.wantErr, err)
+				assert.Equal(t, uuid.Nil, gotID)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, expectedID, gotID)
+			}
+		})
+	}
+
+	t.Run("non-existent registry returns ErrRegistryNotFound", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		gotID, err := lookupRegistryIDWithGate(ctx, svc.pool, "does-not-exist", nil)
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, service.ErrRegistryNotFound), "expected ErrRegistryNotFound, got %v", err)
+		assert.Equal(t, uuid.Nil, gotID)
+	})
+}
+
+func TestCheckRegistryExistsWithGate(t *testing.T) {
+	t.Parallel()
+
+	svc, cleanup := setupTestService(t)
+	t.Cleanup(cleanup)
+
+	tests := []struct {
+		name         string
+		claims       []byte
+		callerClaims map[string]any
+		wantErr      error
+	}{
+		{
+			name:         "open registry with caller claims passes",
+			claims:       nil,
+			callerClaims: map[string]any{"org": "acme"},
+			wantErr:      nil,
+		},
+		{
+			name:         "matching claims passes",
+			claims:       mustMarshalGate(t, map[string]any{"org": "acme"}),
+			callerClaims: map[string]any{"org": "acme"},
+			wantErr:      nil,
+		},
+		{
+			name:         "non-matching claims returns ErrClaimsInsufficient",
+			claims:       mustMarshalGate(t, map[string]any{"org": "acme"}),
+			callerClaims: map[string]any{"org": "contoso"},
+			wantErr:      service.ErrClaimsInsufficient,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := t.Context()
+			regName := "gate-exists-" + t.Name()
+
+			createRegistryWithClaims(t, svc, regName, tt.claims)
+
+			err := checkRegistryExistsWithGate(ctx, svc.pool, regName, tt.callerClaims)
+
+			if tt.wantErr != nil {
+				require.Error(t, err)
+				assert.True(t, errors.Is(err, tt.wantErr), "expected %v, got %v", tt.wantErr, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+
+	t.Run("non-existent registry returns ErrRegistryNotFound", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		err := checkRegistryExistsWithGate(ctx, svc.pool, "does-not-exist-check", nil)
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, service.ErrRegistryNotFound), "expected ErrRegistryNotFound, got %v", err)
+	})
+}

--- a/internal/service/options.go
+++ b/internal/service/options.go
@@ -194,6 +194,23 @@ func WithClaims(claims map[string]any) Option {
 	}
 }
 
+type jwtClaimsOption interface {
+	setJWTClaims(claims map[string]any) error
+}
+
+// WithJWTClaims sets the caller's JWT claims for authorization checks
+// (e.g., verifying published claims are a subset of the publisher's JWT).
+func WithJWTClaims(claims map[string]any) Option {
+	return func(o any) error {
+		switch o := o.(type) {
+		case jwtClaimsOption:
+			return o.setJWTClaims(claims)
+		default:
+			return fmt.Errorf("invalid option type: %T", o)
+		}
+	}
+}
+
 // WithServerData sets the server data for the PublishServerVersion operation
 func WithServerData(serverData *upstreamv0.ServerJSON) Option {
 	return func(o any) error {

--- a/internal/service/options_mcp.go
+++ b/internal/service/options_mcp.go
@@ -128,6 +128,7 @@ func (o *GetServerVersionOptions) setClaims(claims map[string]any) error {
 type PublishServerVersionOptions struct {
 	ServerData *upstreamv0.ServerJSON
 	Claims     map[string]any
+	JWTClaims  map[string]any
 }
 
 //nolint:unparam
@@ -142,10 +143,17 @@ func (o *PublishServerVersionOptions) setClaims(claims map[string]any) error {
 	return nil
 }
 
+//nolint:unparam
+func (o *PublishServerVersionOptions) setJWTClaims(claims map[string]any) error {
+	o.JWTClaims = claims
+	return nil
+}
+
 // DeleteServerVersionOptions is the options for the DeleteServerVersion operation
 type DeleteServerVersionOptions struct {
 	ServerName string
 	Version    string
+	JWTClaims  map[string]any
 }
 
 //nolint:unparam
@@ -157,5 +165,11 @@ func (o *DeleteServerVersionOptions) setName(serverName string) error {
 //nolint:unparam
 func (o *DeleteServerVersionOptions) setVersion(version string) error {
 	o.Version = version
+	return nil
+}
+
+//nolint:unparam
+func (o *DeleteServerVersionOptions) setJWTClaims(claims map[string]any) error {
+	o.JWTClaims = claims
 	return nil
 }

--- a/internal/service/options_skills.go
+++ b/internal/service/options_skills.go
@@ -2,12 +2,19 @@ package service
 
 // PublishSkillOptions is the options for the PublishSkill operation
 type PublishSkillOptions struct {
-	Claims map[string]any
+	Claims    map[string]any
+	JWTClaims map[string]any
 }
 
 //nolint:unparam
 func (o *PublishSkillOptions) setClaims(claims map[string]any) error {
 	o.Claims = claims
+	return nil
+}
+
+//nolint:unparam
+func (o *PublishSkillOptions) setJWTClaims(claims map[string]any) error {
+	o.JWTClaims = claims
 	return nil
 }
 
@@ -117,6 +124,7 @@ type DeleteSkillVersionOptions struct {
 	Namespace string
 	Name      string
 	Version   string
+	JWTClaims map[string]any
 }
 
 //nolint:unparam
@@ -134,5 +142,11 @@ func (o *DeleteSkillVersionOptions) setName(name string) error {
 //nolint:unparam
 func (o *DeleteSkillVersionOptions) setVersion(version string) error {
 	o.Version = version
+	return nil
+}
+
+//nolint:unparam
+func (o *DeleteSkillVersionOptions) setJWTClaims(claims map[string]any) error {
+	o.JWTClaims = claims
 	return nil
 }

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -57,6 +57,8 @@ var (
 	ErrSourceInUse = errors.New("source is referenced by one or more registries")
 	// ErrClaimsMismatch is returned when publish claims do not match the existing entry's claims
 	ErrClaimsMismatch = errors.New("claims mismatch")
+	// ErrClaimsInsufficient is returned when the caller's JWT claims do not cover a resource's claims
+	ErrClaimsInsufficient = errors.New("insufficient claims")
 )
 
 //go:generate mockgen -destination=mocks/mock_service.go -package=mocks -source=service.go Service


### PR DESCRIPTION
## Summary

Enforces JWT claim-based authorization on two paths that were previously unprotected:

- **Registry access gate**: consumer read endpoints (`/registry/{reg}/v0.1/...`) now check the registry's `claims` field against the user's JWT before returning data. Returns 403 if the caller's claims don't cover the registry's claims.
- **Publish subset validation**: `POST /v1/entries` validates that request claims are a subset of the publisher's JWT claims, preventing privilege escalation (a user can't publish entries with broader visibility than their own identity allows).
- **Delete authorization**: `DELETE /v1/entries/{type}/{name}/versions/{ver}` validates that the caller's JWT claims cover the entry's stored claims before allowing deletion.

### Context

The design plan requires claim-based authorization at multiple levels. Per-user entry filtering was already implemented, but the registry-level access gate and write-path claim validation were missing:

- `lookupRegistryID()` fetched the registry row (which includes `claims`) but discarded them — returning only the UUID
- The publish handler passed request body claims to the service but never extracted the publisher's JWT claims for subset validation
- The delete handler had no claim authorization at all

### Design decisions

- **`WithJWTClaims` is separate from `WithClaims`**: `WithClaims` carries the request body claims (what the publisher wants on the entry). `WithJWTClaims` carries the publisher's JWT claims (who they are). These are compared — request claims must be ⊆ JWT claims.
- **Anonymous mode bypass**: when `callerClaims` is nil (anonymous auth), all claim checks are skipped. This preserves the existing no-auth development experience.
- **Super-admin bypass**: resolved roles are now stored in request context via `ContextWithRoles`. `IsSuperAdmin(ctx)` checks for the super-admin role and bypasses claim validation.
- **Old functions removed**: `lookupRegistryID` and `checkRegistryExists` became dead code after all call sites switched to the gated variants — removed rather than keeping unused code.

### Shared infrastructure added

| Component | File | Purpose |
|-----------|------|---------|
| `ErrClaimsInsufficient` | `service.go` | Sentinel error → 403 |
| `ContextWithRoles` / `RolesFromContext` / `IsSuperAdmin` | `auth/claims.go` | Store resolved roles in context for downstream checks |
| `validateClaimsSubset` / `validateClaimsSubsetBytes` | `service/db/authz.go` | Reusable claim validation with anonymous + super-admin bypass |
| `WithJWTClaims` option | `options.go` | Pass publisher JWT to publish/delete service methods |

### What this doesn't cover

- **Claim-scoped admin management** (sources/registries) — separate PR, depends on this one
- **Labels API** — deferred to follow-up phase
- **Update entry claims endpoint** — tracked in #638

## Test plan

- [x] Unit tests for `validateClaimsSubset` helpers (17 cases in `authz_test.go`)
- [x] Integration tests for registry gate (11 cases in `registry_gate_test.go` — nil claims, matching, non-matching, anonymous bypass, super-admin bypass, not-found)
- [x] Integration tests for publish/delete claim validation (14 cases in `publish_claims_test.go` — JWT superset, JWT insufficient, anonymous, nil request claims)
- [x] Handler-level tests for 403 responses (3 cases added to `routes_test.go` — ListServers, ListVersions, GetVersion)
- [x] `task lint-fix` — 0 issues
- [x] `task test` — all tests pass
- [x] Smoke tests via docker compose (31 scenarios, anonymous mode) — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)