### PR TITLE
Improve `GetServerVersion`/`GetSkillVersion` query performance

### DIFF
--- a/database/migrations/000019_registry_source_position_idx.down.sql
+++ b/database/migrations/000019_registry_source_position_idx.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS latest_entry_version_latest_version_id_idx;
+DROP INDEX IF EXISTS registry_source_registry_id_position_source_id_idx;

--- a/database/migrations/000019_registry_source_position_idx.up.sql
+++ b/database/migrations/000019_registry_source_position_idx.up.sql
@@ -1,0 +1,13 @@
+-- Index to support cursor-based pagination in GetServerVersion.
+-- For a given registry_id, rows are stored in (position, source_id) order,
+-- which matches the ORDER BY and the (position, source_id) compound cursor.
+-- This allows PostgreSQL to skip the sort and seek directly to the cursor
+-- position without scanning the full registry_source table.
+CREATE INDEX registry_source_registry_id_position_source_id_idx
+    ON registry_source (registry_id, position ASC, source_id ASC);
+
+-- Index to support the join in GetServerVersion between entry_version and latest_entry_version.
+-- Without this, PostgreSQL does a full seq scan of latest_entry_version (~100k rows) for each
+-- row in the result set, resulting in O(n * 100k) comparisons via nested loop.
+CREATE INDEX latest_entry_version_latest_version_id_idx
+    ON latest_entry_version (latest_version_id);

--- a/database/queries/servers.sql
+++ b/database/queries/servers.sql
@@ -29,10 +29,9 @@ SELECT src.source_type as registry_type,
   JOIN registry_entry e ON v.entry_id = e.id
   JOIN source src ON e.source_id = src.id
   LEFT JOIN latest_entry_version l ON v.id = l.latest_version_id
-  LEFT JOIN registry_source rs ON rs.source_id = e.source_id
-                               AND rs.registry_id = sqlc.narg(registry_id)::uuid
- WHERE (sqlc.narg(registry_id)::uuid IS NULL OR rs.source_id IS NOT NULL)
-   AND (sqlc.narg(name)::text IS NULL OR e.name = sqlc.narg(name)::text)
+  JOIN registry_source rs ON rs.source_id = e.source_id
+                          AND rs.registry_id = sqlc.arg(registry_id)::uuid
+ WHERE (sqlc.narg(name)::text IS NULL OR e.name = sqlc.narg(name)::text)
    AND (sqlc.narg(search)::text IS NULL OR (
        LOWER(e.name) LIKE LOWER('%' || sqlc.narg(search)::text || '%')
        OR LOWER(v.title) LIKE LOWER('%' || sqlc.narg(search)::text || '%')
@@ -55,10 +54,11 @@ SELECT src.source_type as registry_type,
  LIMIT sqlc.arg(size)::bigint;
 
 -- name: GetServerVersion :many
--- Despite the name, this query returns multiple rows. The careful reader will
--- note that there is no limit clause, which might seem a bug, but the actual
--- number of records is bounded by the number of sources that provide the same
--- name and version, which we currently don't expect to be more than a few.
+-- Despite the name, this query returns multiple rows. The actual number of
+-- records is bounded by the number of sources that provide the same name and
+-- version, which we currently don't expect to be more than a few.
+-- Cursor-based pagination using (position, source_id) compound cursor.
+-- position is the sort key but may not be unique; source_id is the tiebreaker.
 SELECT src.source_type as registry_type,
        v.id,
        e.name,
@@ -76,24 +76,61 @@ SELECT src.source_type as registry_type,
        s.repository_subfolder,
        s.repository_type,
        e.claims,
+       rs.source_id,
        -- Sources not linked to the requested registry have no position; default to max int16
        -- so they sort after all explicitly positioned sources (lower position = higher priority).
        COALESCE(rs.position, 32767)::integer AS position
+  FROM entry_version v
+  JOIN registry_entry e ON e.id = v.entry_id
+  JOIN registry_source rs ON rs.source_id = e.source_id
+                          AND rs.registry_id = sqlc.arg(registry_id)::uuid
+  JOIN source src ON e.source_id = src.id
+  JOIN mcp_server s ON s.version_id = v.id
+  LEFT JOIN latest_entry_version l ON v.id = l.latest_version_id
+ WHERE v.name = sqlc.arg(name)
+  AND (
+       v.version = sqlc.arg(version)
+       OR (sqlc.arg(version) = 'latest' AND l.latest_version_id = v.id)
+   )
+   AND (sqlc.narg(source_name)::text IS NULL OR src.name = sqlc.narg(source_name)::text)
+   AND (
+       sqlc.narg(cursor_position)::integer IS NULL
+       OR (rs.position > sqlc.narg(cursor_position)::integer
+           AND rs.source_id > sqlc.narg(cursor_source_id)::uuid
+       )
+   )
+ ORDER BY rs.position ASC, rs.source_id ASC
+ LIMIT sqlc.arg(size)::bigint;
+
+-- name: GetServerVersionBySourceName :one
+-- Source-scoped variant of GetServerVersion used by the publish fetch-back path.
+-- source_name and version are required; registry filtering is not applied.
+SELECT src.source_type as registry_type,
+       v.id,
+       e.name,
+       v.version,
+       (l.latest_version_id IS NOT NULL)::boolean AS is_latest,
+       v.created_at,
+       v.updated_at,
+       v.description,
+       v.title,
+       s.website,
+       s.upstream_meta,
+       s.server_meta,
+       s.repository_url,
+       s.repository_id,
+       s.repository_subfolder,
+       s.repository_type,
+       e.claims,
+       0::integer AS position
   FROM mcp_server s
   JOIN entry_version v ON s.version_id = v.id
   JOIN registry_entry e ON v.entry_id = e.id
   JOIN source src ON e.source_id = src.id
   LEFT JOIN latest_entry_version l ON v.id = l.latest_version_id
-  LEFT JOIN registry r ON r.name = sqlc.narg(registry_name)::text
-  LEFT JOIN registry_source rs ON rs.source_id = e.source_id AND rs.registry_id = r.id
- WHERE e.name = sqlc.arg(name)
-   AND (
-       v.version = sqlc.arg(version)
-       OR (sqlc.arg(version) = 'latest' AND l.latest_version_id = v.id)
-   )
-   AND (sqlc.narg(registry_name)::text IS NULL OR rs.registry_id IS NOT NULL)
-   AND (sqlc.narg(source_name)::text IS NULL OR src.name = sqlc.narg(source_name)::text)
- ORDER BY rs.position ASC;
+ WHERE v.name = sqlc.arg(name)
+   AND v.version = sqlc.arg(version)
+   AND src.name = sqlc.arg(source_name);
 
 -- name: ListServerPackages :many
 SELECT p.server_id,

--- a/database/queries/skills.sql
+++ b/database/queries/skills.sql
@@ -30,10 +30,9 @@ SELECT src.source_type AS registry_type,
   JOIN registry_entry e ON v.entry_id = e.id
   JOIN source src ON e.source_id = src.id
   LEFT JOIN latest_entry_version l ON v.id = l.latest_version_id
-  LEFT JOIN registry_source rs ON rs.source_id = e.source_id
-                               AND rs.registry_id = sqlc.narg(registry_id)::uuid
- WHERE (sqlc.narg(registry_id)::uuid IS NULL OR rs.source_id IS NOT NULL)
-   AND (sqlc.narg(namespace)::text IS NULL OR s.namespace = sqlc.narg(namespace)::text)
+  JOIN registry_source rs ON rs.source_id = e.source_id
+                          AND rs.registry_id = sqlc.arg(registry_id)::uuid
+ WHERE (sqlc.narg(namespace)::text IS NULL OR s.namespace = sqlc.narg(namespace)::text)
    AND (sqlc.narg(name)::text IS NULL OR e.name = sqlc.narg(name)::text)
    AND (sqlc.narg(search)::text IS NULL OR (
        LOWER(e.name) LIKE LOWER('%' || sqlc.narg(search)::text || '%')
@@ -49,10 +48,11 @@ SELECT src.source_type AS registry_type,
  LIMIT sqlc.arg(size)::bigint;
 
 -- name: GetSkillVersion :many
--- Despite the name, this query returns multiple rows. The careful reader will
--- note that there is no limit clause, which might seem a bug, but the actual
--- number of records is bounded by the number of sources that provide the same
--- name and version, which we currently don't expect to be more than a few.
+-- Despite the name, this query returns multiple rows. The actual number of
+-- records is bounded by the number of sources that provide the same name and
+-- version, which we currently don't expect to be more than a few.
+-- Cursor-based pagination using (position, source_id) compound cursor.
+-- position is the sort key but may not be unique; source_id is the tiebreaker.
 SELECT src.source_type AS registry_type,
        v.id,
        e.name,
@@ -73,24 +73,64 @@ SELECT src.source_type AS registry_type,
        s.metadata,
        s.extension_meta,
        e.claims,
+       rs.source_id,
        -- Sources not linked to the requested registry have no position; default to max int16
        -- so they sort after all explicitly positioned sources (lower position = higher priority).
        COALESCE(rs.position, 32767)::integer AS position
+  FROM entry_version v
+  JOIN registry_entry e ON e.id = v.entry_id
+  JOIN registry_source rs ON rs.source_id = e.source_id
+                          AND rs.registry_id = sqlc.arg(registry_id)::uuid
+  JOIN source src ON e.source_id = src.id
+  JOIN skill s ON s.version_id = v.id
+  LEFT JOIN latest_entry_version l ON v.id = l.latest_version_id
+ WHERE v.name = sqlc.arg(name)
+   AND (v.version = sqlc.arg(version)::text
+       OR (sqlc.arg(version)::text = 'latest' AND l.latest_version_id = v.id)
+   )
+   AND (sqlc.narg(source_name)::text IS NULL OR src.name = sqlc.narg(source_name)::text)
+   AND (sqlc.narg(namespace)::text IS NULL OR s.namespace = sqlc.narg(namespace)::text)
+   AND (
+       sqlc.narg(cursor_position)::integer IS NULL
+       OR (rs.position > sqlc.narg(cursor_position)::integer
+           AND rs.source_id > sqlc.narg(cursor_source_id)::uuid
+       )
+   )
+ ORDER BY rs.position ASC, rs.source_id ASC
+ LIMIT sqlc.arg(size)::bigint;
+
+-- name: GetSkillVersionBySourceName :one
+-- Source-scoped variant of GetSkillVersion used by the publish fetch-back path.
+-- source_name and version are required; registry filtering is not applied.
+SELECT src.source_type AS registry_type,
+       v.id,
+       e.name,
+       v.version,
+       (l.latest_version_id IS NOT NULL)::boolean AS is_latest,
+       v.created_at,
+       v.updated_at,
+       v.description,
+       v.title,
+       s.version_id AS skill_version_id,
+       s.namespace,
+       s.status,
+       s.license,
+       s.compatibility,
+       s.allowed_tools,
+       s.repository,
+       s.icons,
+       s.metadata,
+       s.extension_meta,
+       e.claims,
+       0::integer AS position
   FROM skill s
   JOIN entry_version v ON s.version_id = v.id
   JOIN registry_entry e ON v.entry_id = e.id
   JOIN source src ON e.source_id = src.id
   LEFT JOIN latest_entry_version l ON v.id = l.latest_version_id
-  LEFT JOIN registry r ON r.name = sqlc.narg(registry_name)::text
-  LEFT JOIN registry_source rs ON rs.source_id = e.source_id AND rs.registry_id = r.id
- WHERE e.name = sqlc.arg(name)
-   AND (v.version = sqlc.arg(version)::text
-       OR (sqlc.arg(version)::text = 'latest' AND l.latest_version_id = v.id)
-   )
-   AND (sqlc.narg(registry_name)::text IS NULL OR rs.registry_id IS NOT NULL)
-   AND (sqlc.narg(source_name)::text IS NULL OR src.name = sqlc.narg(source_name)::text)
-   AND (sqlc.narg(namespace)::text IS NULL OR s.namespace = sqlc.narg(namespace)::text)
- ORDER BY rs.position ASC;
+ WHERE v.name = sqlc.arg(name)
+   AND v.version = sqlc.arg(version)
+   AND src.name = sqlc.arg(source_name);
 
 -- name: ListSkillOciPackages :many
 SELECT p.id,

--- a/internal/db/sqlc/querier.go
+++ b/internal/db/sqlc/querier.go
@@ -60,16 +60,24 @@ type Querier interface {
 	GetRegistryByName(ctx context.Context, name string) (Registry, error)
 	GetRegistryEntryByName(ctx context.Context, arg GetRegistryEntryByNameParams) (GetRegistryEntryByNameRow, error)
 	GetServerIDsByRegistryNameVersion(ctx context.Context, sourceID uuid.UUID) ([]GetServerIDsByRegistryNameVersionRow, error)
-	// Despite the name, this query returns multiple rows. The careful reader will
-	// note that there is no limit clause, which might seem a bug, but the actual
-	// number of records is bounded by the number of sources that provide the same
-	// name and version, which we currently don't expect to be more than a few.
+	// Despite the name, this query returns multiple rows. The actual number of
+	// records is bounded by the number of sources that provide the same name and
+	// version, which we currently don't expect to be more than a few.
+	// Cursor-based pagination using (position, source_id) compound cursor.
+	// position is the sort key but may not be unique; source_id is the tiebreaker.
 	GetServerVersion(ctx context.Context, arg GetServerVersionParams) ([]GetServerVersionRow, error)
-	// Despite the name, this query returns multiple rows. The careful reader will
-	// note that there is no limit clause, which might seem a bug, but the actual
-	// number of records is bounded by the number of sources that provide the same
-	// name and version, which we currently don't expect to be more than a few.
+	// Source-scoped variant of GetServerVersion used by the publish fetch-back path.
+	// source_name and version are required; registry filtering is not applied.
+	GetServerVersionBySourceName(ctx context.Context, arg GetServerVersionBySourceNameParams) (GetServerVersionBySourceNameRow, error)
+	// Despite the name, this query returns multiple rows. The actual number of
+	// records is bounded by the number of sources that provide the same name and
+	// version, which we currently don't expect to be more than a few.
+	// Cursor-based pagination using (position, source_id) compound cursor.
+	// position is the sort key but may not be unique; source_id is the tiebreaker.
 	GetSkillVersion(ctx context.Context, arg GetSkillVersionParams) ([]GetSkillVersionRow, error)
+	// Source-scoped variant of GetSkillVersion used by the publish fetch-back path.
+	// source_name and version are required; registry filtering is not applied.
+	GetSkillVersionBySourceName(ctx context.Context, arg GetSkillVersionBySourceNameParams) (GetSkillVersionBySourceNameRow, error)
 	GetSource(ctx context.Context, id uuid.UUID) (GetSourceRow, error)
 	GetSourceByName(ctx context.Context, name string) (GetSourceByNameRow, error)
 	GetSourceSync(ctx context.Context, id uuid.UUID) (RegistrySync, error)

--- a/internal/db/sqlc/servers.sql.go
+++ b/internal/db/sqlc/servers.sql.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
 )
 
 const deleteOrphanedServers = `-- name: DeleteOrphanedServers :exec
@@ -133,31 +134,41 @@ SELECT src.source_type as registry_type,
        s.repository_subfolder,
        s.repository_type,
        e.claims,
+       rs.source_id,
        -- Sources not linked to the requested registry have no position; default to max int16
        -- so they sort after all explicitly positioned sources (lower position = higher priority).
        COALESCE(rs.position, 32767)::integer AS position
-  FROM mcp_server s
-  JOIN entry_version v ON s.version_id = v.id
-  JOIN registry_entry e ON v.entry_id = e.id
+  FROM entry_version v
+  JOIN registry_entry e ON e.id = v.entry_id
+  JOIN registry_source rs ON rs.source_id = e.source_id
+                          AND rs.registry_id = $1::uuid
   JOIN source src ON e.source_id = src.id
+  JOIN mcp_server s ON s.version_id = v.id
   LEFT JOIN latest_entry_version l ON v.id = l.latest_version_id
-  LEFT JOIN registry r ON r.name = $1::text
-  LEFT JOIN registry_source rs ON rs.source_id = e.source_id AND rs.registry_id = r.id
- WHERE e.name = $2
-   AND (
+ WHERE v.name = $2
+  AND (
        v.version = $3
        OR ($3 = 'latest' AND l.latest_version_id = v.id)
    )
-   AND ($1::text IS NULL OR rs.registry_id IS NOT NULL)
    AND ($4::text IS NULL OR src.name = $4::text)
- ORDER BY rs.position ASC
+   AND (
+       $5::integer IS NULL
+       OR (rs.position > $5::integer
+           AND rs.source_id > $6::uuid
+       )
+   )
+ ORDER BY rs.position ASC, rs.source_id ASC
+ LIMIT $7::bigint
 `
 
 type GetServerVersionParams struct {
-	RegistryName *string `json:"registry_name"`
-	Name         string  `json:"name"`
-	Version      string  `json:"version"`
-	SourceName   *string `json:"source_name"`
+	RegistryID     uuid.UUID   `json:"registry_id"`
+	Name           string      `json:"name"`
+	Version        string      `json:"version"`
+	SourceName     *string     `json:"source_name"`
+	CursorPosition pgtype.Int4 `json:"cursor_position"`
+	CursorSourceID *uuid.UUID  `json:"cursor_source_id"`
+	Size           int64       `json:"size"`
 }
 
 type GetServerVersionRow struct {
@@ -178,19 +189,24 @@ type GetServerVersionRow struct {
 	RepositorySubfolder *string    `json:"repository_subfolder"`
 	RepositoryType      *string    `json:"repository_type"`
 	Claims              []byte     `json:"claims"`
+	SourceID            uuid.UUID  `json:"source_id"`
 	Position            int32      `json:"position"`
 }
 
-// Despite the name, this query returns multiple rows. The careful reader will
-// note that there is no limit clause, which might seem a bug, but the actual
-// number of records is bounded by the number of sources that provide the same
-// name and version, which we currently don't expect to be more than a few.
+// Despite the name, this query returns multiple rows. The actual number of
+// records is bounded by the number of sources that provide the same name and
+// version, which we currently don't expect to be more than a few.
+// Cursor-based pagination using (position, source_id) compound cursor.
+// position is the sort key but may not be unique; source_id is the tiebreaker.
 func (q *Queries) GetServerVersion(ctx context.Context, arg GetServerVersionParams) ([]GetServerVersionRow, error) {
 	rows, err := q.db.Query(ctx, getServerVersion,
-		arg.RegistryName,
+		arg.RegistryID,
 		arg.Name,
 		arg.Version,
 		arg.SourceName,
+		arg.CursorPosition,
+		arg.CursorSourceID,
+		arg.Size,
 	)
 	if err != nil {
 		return nil, err
@@ -217,6 +233,7 @@ func (q *Queries) GetServerVersion(ctx context.Context, arg GetServerVersionPara
 			&i.RepositorySubfolder,
 			&i.RepositoryType,
 			&i.Claims,
+			&i.SourceID,
 			&i.Position,
 		); err != nil {
 			return nil, err
@@ -227,6 +244,90 @@ func (q *Queries) GetServerVersion(ctx context.Context, arg GetServerVersionPara
 		return nil, err
 	}
 	return items, nil
+}
+
+const getServerVersionBySourceName = `-- name: GetServerVersionBySourceName :one
+SELECT src.source_type as registry_type,
+       v.id,
+       e.name,
+       v.version,
+       (l.latest_version_id IS NOT NULL)::boolean AS is_latest,
+       v.created_at,
+       v.updated_at,
+       v.description,
+       v.title,
+       s.website,
+       s.upstream_meta,
+       s.server_meta,
+       s.repository_url,
+       s.repository_id,
+       s.repository_subfolder,
+       s.repository_type,
+       e.claims,
+       0::integer AS position
+  FROM mcp_server s
+  JOIN entry_version v ON s.version_id = v.id
+  JOIN registry_entry e ON v.entry_id = e.id
+  JOIN source src ON e.source_id = src.id
+  LEFT JOIN latest_entry_version l ON v.id = l.latest_version_id
+ WHERE v.name = $1
+   AND v.version = $2
+   AND src.name = $3
+`
+
+type GetServerVersionBySourceNameParams struct {
+	Name       string `json:"name"`
+	Version    string `json:"version"`
+	SourceName string `json:"source_name"`
+}
+
+type GetServerVersionBySourceNameRow struct {
+	RegistryType        string     `json:"registry_type"`
+	ID                  uuid.UUID  `json:"id"`
+	Name                string     `json:"name"`
+	Version             string     `json:"version"`
+	IsLatest            bool       `json:"is_latest"`
+	CreatedAt           *time.Time `json:"created_at"`
+	UpdatedAt           *time.Time `json:"updated_at"`
+	Description         *string    `json:"description"`
+	Title               *string    `json:"title"`
+	Website             *string    `json:"website"`
+	UpstreamMeta        []byte     `json:"upstream_meta"`
+	ServerMeta          []byte     `json:"server_meta"`
+	RepositoryUrl       *string    `json:"repository_url"`
+	RepositoryID        *string    `json:"repository_id"`
+	RepositorySubfolder *string    `json:"repository_subfolder"`
+	RepositoryType      *string    `json:"repository_type"`
+	Claims              []byte     `json:"claims"`
+	Position            int32      `json:"position"`
+}
+
+// Source-scoped variant of GetServerVersion used by the publish fetch-back path.
+// source_name and version are required; registry filtering is not applied.
+func (q *Queries) GetServerVersionBySourceName(ctx context.Context, arg GetServerVersionBySourceNameParams) (GetServerVersionBySourceNameRow, error) {
+	row := q.db.QueryRow(ctx, getServerVersionBySourceName, arg.Name, arg.Version, arg.SourceName)
+	var i GetServerVersionBySourceNameRow
+	err := row.Scan(
+		&i.RegistryType,
+		&i.ID,
+		&i.Name,
+		&i.Version,
+		&i.IsLatest,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.Description,
+		&i.Title,
+		&i.Website,
+		&i.UpstreamMeta,
+		&i.ServerMeta,
+		&i.RepositoryUrl,
+		&i.RepositoryID,
+		&i.RepositorySubfolder,
+		&i.RepositoryType,
+		&i.Claims,
+		&i.Position,
+	)
+	return i, err
 }
 
 const insertServerIcon = `-- name: InsertServerIcon :exec
@@ -591,10 +692,9 @@ SELECT src.source_type as registry_type,
   JOIN registry_entry e ON v.entry_id = e.id
   JOIN source src ON e.source_id = src.id
   LEFT JOIN latest_entry_version l ON v.id = l.latest_version_id
-  LEFT JOIN registry_source rs ON rs.source_id = e.source_id
-                               AND rs.registry_id = $1::uuid
- WHERE ($1::uuid IS NULL OR rs.source_id IS NOT NULL)
-   AND ($2::text IS NULL OR e.name = $2::text)
+  JOIN registry_source rs ON rs.source_id = e.source_id
+                          AND rs.registry_id = $1::uuid
+ WHERE ($2::text IS NULL OR e.name = $2::text)
    AND ($3::text IS NULL OR (
        LOWER(e.name) LIKE LOWER('%' || $3::text || '%')
        OR LOWER(v.title) LIKE LOWER('%' || $3::text || '%')
@@ -618,7 +718,7 @@ SELECT src.source_type as registry_type,
 `
 
 type ListServersParams struct {
-	RegistryID    *uuid.UUID `json:"registry_id"`
+	RegistryID    uuid.UUID  `json:"registry_id"`
 	Name          *string    `json:"name"`
 	Search        *string    `json:"search"`
 	UpdatedSince  *time.Time `json:"updated_since"`

--- a/internal/db/sqlc/servers_test.go
+++ b/internal/db/sqlc/servers_test.go
@@ -49,6 +49,13 @@ func setupRegistry(t *testing.T, queries *Queries) uuid.UUID {
 }
 
 //nolint:thelper // We want to see these lines in the test output
+func getServerRegistryID(t *testing.T, queries *Queries, name string) uuid.UUID {
+	reg, err := queries.GetRegistryByName(context.Background(), name)
+	require.NoError(t, err)
+	return reg.ID
+}
+
+//nolint:thelper // We want to see these lines in the test output
 func createEntry(
 	t *testing.T,
 	queries *Queries,
@@ -246,6 +253,7 @@ func TestInsertServerVersion(t *testing.T) {
 					context.Background(),
 					InsertEntryVersionParams{
 						EntryID:   invalidEntryID,
+						Name:      "test-server",
 						Version:   "1.0.0",
 						CreatedAt: &createdAt,
 						UpdatedAt: &createdAt,
@@ -281,7 +289,7 @@ func TestListServersByName(t *testing.T) {
 	testCases := []struct {
 		name         string
 		setupFunc    func(t *testing.T, queries *Queries, regID uuid.UUID) string
-		scenarioFunc func(t *testing.T, queries *Queries, serverName string)
+		scenarioFunc func(t *testing.T, queries *Queries, serverName string, registryID uuid.UUID)
 	}{
 		{
 			name: "no server versions",
@@ -290,12 +298,13 @@ func TestListServersByName(t *testing.T) {
 				return "non-existent-server"
 			},
 			//nolint:thelper // We want to see these lines in the test output
-			scenarioFunc: func(t *testing.T, queries *Queries, serverName string) {
+			scenarioFunc: func(t *testing.T, queries *Queries, serverName string, registryID uuid.UUID) {
 				versions, err := queries.ListServers(
 					context.Background(),
 					ListServersParams{
-						Name: &serverName,
-						Size: 10,
+						RegistryID: registryID,
+						Name:       &serverName,
+						Size:       10,
 					},
 				)
 				require.NoError(t, err)
@@ -314,12 +323,13 @@ func TestListServersByName(t *testing.T) {
 				return "test-server"
 			},
 			//nolint:thelper // We want to see these lines in the test output
-			scenarioFunc: func(t *testing.T, queries *Queries, serverName string) {
+			scenarioFunc: func(t *testing.T, queries *Queries, serverName string, registryID uuid.UUID) {
 				versions, err := queries.ListServers(
 					context.Background(),
 					ListServersParams{
-						Name: &serverName,
-						Size: 10,
+						RegistryID: registryID,
+						Name:       &serverName,
+						Size:       10,
 					},
 				)
 				require.NoError(t, err)
@@ -342,12 +352,13 @@ func TestListServersByName(t *testing.T) {
 				return "test-server"
 			},
 			//nolint:thelper // We want to see these lines in the test output
-			scenarioFunc: func(t *testing.T, queries *Queries, serverName string) {
+			scenarioFunc: func(t *testing.T, queries *Queries, serverName string, registryID uuid.UUID) {
 				versions, err := queries.ListServers(
 					context.Background(),
 					ListServersParams{
-						Name: &serverName,
-						Size: 10,
+						RegistryID: registryID,
+						Name:       &serverName,
+						Size:       10,
 					},
 				)
 				require.NoError(t, err)
@@ -369,13 +380,14 @@ func TestListServersByName(t *testing.T) {
 				return "test-server"
 			},
 			//nolint:thelper // We want to see these lines in the test output
-			scenarioFunc: func(t *testing.T, queries *Queries, serverName string) {
+			scenarioFunc: func(t *testing.T, queries *Queries, serverName string, registryID uuid.UUID) {
 				// Get all versions
 				allVersions, err := queries.ListServers(
 					context.Background(),
 					ListServersParams{
-						Name: &serverName,
-						Size: 10,
+						RegistryID: registryID,
+						Name:       &serverName,
+						Size:       10,
 					},
 				)
 				require.NoError(t, err)
@@ -390,6 +402,7 @@ func TestListServersByName(t *testing.T) {
 				nextVersions, err := queries.ListServers(
 					context.Background(),
 					ListServersParams{
+						RegistryID:    registryID,
 						Name:          &serverName,
 						CursorName:    &cursorName,
 						CursorVersion: &cursorVersion,
@@ -416,12 +429,13 @@ func TestListServersByName(t *testing.T) {
 				return "test-server"
 			},
 			//nolint:thelper // We want to see these lines in the test output
-			scenarioFunc: func(t *testing.T, queries *Queries, serverName string) {
+			scenarioFunc: func(t *testing.T, queries *Queries, serverName string, registryID uuid.UUID) {
 				versions, err := queries.ListServers(
 					context.Background(),
 					ListServersParams{
-						Name: &serverName,
-						Size: 2,
+						RegistryID: registryID,
+						Name:       &serverName,
+						Size:       2,
 					},
 				)
 				require.NoError(t, err)
@@ -443,8 +457,9 @@ func TestListServersByName(t *testing.T) {
 			regID := setupRegistry(t, queries)
 			require.NotNil(t, regID)
 
+			registryID := getServerRegistryID(t, queries, "test-registry")
 			serverName := tc.setupFunc(t, queries, regID)
-			tc.scenarioFunc(t, queries, serverName)
+			tc.scenarioFunc(t, queries, serverName, registryID)
 		})
 	}
 }
@@ -455,18 +470,19 @@ func TestListServers(t *testing.T) {
 	testCases := []struct {
 		name         string
 		setupFunc    func(t *testing.T, queries *Queries, regID uuid.UUID)
-		scenarioFunc func(t *testing.T, queries *Queries)
+		scenarioFunc func(t *testing.T, queries *Queries, registryID uuid.UUID)
 	}{
 		{
 			name: "no servers",
 			//nolint:thelper // We want to see these lines in the test output
 			setupFunc: func(_ *testing.T, _ *Queries, _ uuid.UUID) {},
 			//nolint:thelper // We want to see these lines in the test output
-			scenarioFunc: func(t *testing.T, queries *Queries) {
+			scenarioFunc: func(t *testing.T, queries *Queries, registryID uuid.UUID) {
 				servers, err := queries.ListServers(
 					context.Background(),
 					ListServersParams{
-						Size: 10,
+						RegistryID: registryID,
+						Size:       10,
 					},
 				)
 				require.NoError(t, err)
@@ -483,11 +499,12 @@ func TestListServers(t *testing.T) {
 				createServer(t, queries, versionID)
 			},
 			//nolint:thelper // We want to see these lines in the test output
-			scenarioFunc: func(t *testing.T, queries *Queries) {
+			scenarioFunc: func(t *testing.T, queries *Queries, registryID uuid.UUID) {
 				servers, err := queries.ListServers(
 					context.Background(),
 					ListServersParams{
-						Size: 10,
+						RegistryID: registryID,
+						Size:       10,
 					},
 				)
 				require.NoError(t, err)
@@ -510,11 +527,12 @@ func TestListServers(t *testing.T) {
 				}
 			},
 			//nolint:thelper // We want to see these lines in the test output
-			scenarioFunc: func(t *testing.T, queries *Queries) {
+			scenarioFunc: func(t *testing.T, queries *Queries, registryID uuid.UUID) {
 				servers, err := queries.ListServers(
 					context.Background(),
 					ListServersParams{
-						Size: 10,
+						RegistryID: registryID,
+						Size:       10,
 					},
 				)
 				require.NoError(t, err)
@@ -534,12 +552,13 @@ func TestListServers(t *testing.T) {
 				}
 			},
 			//nolint:thelper // We want to see these lines in the test output
-			scenarioFunc: func(t *testing.T, queries *Queries) {
+			scenarioFunc: func(t *testing.T, queries *Queries, registryID uuid.UUID) {
 				// First get all servers without cursor
 				allServers, err := queries.ListServers(
 					context.Background(),
 					ListServersParams{
-						Size: 10,
+						RegistryID: registryID,
+						Size:       10,
 					},
 				)
 				require.NoError(t, err)
@@ -556,6 +575,7 @@ func TestListServers(t *testing.T) {
 				servers, err := queries.ListServers(
 					context.Background(),
 					ListServersParams{
+						RegistryID:    registryID,
 						CursorName:    &cursorName,
 						CursorVersion: &cursorVersion,
 						Size:          10,
@@ -589,11 +609,12 @@ func TestListServers(t *testing.T) {
 				require.NoError(t, err)
 			},
 			//nolint:thelper // We want to see these lines in the test output
-			scenarioFunc: func(t *testing.T, queries *Queries) {
+			scenarioFunc: func(t *testing.T, queries *Queries, registryID uuid.UUID) {
 				servers, err := queries.ListServers(
 					context.Background(),
 					ListServersParams{
-						Size: 10,
+						RegistryID: registryID,
+						Size:       10,
 					},
 				)
 				require.NoError(t, err)
@@ -613,11 +634,12 @@ func TestListServers(t *testing.T) {
 				}
 			},
 			//nolint:thelper // We want to see these lines in the test output
-			scenarioFunc: func(t *testing.T, queries *Queries) {
+			scenarioFunc: func(t *testing.T, queries *Queries, registryID uuid.UUID) {
 				servers, err := queries.ListServers(
 					context.Background(),
 					ListServersParams{
-						Size: 1,
+						RegistryID: registryID,
+						Size:       1,
 					},
 				)
 				require.NoError(t, err)
@@ -637,14 +659,15 @@ func TestListServers(t *testing.T) {
 				}
 			},
 			//nolint:thelper // We want to see these lines in the test output
-			scenarioFunc: func(t *testing.T, queries *Queries) {
+			scenarioFunc: func(t *testing.T, queries *Queries, registryID uuid.UUID) {
 				//nolint:goconst
 				version := "2.0.0"
 				servers, err := queries.ListServers(
 					context.Background(),
 					ListServersParams{
-						Version: &version,
-						Size:    10,
+						RegistryID: registryID,
+						Version:    &version,
+						Size:       10,
 					},
 				)
 				require.NoError(t, err)
@@ -680,13 +703,14 @@ func TestListServers(t *testing.T) {
 				require.NoError(t, err)
 			},
 			//nolint:thelper // We want to see these lines in the test output
-			scenarioFunc: func(t *testing.T, queries *Queries) {
+			scenarioFunc: func(t *testing.T, queries *Queries, registryID uuid.UUID) {
 				version := latestVersion
 				servers, err := queries.ListServers(
 					context.Background(),
 					ListServersParams{
-						Version: &version,
-						Size:    10,
+						RegistryID: registryID,
+						Version:    &version,
+						Size:       10,
 					},
 				)
 				require.NoError(t, err)
@@ -706,13 +730,14 @@ func TestListServers(t *testing.T) {
 				createServer(t, queries, versionID)
 			},
 			//nolint:thelper // We want to see these lines in the test output
-			scenarioFunc: func(t *testing.T, queries *Queries) {
+			scenarioFunc: func(t *testing.T, queries *Queries, registryID uuid.UUID) {
 				version := "9.9.9"
 				servers, err := queries.ListServers(
 					context.Background(),
 					ListServersParams{
-						Version: &version,
-						Size:    10,
+						RegistryID: registryID,
+						Version:    &version,
+						Size:       10,
 					},
 				)
 				require.NoError(t, err)
@@ -732,13 +757,14 @@ func TestListServers(t *testing.T) {
 				}
 			},
 			//nolint:thelper // We want to see these lines in the test output
-			scenarioFunc: func(t *testing.T, queries *Queries) {
+			scenarioFunc: func(t *testing.T, queries *Queries, registryID uuid.UUID) {
 				version := latestVersion
 				servers, err := queries.ListServers(
 					context.Background(),
 					ListServersParams{
-						Version: &version,
-						Size:    10,
+						RegistryID: registryID,
+						Version:    &version,
+						Size:       10,
 					},
 				)
 				require.NoError(t, err)
@@ -758,12 +784,13 @@ func TestListServers(t *testing.T) {
 				}
 			},
 			//nolint:thelper // We want to see these lines in the test output
-			scenarioFunc: func(t *testing.T, queries *Queries) {
+			scenarioFunc: func(t *testing.T, queries *Queries, registryID uuid.UUID) {
 				servers, err := queries.ListServers(
 					context.Background(),
 					ListServersParams{
-						Version: nil,
-						Size:    10,
+						RegistryID: registryID,
+						Version:    nil,
+						Size:       10,
 					},
 				)
 				require.NoError(t, err)
@@ -788,8 +815,9 @@ func TestListServers(t *testing.T) {
 			regID := setupRegistry(t, queries)
 			require.NotNil(t, regID)
 
+			registryID := getServerRegistryID(t, queries, "test-registry")
 			tc.setupFunc(t, queries, regID)
-			tc.scenarioFunc(t, queries)
+			tc.scenarioFunc(t, queries, registryID)
 		})
 	}
 }
@@ -1709,7 +1737,7 @@ func TestGetServerVersion(t *testing.T) {
 	testCases := []struct {
 		name         string
 		setupFunc    func(t *testing.T, queries *Queries, regID uuid.UUID) (string, string)
-		scenarioFunc func(t *testing.T, queries *Queries, serverName, version string)
+		scenarioFunc func(t *testing.T, queries *Queries, serverName, version string, registryID uuid.UUID)
 	}{
 		{
 			name: "get server version with minimal fields",
@@ -1724,12 +1752,14 @@ func TestGetServerVersion(t *testing.T) {
 				return "test-server", "1.0.0"
 			},
 			//nolint:thelper // We want to see these lines in the test output
-			scenarioFunc: func(t *testing.T, queries *Queries, serverName, version string) {
+			scenarioFunc: func(t *testing.T, queries *Queries, serverName, version string, registryID uuid.UUID) {
 				serverRows, err := queries.GetServerVersion(
 					context.Background(),
 					GetServerVersionParams{
-						Name:    serverName,
-						Version: version,
+						RegistryID: registryID,
+						Name:       serverName,
+						Version:    version,
+						Size:       10,
 					},
 				)
 				require.NoError(t, err)
@@ -1768,12 +1798,14 @@ func TestGetServerVersion(t *testing.T) {
 				return "test-server", "1.0.0"
 			},
 			//nolint:thelper // We want to see these lines in the test output
-			scenarioFunc: func(t *testing.T, queries *Queries, serverName, version string) {
+			scenarioFunc: func(t *testing.T, queries *Queries, serverName, version string, registryID uuid.UUID) {
 				serverRows, err := queries.GetServerVersion(
 					context.Background(),
 					GetServerVersionParams{
-						Name:    serverName,
-						Version: version,
+						RegistryID: registryID,
+						Name:       serverName,
+						Version:    version,
+						Size:       10,
 					},
 				)
 				require.NoError(t, err)
@@ -1822,12 +1854,14 @@ func TestGetServerVersion(t *testing.T) {
 				return "test-server", "1.0.0"
 			},
 			//nolint:thelper // We want to see these lines in the test output
-			scenarioFunc: func(t *testing.T, queries *Queries, serverName, version string) {
+			scenarioFunc: func(t *testing.T, queries *Queries, serverName, version string, registryID uuid.UUID) {
 				serverRows, err := queries.GetServerVersion(
 					context.Background(),
 					GetServerVersionParams{
-						Name:    serverName,
-						Version: version,
+						RegistryID: registryID,
+						Name:       serverName,
+						Version:    version,
+						Size:       10,
 					},
 				)
 				require.NoError(t, err)
@@ -1867,12 +1901,14 @@ func TestGetServerVersion(t *testing.T) {
 				return "test-server", "2.0.0"
 			},
 			//nolint:thelper // We want to see these lines in the test output
-			scenarioFunc: func(t *testing.T, queries *Queries, serverName, version string) {
+			scenarioFunc: func(t *testing.T, queries *Queries, serverName, version string, registryID uuid.UUID) {
 				serverRows, err := queries.GetServerVersion(
 					context.Background(),
 					GetServerVersionParams{
-						Name:    serverName,
-						Version: version,
+						RegistryID: registryID,
+						Name:       serverName,
+						Version:    version,
+						Size:       10,
 					},
 				)
 				require.NoError(t, err)
@@ -1890,12 +1926,14 @@ func TestGetServerVersion(t *testing.T) {
 				return "non-existent-server", "1.0.0"
 			},
 			//nolint:thelper // We want to see these lines in the test output
-			scenarioFunc: func(t *testing.T, queries *Queries, serverName, version string) {
+			scenarioFunc: func(t *testing.T, queries *Queries, serverName, version string, registryID uuid.UUID) {
 				serverRows, err := queries.GetServerVersion(
 					context.Background(),
 					GetServerVersionParams{
-						Name:    serverName,
-						Version: version,
+						RegistryID: registryID,
+						Name:       serverName,
+						Version:    version,
+						Size:       10,
 					},
 				)
 				require.NoError(t, err)
@@ -1913,12 +1951,14 @@ func TestGetServerVersion(t *testing.T) {
 				return "test-server", "2.0.0"
 			},
 			//nolint:thelper // We want to see these lines in the test output
-			scenarioFunc: func(t *testing.T, queries *Queries, serverName, version string) {
+			scenarioFunc: func(t *testing.T, queries *Queries, serverName, version string, registryID uuid.UUID) {
 				serverRows, err := queries.GetServerVersion(
 					context.Background(),
 					GetServerVersionParams{
-						Name:    serverName,
-						Version: version,
+						RegistryID: registryID,
+						Name:       serverName,
+						Version:    version,
+						Size:       10,
 					},
 				)
 				require.NoError(t, err)
@@ -1940,8 +1980,9 @@ func TestGetServerVersion(t *testing.T) {
 			regID := setupRegistry(t, queries)
 			require.NotNil(t, regID)
 
+			registryID := getServerRegistryID(t, queries, "test-registry")
 			serverName, version := tc.setupFunc(t, queries, regID)
-			tc.scenarioFunc(t, queries, serverName, version)
+			tc.scenarioFunc(t, queries, serverName, version, registryID)
 		})
 	}
 }

--- a/internal/db/sqlc/skills.sql.go
+++ b/internal/db/sqlc/skills.sql.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
 )
 
 const deleteOrphanedSkills = `-- name: DeleteOrphanedSkills :exec
@@ -72,32 +73,42 @@ SELECT src.source_type AS registry_type,
        s.metadata,
        s.extension_meta,
        e.claims,
+       rs.source_id,
        -- Sources not linked to the requested registry have no position; default to max int16
        -- so they sort after all explicitly positioned sources (lower position = higher priority).
        COALESCE(rs.position, 32767)::integer AS position
-  FROM skill s
-  JOIN entry_version v ON s.version_id = v.id
-  JOIN registry_entry e ON v.entry_id = e.id
+  FROM entry_version v
+  JOIN registry_entry e ON e.id = v.entry_id
+  JOIN registry_source rs ON rs.source_id = e.source_id
+                          AND rs.registry_id = $1::uuid
   JOIN source src ON e.source_id = src.id
+  JOIN skill s ON s.version_id = v.id
   LEFT JOIN latest_entry_version l ON v.id = l.latest_version_id
-  LEFT JOIN registry r ON r.name = $1::text
-  LEFT JOIN registry_source rs ON rs.source_id = e.source_id AND rs.registry_id = r.id
- WHERE e.name = $2
+ WHERE v.name = $2
    AND (v.version = $3::text
        OR ($3::text = 'latest' AND l.latest_version_id = v.id)
    )
-   AND ($1::text IS NULL OR rs.registry_id IS NOT NULL)
    AND ($4::text IS NULL OR src.name = $4::text)
    AND ($5::text IS NULL OR s.namespace = $5::text)
- ORDER BY rs.position ASC
+   AND (
+       $6::integer IS NULL
+       OR (rs.position > $6::integer
+           AND rs.source_id > $7::uuid
+       )
+   )
+ ORDER BY rs.position ASC, rs.source_id ASC
+ LIMIT $8::bigint
 `
 
 type GetSkillVersionParams struct {
-	RegistryName *string `json:"registry_name"`
-	Name         string  `json:"name"`
-	Version      string  `json:"version"`
-	SourceName   *string `json:"source_name"`
-	Namespace    *string `json:"namespace"`
+	RegistryID     uuid.UUID   `json:"registry_id"`
+	Name           string      `json:"name"`
+	Version        string      `json:"version"`
+	SourceName     *string     `json:"source_name"`
+	Namespace      *string     `json:"namespace"`
+	CursorPosition pgtype.Int4 `json:"cursor_position"`
+	CursorSourceID *uuid.UUID  `json:"cursor_source_id"`
+	Size           int64       `json:"size"`
 }
 
 type GetSkillVersionRow struct {
@@ -121,20 +132,25 @@ type GetSkillVersionRow struct {
 	Metadata       []byte      `json:"metadata"`
 	ExtensionMeta  []byte      `json:"extension_meta"`
 	Claims         []byte      `json:"claims"`
+	SourceID       uuid.UUID   `json:"source_id"`
 	Position       int32       `json:"position"`
 }
 
-// Despite the name, this query returns multiple rows. The careful reader will
-// note that there is no limit clause, which might seem a bug, but the actual
-// number of records is bounded by the number of sources that provide the same
-// name and version, which we currently don't expect to be more than a few.
+// Despite the name, this query returns multiple rows. The actual number of
+// records is bounded by the number of sources that provide the same name and
+// version, which we currently don't expect to be more than a few.
+// Cursor-based pagination using (position, source_id) compound cursor.
+// position is the sort key but may not be unique; source_id is the tiebreaker.
 func (q *Queries) GetSkillVersion(ctx context.Context, arg GetSkillVersionParams) ([]GetSkillVersionRow, error) {
 	rows, err := q.db.Query(ctx, getSkillVersion,
-		arg.RegistryName,
+		arg.RegistryID,
 		arg.Name,
 		arg.Version,
 		arg.SourceName,
 		arg.Namespace,
+		arg.CursorPosition,
+		arg.CursorSourceID,
+		arg.Size,
 	)
 	if err != nil {
 		return nil, err
@@ -164,6 +180,7 @@ func (q *Queries) GetSkillVersion(ctx context.Context, arg GetSkillVersionParams
 			&i.Metadata,
 			&i.ExtensionMeta,
 			&i.Claims,
+			&i.SourceID,
 			&i.Position,
 		); err != nil {
 			return nil, err
@@ -174,6 +191,99 @@ func (q *Queries) GetSkillVersion(ctx context.Context, arg GetSkillVersionParams
 		return nil, err
 	}
 	return items, nil
+}
+
+const getSkillVersionBySourceName = `-- name: GetSkillVersionBySourceName :one
+SELECT src.source_type AS registry_type,
+       v.id,
+       e.name,
+       v.version,
+       (l.latest_version_id IS NOT NULL)::boolean AS is_latest,
+       v.created_at,
+       v.updated_at,
+       v.description,
+       v.title,
+       s.version_id AS skill_version_id,
+       s.namespace,
+       s.status,
+       s.license,
+       s.compatibility,
+       s.allowed_tools,
+       s.repository,
+       s.icons,
+       s.metadata,
+       s.extension_meta,
+       e.claims,
+       0::integer AS position
+  FROM skill s
+  JOIN entry_version v ON s.version_id = v.id
+  JOIN registry_entry e ON v.entry_id = e.id
+  JOIN source src ON e.source_id = src.id
+  LEFT JOIN latest_entry_version l ON v.id = l.latest_version_id
+ WHERE v.name = $1
+   AND v.version = $2
+   AND src.name = $3
+`
+
+type GetSkillVersionBySourceNameParams struct {
+	Name       string `json:"name"`
+	Version    string `json:"version"`
+	SourceName string `json:"source_name"`
+}
+
+type GetSkillVersionBySourceNameRow struct {
+	RegistryType   string      `json:"registry_type"`
+	ID             uuid.UUID   `json:"id"`
+	Name           string      `json:"name"`
+	Version        string      `json:"version"`
+	IsLatest       bool        `json:"is_latest"`
+	CreatedAt      *time.Time  `json:"created_at"`
+	UpdatedAt      *time.Time  `json:"updated_at"`
+	Description    *string     `json:"description"`
+	Title          *string     `json:"title"`
+	SkillVersionID uuid.UUID   `json:"skill_version_id"`
+	Namespace      string      `json:"namespace"`
+	Status         SkillStatus `json:"status"`
+	License        *string     `json:"license"`
+	Compatibility  *string     `json:"compatibility"`
+	AllowedTools   []string    `json:"allowed_tools"`
+	Repository     []byte      `json:"repository"`
+	Icons          []byte      `json:"icons"`
+	Metadata       []byte      `json:"metadata"`
+	ExtensionMeta  []byte      `json:"extension_meta"`
+	Claims         []byte      `json:"claims"`
+	Position       int32       `json:"position"`
+}
+
+// Source-scoped variant of GetSkillVersion used by the publish fetch-back path.
+// source_name and version are required; registry filtering is not applied.
+func (q *Queries) GetSkillVersionBySourceName(ctx context.Context, arg GetSkillVersionBySourceNameParams) (GetSkillVersionBySourceNameRow, error) {
+	row := q.db.QueryRow(ctx, getSkillVersionBySourceName, arg.Name, arg.Version, arg.SourceName)
+	var i GetSkillVersionBySourceNameRow
+	err := row.Scan(
+		&i.RegistryType,
+		&i.ID,
+		&i.Name,
+		&i.Version,
+		&i.IsLatest,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.Description,
+		&i.Title,
+		&i.SkillVersionID,
+		&i.Namespace,
+		&i.Status,
+		&i.License,
+		&i.Compatibility,
+		&i.AllowedTools,
+		&i.Repository,
+		&i.Icons,
+		&i.Metadata,
+		&i.ExtensionMeta,
+		&i.Claims,
+		&i.Position,
+	)
+	return i, err
 }
 
 const insertSkillGitPackage = `-- name: InsertSkillGitPackage :exec
@@ -462,10 +572,9 @@ SELECT src.source_type AS registry_type,
   JOIN registry_entry e ON v.entry_id = e.id
   JOIN source src ON e.source_id = src.id
   LEFT JOIN latest_entry_version l ON v.id = l.latest_version_id
-  LEFT JOIN registry_source rs ON rs.source_id = e.source_id
-                               AND rs.registry_id = $1::uuid
- WHERE ($1::uuid IS NULL OR rs.source_id IS NOT NULL)
-   AND ($2::text IS NULL OR s.namespace = $2::text)
+  JOIN registry_source rs ON rs.source_id = e.source_id
+                          AND rs.registry_id = $1::uuid
+ WHERE ($2::text IS NULL OR s.namespace = $2::text)
    AND ($3::text IS NULL OR e.name = $3::text)
    AND ($4::text IS NULL OR (
        LOWER(e.name) LIKE LOWER('%' || $4::text || '%')
@@ -482,7 +591,7 @@ SELECT src.source_type AS registry_type,
 `
 
 type ListSkillsParams struct {
-	RegistryID    *uuid.UUID `json:"registry_id"`
+	RegistryID    uuid.UUID  `json:"registry_id"`
 	Namespace     *string    `json:"namespace"`
 	Name          *string    `json:"name"`
 	Search        *string    `json:"search"`

--- a/internal/db/sqlc/skills_test.go
+++ b/internal/db/sqlc/skills_test.go
@@ -76,7 +76,7 @@ func insertSkill(
 	return skillEntryID
 }
 
-//nolint:thelper // We want to see these lines in the test output
+//nolint:thelper,unparam // We want to see these lines in the test output; name is intentionally flexible
 func getRegistryID(t *testing.T, queries *Queries, name string) uuid.UUID {
 	reg, err := queries.GetRegistryByName(context.Background(), name)
 	require.NoError(t, err)
@@ -169,6 +169,7 @@ func TestInsertSkillVersion(t *testing.T) {
 					context.Background(),
 					InsertEntryVersionParams{
 						EntryID:   entryID,
+						Name:      "test-skill-dup",
 						Version:   testSkillVersion,
 						CreatedAt: &createdAt,
 						UpdatedAt: &createdAt,
@@ -181,6 +182,7 @@ func TestInsertSkillVersion(t *testing.T) {
 					context.Background(),
 					InsertEntryVersionParams{
 						EntryID:   entryID,
+						Name:      "test-skill-dup",
 						Version:   testSkillVersion,
 						CreatedAt: &createdAt,
 						UpdatedAt: &createdAt,
@@ -235,8 +237,10 @@ func TestInsertSkillVersion(t *testing.T) {
 				skillRows, err := queries.GetSkillVersion(
 					context.Background(),
 					GetSkillVersionParams{
-						Name:    "test-skill",
-						Version: testSkillVersion,
+						RegistryID: getRegistryID(t, queries, "test-registry"),
+						Name:       "test-skill",
+						Version:    testSkillVersion,
+						Size:       10,
 					},
 				)
 				require.NoError(t, err)
@@ -412,8 +416,10 @@ func TestUpsertSkillVersionForSync(t *testing.T) {
 				existingRows, err := queries.GetSkillVersion(
 					context.Background(),
 					GetSkillVersionParams{
-						Name:    "test-skill",
-						Version: testSkillVersion,
+						RegistryID: getRegistryID(t, queries, "test-registry"),
+						Name:       "test-skill",
+						Version:    testSkillVersion,
+						Size:       10,
 					},
 				)
 				require.NoError(t, err)
@@ -443,8 +449,10 @@ func TestUpsertSkillVersionForSync(t *testing.T) {
 				skillRows, err := queries.GetSkillVersion(
 					context.Background(),
 					GetSkillVersionParams{
-						Name:    "test-skill",
-						Version: testSkillVersion,
+						RegistryID: getRegistryID(t, queries, "test-registry"),
+						Name:       "test-skill",
+						Version:    testSkillVersion,
+						Size:       10,
 					},
 				)
 				require.NoError(t, err)
@@ -517,8 +525,10 @@ func TestGetSkillVersion(t *testing.T) {
 				skillRows, err := queries.GetSkillVersion(
 					context.Background(),
 					GetSkillVersionParams{
-						Name:    skillName,
-						Version: version,
+						RegistryID: getRegistryID(t, queries, "test-registry"),
+						Name:       skillName,
+						Version:    version,
+						Size:       10,
 					},
 				)
 				require.NoError(t, err)
@@ -564,8 +574,10 @@ func TestGetSkillVersion(t *testing.T) {
 				skillRows, err := queries.GetSkillVersion(
 					context.Background(),
 					GetSkillVersionParams{
-						Name:    skillName,
-						Version: version,
+						RegistryID: getRegistryID(t, queries, "test-registry"),
+						Name:       skillName,
+						Version:    version,
+						Size:       10,
 					},
 				)
 				require.NoError(t, err)
@@ -614,8 +626,10 @@ func TestGetSkillVersion(t *testing.T) {
 				skillRows, err := queries.GetSkillVersion(
 					context.Background(),
 					GetSkillVersionParams{
-						Name:    skillName,
-						Version: version,
+						RegistryID: getRegistryID(t, queries, "test-registry"),
+						Name:       skillName,
+						Version:    version,
+						Size:       10,
 					},
 				)
 				require.NoError(t, err)
@@ -651,8 +665,10 @@ func TestGetSkillVersion(t *testing.T) {
 				skillRows, err := queries.GetSkillVersion(
 					context.Background(),
 					GetSkillVersionParams{
-						Name:    skillName,
-						Version: version,
+						RegistryID: getRegistryID(t, queries, "test-registry"),
+						Name:       skillName,
+						Version:    version,
+						Size:       10,
 					},
 				)
 				require.NoError(t, err)
@@ -673,13 +689,14 @@ func TestGetSkillVersion(t *testing.T) {
 			},
 			//nolint:thelper // We want to see these lines in the test output
 			scenarioFunc: func(t *testing.T, queries *Queries, _ uuid.UUID, skillName, version string) {
-				regName := "test-registry"
+				regID := getRegistryID(t, queries, "test-registry")
 				skillRows, err := queries.GetSkillVersion(
 					context.Background(),
 					GetSkillVersionParams{
-						Name:         skillName,
-						Version:      version,
-						RegistryName: &regName,
+						Name:       skillName,
+						Version:    version,
+						RegistryID: regID,
+						Size:       10,
 					},
 				)
 				require.NoError(t, err)
@@ -687,14 +704,15 @@ func TestGetSkillVersion(t *testing.T) {
 				require.Equal(t, skillName, skillRows[0].Name)
 				require.Equal(t, version, skillRows[0].Version)
 
-				// Wrong registry name returns empty results
-				wrongName := "nonexistent-registry"
+				// Wrong registry ID returns empty results
+				wrongID := uuid.New()
 				wrongRows, err := queries.GetSkillVersion(
 					context.Background(),
 					GetSkillVersionParams{
-						Name:         skillName,
-						Version:      version,
-						RegistryName: &wrongName,
+						Name:       skillName,
+						Version:    version,
+						RegistryID: wrongID,
+						Size:       10,
 					},
 				)
 				require.NoError(t, err)
@@ -712,8 +730,10 @@ func TestGetSkillVersion(t *testing.T) {
 				skillRows, err := queries.GetSkillVersion(
 					context.Background(),
 					GetSkillVersionParams{
-						Name:    skillName,
-						Version: version,
+						RegistryID: getRegistryID(t, queries, "test-registry"),
+						Name:       skillName,
+						Version:    version,
+						Size:       10,
 					},
 				)
 				require.NoError(t, err)
@@ -733,8 +753,10 @@ func TestGetSkillVersion(t *testing.T) {
 				skillRows, err := queries.GetSkillVersion(
 					context.Background(),
 					GetSkillVersionParams{
-						Name:    skillName,
-						Version: version,
+						RegistryID: getRegistryID(t, queries, "test-registry"),
+						Name:       skillName,
+						Version:    version,
+						Size:       10,
 					},
 				)
 				require.NoError(t, err)
@@ -779,7 +801,8 @@ func TestListSkills(t *testing.T) {
 				skills, err := queries.ListSkills(
 					context.Background(),
 					ListSkillsParams{
-						Size: 10,
+						RegistryID: getRegistryID(t, queries, "test-registry"),
+						Size:       10,
 					},
 				)
 				require.NoError(t, err)
@@ -798,7 +821,8 @@ func TestListSkills(t *testing.T) {
 				skills, err := queries.ListSkills(
 					context.Background(),
 					ListSkillsParams{
-						Size: 10,
+						RegistryID: getRegistryID(t, queries, "test-registry"),
+						Size:       10,
 					},
 				)
 				require.NoError(t, err)
@@ -823,7 +847,8 @@ func TestListSkills(t *testing.T) {
 				skills, err := queries.ListSkills(
 					context.Background(),
 					ListSkillsParams{
-						Size: 10,
+						RegistryID: getRegistryID(t, queries, "test-registry"),
+						Size:       10,
 					},
 				)
 				require.NoError(t, err)
@@ -845,11 +870,13 @@ func TestListSkills(t *testing.T) {
 			},
 			//nolint:thelper // We want to see these lines in the test output
 			scenarioFunc: func(t *testing.T, queries *Queries, _ uuid.UUID) {
+				regID := getRegistryID(t, queries, "test-registry")
 				// Get first page
 				allSkills, err := queries.ListSkills(
 					context.Background(),
 					ListSkillsParams{
-						Size: 10,
+						RegistryID: regID,
+						Size:       10,
 					},
 				)
 				require.NoError(t, err)
@@ -861,6 +888,7 @@ func TestListSkills(t *testing.T) {
 				skills, err := queries.ListSkills(
 					context.Background(),
 					ListSkillsParams{
+						RegistryID:    regID,
 						CursorName:    &cursorName,
 						CursorVersion: &cursorVersion,
 						Size:          10,
@@ -886,7 +914,8 @@ func TestListSkills(t *testing.T) {
 				skills, err := queries.ListSkills(
 					context.Background(),
 					ListSkillsParams{
-						Size: 2,
+						RegistryID: getRegistryID(t, queries, "test-registry"),
+						Size:       2,
 					},
 				)
 				require.NoError(t, err)
@@ -910,8 +939,9 @@ func TestListSkills(t *testing.T) {
 				skills, err := queries.ListSkills(
 					context.Background(),
 					ListSkillsParams{
-						Namespace: &ns,
-						Size:      10,
+						RegistryID: getRegistryID(t, queries, "test-registry"),
+						Namespace:  &ns,
+						Size:       10,
 					},
 				)
 				require.NoError(t, err)
@@ -935,8 +965,9 @@ func TestListSkills(t *testing.T) {
 				skills, err := queries.ListSkills(
 					context.Background(),
 					ListSkillsParams{
-						Name: &name,
-						Size: 10,
+						RegistryID: getRegistryID(t, queries, "test-registry"),
+						Name:       &name,
+						Size:       10,
 					},
 				)
 				require.NoError(t, err)
@@ -962,8 +993,9 @@ func TestListSkills(t *testing.T) {
 				skills, err := queries.ListSkills(
 					context.Background(),
 					ListSkillsParams{
-						Search: &search,
-						Size:   10,
+						RegistryID: getRegistryID(t, queries, "test-registry"),
+						Search:     &search,
+						Size:       10,
 					},
 				)
 				require.NoError(t, err)
@@ -993,6 +1025,7 @@ func TestListSkills(t *testing.T) {
 					context.Background(),
 					InsertEntryVersionParams{
 						EntryID:   oldEntryID,
+						Name:      "old-skill",
 						Version:   testSkillVersion,
 						CreatedAt: &oldTime,
 						UpdatedAt: &oldTime,
@@ -1016,6 +1049,7 @@ func TestListSkills(t *testing.T) {
 					context.Background(),
 					InsertEntryVersionParams{
 						EntryID:   recentEntryID,
+						Name:      "recent-skill",
 						Version:   testSkillVersion,
 						CreatedAt: &recentTime,
 						UpdatedAt: &recentTime,
@@ -1030,6 +1064,7 @@ func TestListSkills(t *testing.T) {
 				skills, err := queries.ListSkills(
 					context.Background(),
 					ListSkillsParams{
+						RegistryID:   getRegistryID(t, queries, "test-registry"),
 						UpdatedSince: &since,
 						Size:         10,
 					},
@@ -1052,7 +1087,7 @@ func TestListSkills(t *testing.T) {
 				skills, err := queries.ListSkills(
 					context.Background(),
 					ListSkillsParams{
-						RegistryID: &regID,
+						RegistryID: regID,
 						Size:       10,
 					},
 				)
@@ -1064,7 +1099,7 @@ func TestListSkills(t *testing.T) {
 				skills, err = queries.ListSkills(
 					context.Background(),
 					ListSkillsParams{
-						RegistryID: &wrongID,
+						RegistryID: wrongID,
 						Size:       10,
 					},
 				)
@@ -1093,6 +1128,7 @@ func TestListSkills(t *testing.T) {
 						context.Background(),
 						InsertEntryVersionParams{
 							EntryID:   entryID,
+							Name:      "test-skill",
 							Version:   version,
 							CreatedAt: &createdAt,
 							UpdatedAt: &createdAt,
@@ -1107,7 +1143,8 @@ func TestListSkills(t *testing.T) {
 				skills, err := queries.ListSkills(
 					context.Background(),
 					ListSkillsParams{
-						Size: 10,
+						RegistryID: getRegistryID(t, queries, "test-registry"),
+						Size:       10,
 					},
 				)
 				require.NoError(t, err)
@@ -1193,6 +1230,7 @@ func TestUpsertLatestSkillVersion(t *testing.T) {
 						context.Background(),
 						InsertEntryVersionParams{
 							EntryID:   entryID,
+							Name:      "test-skill",
 							Version:   version,
 							CreatedAt: &createdAt,
 							UpdatedAt: &createdAt,
@@ -1330,7 +1368,10 @@ func TestDeleteOrphanedSkills(t *testing.T) {
 				// Verify only the kept skill remains
 				skills, err := queries.ListSkills(
 					context.Background(),
-					ListSkillsParams{Size: 10},
+					ListSkillsParams{
+						RegistryID: getRegistryID(t, queries, "test-registry"),
+						Size:       10,
+					},
 				)
 				require.NoError(t, err)
 				require.Len(t, skills, 1)
@@ -1362,7 +1403,10 @@ func TestDeleteOrphanedSkills(t *testing.T) {
 
 				skills, err := queries.ListSkills(
 					context.Background(),
-					ListSkillsParams{Size: 10},
+					ListSkillsParams{
+						RegistryID: getRegistryID(t, queries, "test-registry"),
+						Size:       10,
+					},
 				)
 				require.NoError(t, err)
 				require.Empty(t, skills)

--- a/internal/service/db/impl.go
+++ b/internal/service/db/impl.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"go.opentelemetry.io/otel/trace"
 
@@ -26,8 +27,10 @@ var (
 // serverCursor represents a cursor for pagination based on server name and version.
 // This provides deterministic ordering regardless of timestamp values.
 type serverCursor struct {
-	Name    string
-	Version string
+	Name     string
+	Version  string
+	Position int32
+	SourceID uuid.UUID
 }
 
 // options holds configuration options for the database service

--- a/internal/service/db/impl_common.go
+++ b/internal/service/db/impl_common.go
@@ -36,13 +36,6 @@ func lookupRegistryID(ctx context.Context, pool sqlc.DBTX, registryName string) 
 	return row.ID, nil
 }
 
-// checkRegistryExists validates that a registry with the given name exists.
-// Returns ErrRegistryNotFound if the registry does not exist.
-func checkRegistryExists(ctx context.Context, pool sqlc.DBTX, registryName string) error {
-	_, err := lookupRegistryID(ctx, pool, registryName)
-	return err
-}
-
 // upsertLatestFunc is a callback used by rePointLatestVersionIfNeeded to update
 // the latest-version pointer for a specific entry type (MCP server or skill).
 type upsertLatestFunc func(

--- a/internal/service/db/impl_mcp.go
+++ b/internal/service/db/impl_mcp.go
@@ -12,6 +12,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgtype"
 	upstreamv0 "github.com/modelcontextprotocol/registry/pkg/api/v0"
 	model "github.com/modelcontextprotocol/registry/pkg/model"
 
@@ -52,19 +53,21 @@ func (s *dbService) ListServers(
 		otel.AttrPageSize.Int(options.Limit),
 		otel.AttrHasCursor.Bool(options.Cursor != ""),
 	)
+	if options.RegistryName == "" {
+		return nil, fmt.Errorf("registry name is required")
+	}
+	span.SetAttributes(otel.AttrRegistryName.String(options.RegistryName))
+
+	registryID, err := lookupRegistryID(ctx, s.pool, options.RegistryName)
+	if err != nil {
+		otel.RecordError(span, err)
+		return nil, err
+	}
+
 	// Request one extra record to detect if there are more results
 	params := sqlc.ListServersParams{
-		Size: int64(options.Limit + 1),
-	}
-	if options.RegistryName != nil {
-		span.SetAttributes(otel.AttrRegistryName.String(*options.RegistryName))
-
-		registryID, err := lookupRegistryID(ctx, s.pool, *options.RegistryName)
-		if err != nil {
-			otel.RecordError(span, err)
-			return nil, err
-		}
-		params.RegistryID = &registryID
+		Size:       int64(options.Limit + 1),
+		RegistryID: registryID,
 	}
 
 	slog.DebugContext(ctx, "ListServers query",
@@ -174,19 +177,21 @@ func (s *dbService) ListServerVersions(
 		otel.AttrServerName.String(options.Name),
 		otel.AttrPageSize.Int(options.Limit),
 	)
-	params := sqlc.ListServersParams{
-		Name: &options.Name,
-		Size: int64(options.Limit),
+	if options.RegistryName == "" {
+		return nil, fmt.Errorf("registry name is required")
 	}
-	if options.RegistryName != nil {
-		span.SetAttributes(otel.AttrRegistryName.String(*options.RegistryName))
+	span.SetAttributes(otel.AttrRegistryName.String(options.RegistryName))
 
-		registryID, err := lookupRegistryID(ctx, s.pool, *options.RegistryName)
-		if err != nil {
-			otel.RecordError(span, err)
-			return nil, err
-		}
-		params.RegistryID = &registryID
+	registryIDForVersions, err := lookupRegistryID(ctx, s.pool, options.RegistryName)
+	if err != nil {
+		otel.RecordError(span, err)
+		return nil, err
+	}
+
+	params := sqlc.ListServersParams{
+		Name:       &options.Name,
+		Size:       int64(options.Limit),
+		RegistryID: registryIDForVersions,
 	}
 
 	// Note: this function fetches a list of server versions. In case no records are
@@ -245,39 +250,42 @@ func (s *dbService) GetServerVersion(
 		}
 	}
 
+	if options.RegistryName == "" {
+		return nil, fmt.Errorf("registry name is required")
+	}
+
 	// Add tracing attributes
 	span.SetAttributes(
 		otel.AttrServerName.String(options.Name),
 		otel.AttrServerVersion.String(options.Version),
+		otel.AttrRegistryName.String(options.RegistryName),
 	)
-	if options.RegistryName != "" {
-		span.SetAttributes(otel.AttrRegistryName.String(options.RegistryName))
-	}
 
-	if options.RegistryName != "" {
-		if err := checkRegistryExists(ctx, s.pool, options.RegistryName); err != nil {
-			otel.RecordError(span, err)
-			return nil, err
-		}
-	}
-
-	params := sqlc.GetServerVersionParams{
-		Name:    options.Name,
-		Version: options.Version,
-	}
-	if options.RegistryName != "" {
-		params.RegistryName = &options.RegistryName
-	}
-	if options.SourceName != "" {
-		params.SourceName = &options.SourceName
+	registryID, err := lookupRegistryID(ctx, s.pool, options.RegistryName)
+	if err != nil {
+		otel.RecordError(span, err)
+		return nil, err
 	}
 
 	// Note: this function fetches a single record given name and version.
 	// In case no record is found, the called function maps the underlying
 	// `pgx.ErrNoRows` to `service.ErrNotFound`, and callers should expect
 	// to receive `service.ErrNotFound` for a missing record.
-	querierFunc := func(ctx context.Context, querier sqlc.Querier, _ *serverCursor) ([]helper, error) {
-		servers, err := querier.GetServerVersion(ctx, params)
+	querierFunc := func(ctx context.Context, querier sqlc.Querier, cursor *serverCursor) ([]helper, error) {
+		p := sqlc.GetServerVersionParams{
+			Name:       options.Name,
+			Version:    options.Version,
+			RegistryID: registryID,
+			Size:       int64(service.MaxPageSize) + 1,
+		}
+		if options.SourceName != "" {
+			p.SourceName = &options.SourceName
+		}
+		if cursor != nil {
+			p.CursorPosition = pgtype.Int4{Int32: cursor.Position, Valid: true}
+			p.CursorSourceID = &cursor.SourceID
+		}
+		servers, err := querier.GetServerVersion(ctx, p)
 		if err != nil {
 			if errors.Is(err, pgx.ErrNoRows) {
 				return nil, fmt.Errorf("%w: %s %s", service.ErrNotFound, options.Name, options.Version)
@@ -626,17 +634,51 @@ func (s *dbService) PublishServerVersion(
 		"request_id", middleware.GetReqID(ctx))
 
 	// Fetch the inserted server to return it
-	result, err := s.GetServerVersion(ctx,
-		service.WithSourceName(sourceName),
-		service.WithName(serverData.Name),
-		service.WithVersion(serverData.Version),
-	)
+	result, err := s.fetchServerVersionBySource(ctx, serverData.Name, serverData.Version, sourceName)
 	if err != nil {
 		otel.RecordError(span, err)
 		return nil, fmt.Errorf("failed to fetch published server: %w", err)
 	}
 
 	return result, nil
+}
+
+// fetchServerVersionBySource retrieves a server version using the source name directly,
+// bypassing registry filtering. Used by the publish fetch-back path.
+func (s *dbService) fetchServerVersionBySource(
+	ctx context.Context,
+	name, version, sourceName string,
+) (*upstreamv0.ServerJSON, error) {
+	querier := sqlc.New(s.pool)
+	row, err := querier.GetServerVersionBySourceName(ctx, sqlc.GetServerVersionBySourceNameParams{
+		Name:       name,
+		Version:    version,
+		SourceName: sourceName,
+	})
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, fmt.Errorf("%w: %s %s", service.ErrNotFound, name, version)
+		}
+		return nil, err
+	}
+
+	h := getServerVersionBySourceNameRowToHelper(row)
+
+	versionIDs := []uuid.UUID{row.ID}
+	packages, err := querier.ListServerPackages(ctx, versionIDs)
+	if err != nil {
+		return nil, err
+	}
+	remotes, err := querier.ListServerRemotes(ctx, versionIDs)
+	if err != nil {
+		return nil, err
+	}
+
+	server, err := helperToServer(h, packages, remotes)
+	if err != nil {
+		return nil, err
+	}
+	return &server, nil
 }
 
 // executePublishTransaction executes the publish operation within a transaction
@@ -1003,7 +1045,12 @@ func streamHelpers(
 		// Advance cursor to continue fetching
 		if len(batch) > 0 {
 			lastRow := batch[len(batch)-1]
-			cursor = &serverCursor{Name: lastRow.Name, Version: lastRow.Version}
+			cursor = &serverCursor{
+				Name:     lastRow.Name,
+				Version:  lastRow.Version,
+				Position: lastRow.Position,
+				SourceID: lastRow.SourceID,
+			}
 		}
 	}
 
@@ -1011,7 +1058,12 @@ func streamHelpers(
 	var lastCursor *serverCursor
 	if len(accumulated) > limit {
 		last := accumulated[limit-1]
-		lastCursor = &serverCursor{Name: last.Name, Version: last.Version}
+		lastCursor = &serverCursor{
+			Name:     last.Name,
+			Version:  last.Version,
+			Position: last.Position,
+			SourceID: last.SourceID,
+		}
 		accumulated = accumulated[:limit]
 	}
 

--- a/internal/service/db/impl_skills.go
+++ b/internal/service/db/impl_skills.go
@@ -58,7 +58,7 @@ func (s *dbService) ListSkills(
 	querier := sqlc.New(s.pool)
 
 	params := sqlc.ListSkillsParams{
-		RegistryID: &registryID,
+		RegistryID: registryID,
 		Size:       int64(options.Limit + 1),
 	}
 	if options.Namespace != "" {
@@ -162,8 +162,8 @@ func (s *dbService) GetSkillVersion(
 		}
 	}
 
-	if options.RegistryName == "" && options.SourceName == "" {
-		return nil, fmt.Errorf("registry name or source name is required")
+	if options.RegistryName == "" {
+		return nil, fmt.Errorf("registry name is required")
 	}
 	if options.Name == "" || options.Version == "" {
 		return nil, fmt.Errorf("name and version are required")
@@ -174,22 +174,20 @@ func (s *dbService) GetSkillVersion(
 
 	span.SetAttributes(otel.AttrRegistryName.String(options.RegistryName))
 
-	if options.RegistryName != "" {
-		if err := checkRegistryExists(ctx, s.pool, options.RegistryName); err != nil {
-			otel.RecordError(span, err)
-			return nil, err
-		}
+	registryID, err := lookupRegistryID(ctx, s.pool, options.RegistryName)
+	if err != nil {
+		otel.RecordError(span, err)
+		return nil, err
 	}
 
 	querier := sqlc.New(s.pool)
 
 	params := sqlc.GetSkillVersionParams{
-		Name:      options.Name,
-		Version:   options.Version,
-		Namespace: &options.Namespace,
-	}
-	if options.RegistryName != "" {
-		params.RegistryName = &options.RegistryName
+		Name:       options.Name,
+		Version:    options.Version,
+		Namespace:  &options.Namespace,
+		RegistryID: registryID,
+		Size:       int64(service.MaxPageSize) + 1,
 	}
 	if options.SourceName != "" {
 		params.SourceName = &options.SourceName
@@ -320,12 +318,75 @@ func (s *dbService) PublishSkill(
 		return nil, err
 	}
 
-	return s.GetSkillVersion(ctx,
-		service.WithSourceName(sourceName),
-		service.WithName(skill.Name),
-		service.WithVersion(skill.Version),
-		service.WithNamespace(skill.Namespace),
-	)
+	result, err := s.fetchSkillVersionBySource(ctx, skill.Name, skill.Version, sourceName)
+	if err != nil {
+		otel.RecordError(span, err)
+		return nil, fmt.Errorf("failed to fetch published skill: %w", err)
+	}
+	return result, nil
+}
+
+// fetchSkillVersionBySource retrieves a skill version using the source name directly,
+// bypassing registry filtering. Used by the publish fetch-back path.
+func (s *dbService) fetchSkillVersionBySource(
+	ctx context.Context,
+	name, version, sourceName string,
+) (*service.Skill, error) {
+	querier := sqlc.New(s.pool)
+	row, err := querier.GetSkillVersionBySourceName(ctx, sqlc.GetSkillVersionBySourceNameParams{
+		Name:       name,
+		Version:    version,
+		SourceName: sourceName,
+	})
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, fmt.Errorf("%w: %s %s", service.ErrNotFound, name, version)
+		}
+		return nil, err
+	}
+
+	ociPackages, err := querier.ListSkillOciPackages(ctx, []uuid.UUID{row.SkillVersionID})
+	if err != nil {
+		return nil, err
+	}
+	gitPackages, err := querier.ListSkillGitPackages(ctx, []uuid.UUID{row.SkillVersionID})
+	if err != nil {
+		return nil, err
+	}
+
+	packages := make([]service.SkillPackage, 0, len(ociPackages)+len(gitPackages))
+	for _, pkg := range ociPackages {
+		packages = append(packages, toServiceSkillOciPackage(pkg))
+	}
+	for _, pkg := range gitPackages {
+		packages = append(packages, toServiceSkillGitPackage(pkg))
+	}
+
+	result := service.GetSkillVersionRowToSkill(sqlc.GetSkillVersionRow{
+		RegistryType:   row.RegistryType,
+		ID:             row.ID,
+		Name:           row.Name,
+		Version:        row.Version,
+		IsLatest:       row.IsLatest,
+		CreatedAt:      row.CreatedAt,
+		UpdatedAt:      row.UpdatedAt,
+		Description:    row.Description,
+		Title:          row.Title,
+		SkillVersionID: row.SkillVersionID,
+		Namespace:      row.Namespace,
+		Status:         row.Status,
+		License:        row.License,
+		Compatibility:  row.Compatibility,
+		AllowedTools:   row.AllowedTools,
+		Repository:     row.Repository,
+		Icons:          row.Icons,
+		Metadata:       row.Metadata,
+		ExtensionMeta:  row.ExtensionMeta,
+		Claims:         row.Claims,
+		Position:       row.Position,
+	})
+	result.Packages = packages
+	return result, nil
 }
 
 // executePublishSkillTransaction executes the skill publish operation within a transaction.

--- a/internal/service/db/impl_test.go
+++ b/internal/service/db/impl_test.go
@@ -103,6 +103,7 @@ func setupTestData(t *testing.T, pool *pgxpool.Pool) {
 			ctx,
 			sqlc.InsertEntryVersionParams{
 				EntryID:     entryID1,
+				Name:        "com.example/test-server-1",
 				Version:     version,
 				Title:       ptr.String("Test Server 1"),
 				Description: ptr.String("Test server 1 description"),
@@ -160,6 +161,7 @@ func setupTestData(t *testing.T, pool *pgxpool.Pool) {
 		ctx,
 		sqlc.InsertEntryVersionParams{
 			EntryID:     entryID2,
+			Name:        "com.example/test-server-2",
 			Version:     "1.0.0",
 			Title:       ptr.String("Test Server 2"),
 			Description: ptr.String("Test server 2 description"),
@@ -203,6 +205,7 @@ func TestListServers(t *testing.T) {
 				setupTestData(t, pool)
 			},
 			options: []service.Option{
+				service.WithRegistryName("test-registry"),
 				service.WithLimit(10),
 			},
 			//nolint:thelper // We want to see these lines in the test output
@@ -222,6 +225,7 @@ func TestListServers(t *testing.T) {
 				setupTestData(t, pool)
 			},
 			options: []service.Option{
+				service.WithRegistryName("test-registry"),
 				service.WithLimit(2),
 			},
 			//nolint:thelper // We want to see these lines in the test output
@@ -255,10 +259,21 @@ func TestListServers(t *testing.T) {
 		{
 			name: "empty database",
 			//nolint:thelper // We want to see these lines in the test output
-			setupFunc: func(_ *testing.T, _ *pgxpool.Pool) {
-				// Don't set up any data
+			setupFunc: func(t *testing.T, pool *pgxpool.Pool) {
+				// Don't set up server data, but create the registry so the lookup succeeds.
+				ctx := context.Background()
+				queries := sqlc.New(pool)
+				now := time.Now().UTC()
+				_, err := queries.UpsertRegistry(ctx, sqlc.UpsertRegistryParams{
+					Name:         "test-registry",
+					CreationType: sqlc.CreationTypeCONFIG,
+					CreatedAt:    &now,
+					UpdatedAt:    &now,
+				})
+				require.NoError(t, err)
 			},
 			options: []service.Option{
+				service.WithRegistryName("test-registry"),
 				service.WithLimit(10),
 			},
 			//nolint:thelper // We want to see these lines in the test output
@@ -304,6 +319,7 @@ func TestListServers(t *testing.T) {
 				setupTestData(t, pool)
 			},
 			options: []service.Option{
+				service.WithRegistryName("test-registry"),
 				service.WithSearch("server-1"),
 				service.WithLimit(10),
 			},
@@ -322,6 +338,7 @@ func TestListServers(t *testing.T) {
 				setupTestData(t, pool)
 			},
 			options: []service.Option{
+				service.WithRegistryName("test-registry"),
 				service.WithSearch("Test Server 2"),
 				service.WithLimit(10),
 			},
@@ -338,6 +355,7 @@ func TestListServers(t *testing.T) {
 				setupTestData(t, pool)
 			},
 			options: []service.Option{
+				service.WithRegistryName("test-registry"),
 				service.WithSearch("server 2 description"),
 				service.WithLimit(10),
 			},
@@ -354,6 +372,7 @@ func TestListServers(t *testing.T) {
 				setupTestData(t, pool)
 			},
 			options: []service.Option{
+				service.WithRegistryName("test-registry"),
 				service.WithSearch("SERVER-1"), // Uppercase
 				service.WithLimit(10),
 			},
@@ -372,6 +391,7 @@ func TestListServers(t *testing.T) {
 				setupTestData(t, pool)
 			},
 			options: []service.Option{
+				service.WithRegistryName("test-registry"),
 				service.WithSearch("server"), // Partial match
 				service.WithLimit(10),
 			},
@@ -387,6 +407,7 @@ func TestListServers(t *testing.T) {
 				setupTestData(t, pool)
 			},
 			options: []service.Option{
+				service.WithRegistryName("test-registry"),
 				service.WithSearch("nonexistent"),
 				service.WithLimit(10),
 			},
@@ -421,6 +442,7 @@ func TestListServers(t *testing.T) {
 				setupTestData(t, pool)
 			},
 			options: []service.Option{
+				service.WithRegistryName("test-registry"),
 				service.WithVersion("latest"),
 				service.WithLimit(10),
 			},
@@ -474,6 +496,7 @@ func TestListServerVersions(t *testing.T) {
 			},
 			options: []service.Option{
 				service.WithName("com.example/test-server-1"),
+				service.WithRegistryName("test-registry"),
 				service.WithLimit(10),
 			},
 			//nolint:thelper // We want to see these lines in the test output
@@ -501,6 +524,7 @@ func TestListServerVersions(t *testing.T) {
 			},
 			options: []service.Option{
 				service.WithName("com.example/test-server-1"),
+				service.WithRegistryName("test-registry"),
 				service.WithLimit(2),
 			},
 			//nolint:thelper // We want to see these lines in the test output
@@ -516,6 +540,7 @@ func TestListServerVersions(t *testing.T) {
 			},
 			options: []service.Option{
 				service.WithName("com.example/non-existent-server"),
+				service.WithRegistryName("test-registry"),
 				service.WithLimit(10),
 			},
 			//nolint:thelper // We want to see these lines in the test output
@@ -615,6 +640,7 @@ func TestGetServerVersion(t *testing.T) {
 				setupTestData(t, pool)
 			},
 			options: []service.Option{
+				service.WithRegistryName("test-registry"),
 				service.WithName("com.example/test-server-1"),
 				service.WithVersion("1.0.0"),
 			},
@@ -636,6 +662,7 @@ func TestGetServerVersion(t *testing.T) {
 				setupTestData(t, pool)
 			},
 			options: []service.Option{
+				service.WithRegistryName("test-registry"),
 				service.WithName("com.example/test-server-1"),
 				service.WithVersion("2.0.0"),
 			},
@@ -697,6 +724,7 @@ func TestGetServerVersion(t *testing.T) {
 				setupTestData(t, pool)
 			},
 			options: []service.Option{
+				service.WithRegistryName("test-registry"),
 				service.WithName("com.example/test-server-2"),
 				service.WithVersion("1.0.0"),
 			},
@@ -727,8 +755,24 @@ func TestGetServerVersion(t *testing.T) {
 				)
 				require.NoError(t, err)
 
-				// Create a server version
+				// Create a registry and link the source to it
 				now := time.Now().UTC()
+				registry, err := queries.UpsertRegistry(ctx, sqlc.UpsertRegistryParams{
+					Name:         "test-registry-with-packages",
+					CreationType: sqlc.CreationTypeCONFIG,
+					CreatedAt:    &now,
+					UpdatedAt:    &now,
+				})
+				require.NoError(t, err)
+
+				err = queries.LinkRegistrySource(ctx, sqlc.LinkRegistrySourceParams{
+					RegistryID: registry.ID,
+					SourceID:   regID,
+					Position:   0,
+				})
+				require.NoError(t, err)
+
+				// Create a server version
 				entryID, err := queries.InsertRegistryEntry(
 					ctx,
 					sqlc.InsertRegistryEntryParams{
@@ -745,6 +789,7 @@ func TestGetServerVersion(t *testing.T) {
 					ctx,
 					sqlc.InsertEntryVersionParams{
 						EntryID:     entryID,
+						Name:        "com.test/server-with-packages",
 						Version:     "1.0.0",
 						Title:       ptr.String("Test Server With Packages"),
 						Description: ptr.String("Test server with packages and remotes"),
@@ -804,6 +849,7 @@ func TestGetServerVersion(t *testing.T) {
 				require.NoError(t, err)
 			},
 			options: []service.Option{
+				service.WithRegistryName("test-registry-with-packages"),
 				service.WithName("com.test/server-with-packages"),
 				service.WithVersion("1.0.0"),
 			},
@@ -1288,6 +1334,7 @@ func TestPublishServerVersion(t *testing.T) {
 
 				versionID, err := queries.InsertEntryVersion(ctx, sqlc.InsertEntryVersionParams{
 					EntryID:     entryID,
+					Name:        "com.example/existing-server",
 					Version:     "1.0.0",
 					Description: ptr.String("Existing"),
 					CreatedAt:   &now,
@@ -2622,11 +2669,27 @@ func TestDeleteServerVersion(t *testing.T) {
 				})
 				require.NoError(t, err)
 			} else {
-				_, err := queries.InsertSource(ctx, sqlc.InsertSourceParams{
+				src, err := queries.InsertSource(ctx, sqlc.InsertSourceParams{
 					Name:         tt.registryName,
 					SourceType:   "managed",
 					CreationType: sqlc.CreationTypeCONFIG,
 					Syncable:     false,
+				})
+				require.NoError(t, err)
+
+				now := time.Now()
+				reg, err := queries.UpsertRegistry(ctx, sqlc.UpsertRegistryParams{
+					Name:         tt.registryName,
+					CreationType: sqlc.CreationTypeCONFIG,
+					CreatedAt:    &now,
+					UpdatedAt:    &now,
+				})
+				require.NoError(t, err)
+
+				err = queries.LinkRegistrySource(ctx, sqlc.LinkRegistrySourceParams{
+					RegistryID: reg.ID,
+					SourceID:   src.ID,
+					Position:   0,
 				})
 				require.NoError(t, err)
 			}
@@ -2662,6 +2725,7 @@ func TestDeleteServerVersion(t *testing.T) {
 			// Verify the latest pointer.
 			result, err := svc.GetServerVersion(
 				ctx,
+				service.WithRegistryName(tt.registryName),
 				service.WithName(tt.serverName),
 				service.WithVersion("latest"),
 			)

--- a/internal/service/db/shadowing_get_server_version_test.go
+++ b/internal/service/db/shadowing_get_server_version_test.go
@@ -140,6 +140,7 @@ func TestGetServerVersionClaimsVisibility(t *testing.T) {
 
 				versionID, err := queries.InsertEntryVersion(ctx, sqlc.InsertEntryVersionParams{
 					EntryID:     entryID,
+					Name:        entryName,
 					Version:     "1.0.0",
 					Title:       ptr.String(entryName),
 					Description: ptr.String(desc),

--- a/internal/service/db/shadowing_get_skill_version_test.go
+++ b/internal/service/db/shadowing_get_skill_version_test.go
@@ -140,6 +140,7 @@ func TestGetSkillVersionClaimsVisibility(t *testing.T) {
 
 				versionID, err := queries.InsertEntryVersion(ctx, sqlc.InsertEntryVersionParams{
 					EntryID:     entryID,
+					Name:        entryName,
 					Version:     "1.0.0",
 					Title:       ptr.String(entryName),
 					Description: ptr.String(desc),

--- a/internal/service/db/shadowing_list_server_versions_test.go
+++ b/internal/service/db/shadowing_list_server_versions_test.go
@@ -148,6 +148,7 @@ func TestListServerVersionsClaimsVisibility(t *testing.T) {
 
 				versionID, err := queries.InsertEntryVersion(ctx, sqlc.InsertEntryVersionParams{
 					EntryID:     entryID,
+					Name:        entryName,
 					Version:     "1.0.0",
 					Title:       ptr.String(entryName),
 					Description: ptr.String(desc),

--- a/internal/service/db/shadowing_list_servers_test.go
+++ b/internal/service/db/shadowing_list_servers_test.go
@@ -196,6 +196,7 @@ func TestListServersClaimsVisibility(t *testing.T) {
 
 				versionID, err := queries.InsertEntryVersion(ctx, sqlc.InsertEntryVersionParams{
 					EntryID:     entryID,
+					Name:        entryName,
 					Version:     "1.0.0",
 					Title:       ptr.String(entryName),
 					Description: ptr.String(desc),

--- a/internal/service/db/shadowing_list_skills_test.go
+++ b/internal/service/db/shadowing_list_skills_test.go
@@ -148,6 +148,7 @@ func TestListSkillsClaimsVisibility(t *testing.T) {
 
 				versionID, err := queries.InsertEntryVersion(ctx, sqlc.InsertEntryVersionParams{
 					EntryID:     entryID,
+					Name:        entryName,
 					Version:     "1.0.0",
 					Title:       ptr.String(entryName),
 					Description: ptr.String(desc),

--- a/internal/service/db/types.go
+++ b/internal/service/db/types.go
@@ -38,6 +38,7 @@ type helper struct {
 	RepositorySubfolder *string
 	RepositoryType      *string
 	Claims              []byte
+	SourceID            uuid.UUID
 	Position            int32
 }
 
@@ -67,6 +68,31 @@ func listServersRowToHelper(
 
 func getServerVersionRowToHelper(
 	dbServer sqlc.GetServerVersionRow,
+) helper {
+	return helper{
+		ID:                  dbServer.ID,
+		Name:                dbServer.Name,
+		Version:             dbServer.Version,
+		IsLatest:            dbServer.IsLatest,
+		CreatedAt:           dbServer.CreatedAt,
+		UpdatedAt:           dbServer.UpdatedAt,
+		Description:         dbServer.Description,
+		Title:               dbServer.Title,
+		Website:             dbServer.Website,
+		UpstreamMeta:        dbServer.UpstreamMeta,
+		ServerMeta:          dbServer.ServerMeta,
+		RepositoryUrl:       dbServer.RepositoryUrl,
+		RepositoryID:        dbServer.RepositoryID,
+		RepositorySubfolder: dbServer.RepositorySubfolder,
+		RepositoryType:      dbServer.RepositoryType,
+		Claims:              dbServer.Claims,
+		SourceID:            dbServer.SourceID,
+		Position:            dbServer.Position,
+	}
+}
+
+func getServerVersionBySourceNameRowToHelper(
+	dbServer sqlc.GetServerVersionBySourceNameRow,
 ) helper {
 	return helper{
 		ID:                  dbServer.ID,

--- a/internal/service/options.go
+++ b/internal/service/options.go
@@ -42,10 +42,6 @@ type registryNameOption interface {
 	setRegistryName(registryName string) error
 }
 
-type sourceNameOption interface {
-	setSourceName(sourceName string) error
-}
-
 type serverDataOption interface {
 	setServerData(serverData *upstreamv0.ServerJSON) error
 }
@@ -113,22 +109,6 @@ func WithRegistryName(registryName string) Option {
 		switch o := o.(type) {
 		case registryNameOption:
 			return o.setRegistryName(registryName)
-		default:
-			return fmt.Errorf("invalid option type: %T", o)
-		}
-	}
-}
-
-// WithSourceName sets the source name for the GetSkillVersion operation
-func WithSourceName(sourceName string) Option {
-	return func(o any) error {
-		if sourceName == "" {
-			return fmt.Errorf("invalid source name: %s", sourceName)
-		}
-
-		switch o := o.(type) {
-		case sourceNameOption:
-			return o.setSourceName(sourceName)
 		default:
 			return fmt.Errorf("invalid option type: %T", o)
 		}

--- a/internal/service/options_mcp.go
+++ b/internal/service/options_mcp.go
@@ -8,7 +8,7 @@ import (
 
 // ListServersOptions is the options for the ListServers operation
 type ListServersOptions struct {
-	RegistryName *string
+	RegistryName string
 	Cursor       string
 	Limit        int
 	Search       string
@@ -19,7 +19,7 @@ type ListServersOptions struct {
 
 //nolint:unparam
 func (o *ListServersOptions) setRegistryName(registryName string) error {
-	o.RegistryName = &registryName
+	o.RegistryName = registryName
 	return nil
 }
 
@@ -61,7 +61,7 @@ func (o *ListServersOptions) setClaims(claims map[string]any) error {
 
 // ListServerVersionsOptions is the options for the ListServerVersions operation
 type ListServerVersionsOptions struct {
-	RegistryName *string
+	RegistryName string
 	Name         string
 	Limit        int
 	Claims       map[string]any
@@ -69,7 +69,7 @@ type ListServerVersionsOptions struct {
 
 //nolint:unparam
 func (o *ListServerVersionsOptions) setRegistryName(registryName string) error {
-	o.RegistryName = &registryName
+	o.RegistryName = registryName
 	return nil
 }
 
@@ -103,12 +103,6 @@ type GetServerVersionOptions struct {
 //nolint:unparam
 func (o *GetServerVersionOptions) setRegistryName(registryName string) error {
 	o.RegistryName = registryName
-	return nil
-}
-
-//nolint:unparam
-func (o *GetServerVersionOptions) setSourceName(sourceName string) error {
-	o.SourceName = sourceName
 	return nil
 }
 

--- a/internal/service/options_skills.go
+++ b/internal/service/options_skills.go
@@ -89,12 +89,6 @@ func (o *GetSkillVersionOptions) setRegistryName(registryName string) error {
 }
 
 //nolint:unparam
-func (o *GetSkillVersionOptions) setSourceName(sourceName string) error {
-	o.SourceName = sourceName
-	return nil
-}
-
-//nolint:unparam
 func (o *GetSkillVersionOptions) setNamespace(namespace string) error {
 	o.Namespace = namespace
 	return nil

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -183,7 +183,7 @@ func TestWithRegistryNameListServers(t *testing.T) {
 			}
 
 			require.NoError(t, err)
-			assert.Equal(t, tt.expectedValue, *opts.RegistryName)
+			assert.Equal(t, tt.expectedValue, opts.RegistryName)
 		})
 	}
 }
@@ -225,7 +225,7 @@ func TestWithRegistryNameListServersVersions(t *testing.T) {
 			}
 
 			require.NoError(t, err)
-			assert.Equal(t, tt.expectedValue, *opts.RegistryName)
+			assert.Equal(t, tt.expectedValue, opts.RegistryName)
 		})
 	}
 }

--- a/internal/sync/writer/db_test.go
+++ b/internal/sync/writer/db_test.go
@@ -4,6 +4,7 @@ package writer
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/aws/smithy-go/ptr"
 	"github.com/google/uuid"
@@ -57,15 +58,21 @@ func setupTestDB(t *testing.T) (*pgxpool.Pool, func()) {
 	return pool, poolCleanup
 }
 
-// createTestRegistry creates a test source in the database and returns its ID
-// Uses "git" source type by default, which is the typical type for synced registries
-func createTestRegistry(t *testing.T, pool *pgxpool.Pool, name string) uuid.UUID {
+// testRegistryIDs holds IDs returned by createTestRegistry
+type testRegistryIDs struct {
+	sourceID   uuid.UUID
+	registryID uuid.UUID
+}
+
+// createTestRegistry creates a test source, registry entry, and links them.
+// Returns both the source ID and registry ID.
+func createTestRegistry(t *testing.T, pool *pgxpool.Pool, name string) testRegistryIDs {
 	t.Helper()
 
 	ctx := context.Background()
 	queries := sqlc.New(pool)
 
-	regID, err := queries.UpsertSource(ctx, sqlc.UpsertSourceParams{
+	sourceID, err := queries.UpsertSource(ctx, sqlc.UpsertSourceParams{
 		Name:         name,
 		CreationType: sqlc.CreationTypeCONFIG,
 		SourceType:   "git",
@@ -73,7 +80,36 @@ func createTestRegistry(t *testing.T, pool *pgxpool.Pool, name string) uuid.UUID
 	})
 	require.NoError(t, err)
 
-	return regID
+	now := time.Now().UTC()
+	reg, err := queries.UpsertRegistry(ctx, sqlc.UpsertRegistryParams{
+		Name:         name,
+		CreationType: sqlc.CreationTypeCONFIG,
+		CreatedAt:    &now,
+		UpdatedAt:    &now,
+	})
+	require.NoError(t, err)
+
+	err = queries.LinkRegistrySource(ctx, sqlc.LinkRegistrySourceParams{
+		RegistryID: reg.ID,
+		SourceID:   sourceID,
+		Position:   0,
+	})
+	require.NoError(t, err)
+
+	return testRegistryIDs{
+		sourceID:   sourceID,
+		registryID: reg.ID,
+	}
+}
+
+// getTestRegistryID looks up the registry UUID by name
+func getTestRegistryID(t *testing.T, pool *pgxpool.Pool, name string) uuid.UUID {
+	t.Helper()
+	ctx := context.Background()
+	queries := sqlc.New(pool)
+	reg, err := queries.GetRegistryByName(ctx, name)
+	require.NoError(t, err)
+	return reg.ID
 }
 
 // createTestUpstreamRegistry creates a test UpstreamRegistry with the given servers
@@ -317,11 +353,12 @@ func TestDbSyncWriter_Store(t *testing.T) {
 			}),
 			expectError: false,
 			//nolint:thelper // We want to see these lines in the test output
-			validateFunc: func(t *testing.T, pool *pgxpool.Pool, _ string) {
+			validateFunc: func(t *testing.T, pool *pgxpool.Pool, registryName string) {
 				ctx := context.Background()
 				queries := sqlc.New(pool)
+				regID := getTestRegistryID(t, pool, registryName)
 
-				servers, err := queries.ListServers(ctx, sqlc.ListServersParams{Size: 100})
+				servers, err := queries.ListServers(ctx, sqlc.ListServersParams{RegistryID: regID, Size: 100})
 				require.NoError(t, err)
 				require.Len(t, servers, 1)
 				assert.Equal(t, "test.org/server", servers[0].Name)
@@ -342,11 +379,12 @@ func TestDbSyncWriter_Store(t *testing.T) {
 			}),
 			expectError: false,
 			//nolint:thelper // We want to see these lines in the test output
-			validateFunc: func(t *testing.T, pool *pgxpool.Pool, _ string) {
+			validateFunc: func(t *testing.T, pool *pgxpool.Pool, registryName string) {
 				ctx := context.Background()
 				queries := sqlc.New(pool)
+				regID := getTestRegistryID(t, pool, registryName)
 
-				servers, err := queries.ListServers(ctx, sqlc.ListServersParams{Size: 100})
+				servers, err := queries.ListServers(ctx, sqlc.ListServersParams{RegistryID: regID, Size: 100})
 				require.NoError(t, err)
 				require.Len(t, servers, 3)
 			},
@@ -363,11 +401,12 @@ func TestDbSyncWriter_Store(t *testing.T) {
 			}),
 			expectError: false,
 			//nolint:thelper // We want to see these lines in the test output
-			validateFunc: func(t *testing.T, pool *pgxpool.Pool, _ string) {
+			validateFunc: func(t *testing.T, pool *pgxpool.Pool, registryName string) {
 				ctx := context.Background()
 				queries := sqlc.New(pool)
+				regID := getTestRegistryID(t, pool, registryName)
 
-				servers, err := queries.ListServers(ctx, sqlc.ListServersParams{Size: 100})
+				servers, err := queries.ListServers(ctx, sqlc.ListServersParams{RegistryID: regID, Size: 100})
 				require.NoError(t, err)
 				require.Len(t, servers, 1)
 
@@ -390,11 +429,12 @@ func TestDbSyncWriter_Store(t *testing.T) {
 			}),
 			expectError: false,
 			//nolint:thelper // We want to see these lines in the test output
-			validateFunc: func(t *testing.T, pool *pgxpool.Pool, _ string) {
+			validateFunc: func(t *testing.T, pool *pgxpool.Pool, registryName string) {
 				ctx := context.Background()
 				queries := sqlc.New(pool)
+				regID := getTestRegistryID(t, pool, registryName)
 
-				servers, err := queries.ListServers(ctx, sqlc.ListServersParams{Size: 100})
+				servers, err := queries.ListServers(ctx, sqlc.ListServersParams{RegistryID: regID, Size: 100})
 				require.NoError(t, err)
 				require.Len(t, servers, 1)
 
@@ -417,11 +457,12 @@ func TestDbSyncWriter_Store(t *testing.T) {
 			}),
 			expectError: false,
 			//nolint:thelper // We want to see these lines in the test output
-			validateFunc: func(t *testing.T, pool *pgxpool.Pool, _ string) {
+			validateFunc: func(t *testing.T, pool *pgxpool.Pool, registryName string) {
 				ctx := context.Background()
 				queries := sqlc.New(pool)
+				regID := getTestRegistryID(t, pool, registryName)
 
-				servers, err := queries.ListServers(ctx, sqlc.ListServersParams{Size: 100})
+				servers, err := queries.ListServers(ctx, sqlc.ListServersParams{RegistryID: regID, Size: 100})
 				require.NoError(t, err)
 				require.Len(t, servers, 1)
 				// Icons are stored but not retrieved by ListServers
@@ -439,13 +480,16 @@ func TestDbSyncWriter_Store(t *testing.T) {
 			}),
 			expectError: false,
 			//nolint:thelper // We want to see these lines in the test output
-			validateFunc: func(t *testing.T, pool *pgxpool.Pool, _ string) {
+			validateFunc: func(t *testing.T, pool *pgxpool.Pool, registryName string) {
 				ctx := context.Background()
 				queries := sqlc.New(pool)
+				regID := getTestRegistryID(t, pool, registryName)
 
 				serverRows, err := queries.GetServerVersion(ctx, sqlc.GetServerVersionParams{
-					Name:    "test.org/server",
-					Version: "1.0.0",
+					RegistryID: regID,
+					Name:       "test.org/server",
+					Version:    "1.0.0",
+					Size:       100,
 				})
 				require.NoError(t, err)
 				require.NotEmpty(t, serverRows)
@@ -466,13 +510,16 @@ func TestDbSyncWriter_Store(t *testing.T) {
 			}),
 			expectError: false,
 			//nolint:thelper // We want to see these lines in the test output
-			validateFunc: func(t *testing.T, pool *pgxpool.Pool, _ string) {
+			validateFunc: func(t *testing.T, pool *pgxpool.Pool, registryName string) {
 				ctx := context.Background()
 				queries := sqlc.New(pool)
+				regID := getTestRegistryID(t, pool, registryName)
 
 				serverRows, err := queries.GetServerVersion(ctx, sqlc.GetServerVersionParams{
-					Name:    "test.org/server",
-					Version: "1.0.0",
+					RegistryID: regID,
+					Name:       "test.org/server",
+					Version:    "1.0.0",
+					Size:       100,
 				})
 				require.NoError(t, err)
 				require.NotEmpty(t, serverRows)
@@ -492,11 +539,12 @@ func TestDbSyncWriter_Store(t *testing.T) {
 			}),
 			expectError: false,
 			//nolint:thelper // We want to see these lines in the test output
-			validateFunc: func(t *testing.T, pool *pgxpool.Pool, _ string) {
+			validateFunc: func(t *testing.T, pool *pgxpool.Pool, registryName string) {
 				ctx := context.Background()
 				queries := sqlc.New(pool)
+				regID := getTestRegistryID(t, pool, registryName)
 
-				servers, err := queries.ListServers(ctx, sqlc.ListServersParams{Size: 100})
+				servers, err := queries.ListServers(ctx, sqlc.ListServersParams{RegistryID: regID, Size: 100})
 				require.NoError(t, err)
 				require.Len(t, servers, 1)
 
@@ -519,11 +567,12 @@ func TestDbSyncWriter_Store(t *testing.T) {
 			registry:    createTestUpstreamRegistry([]upstreamv0.ServerJSON{}),
 			expectError: false,
 			//nolint:thelper // We want to see these lines in the test output
-			validateFunc: func(t *testing.T, pool *pgxpool.Pool, _ string) {
+			validateFunc: func(t *testing.T, pool *pgxpool.Pool, registryName string) {
 				ctx := context.Background()
 				queries := sqlc.New(pool)
+				regID := getTestRegistryID(t, pool, registryName)
 
-				servers, err := queries.ListServers(ctx, sqlc.ListServersParams{Size: 100})
+				servers, err := queries.ListServers(ctx, sqlc.ListServersParams{RegistryID: regID, Size: 100})
 				require.NoError(t, err)
 				require.Len(t, servers, 0)
 			},
@@ -534,12 +583,12 @@ func TestDbSyncWriter_Store(t *testing.T) {
 			//nolint:thelper // We want to see these lines in the test output
 			setupFunc: func(t *testing.T, pool *pgxpool.Pool) {
 				ctx := context.Background()
-				regID := createTestRegistry(t, pool, "test-registry")
+				ids := createTestRegistry(t, pool, "test-registry")
 				queries := sqlc.New(pool)
 
 				// Insert registry entry
 				entryID, err := queries.InsertRegistryEntry(ctx, sqlc.InsertRegistryEntryParams{
-					SourceID:  regID,
+					SourceID:  ids.sourceID,
 					EntryType: sqlc.EntryTypeMCP,
 					Name:      "test.org/old-server",
 				})
@@ -563,11 +612,12 @@ func TestDbSyncWriter_Store(t *testing.T) {
 			}),
 			expectError: false,
 			//nolint:thelper // We want to see these lines in the test output
-			validateFunc: func(t *testing.T, pool *pgxpool.Pool, _ string) {
+			validateFunc: func(t *testing.T, pool *pgxpool.Pool, registryName string) {
 				ctx := context.Background()
 				queries := sqlc.New(pool)
+				regID := getTestRegistryID(t, pool, registryName)
 
-				servers, err := queries.ListServers(ctx, sqlc.ListServersParams{Size: 100})
+				servers, err := queries.ListServers(ctx, sqlc.ListServersParams{RegistryID: regID, Size: 100})
 				require.NoError(t, err)
 				require.Len(t, servers, 1)
 				assert.Equal(t, "test.org/new-server", servers[0].Name)
@@ -585,13 +635,16 @@ func TestDbSyncWriter_Store(t *testing.T) {
 			}),
 			expectError: false,
 			//nolint:thelper // We want to see these lines in the test output
-			validateFunc: func(t *testing.T, pool *pgxpool.Pool, _ string) {
+			validateFunc: func(t *testing.T, pool *pgxpool.Pool, registryName string) {
 				ctx := context.Background()
 				queries := sqlc.New(pool)
+				regID := getTestRegistryID(t, pool, registryName)
 
 				serverRows, err := queries.GetServerVersion(ctx, sqlc.GetServerVersionParams{
-					Name:    "test.org/server",
-					Version: "1.0.0",
+					RegistryID: regID,
+					Name:       "test.org/server",
+					Version:    "1.0.0",
+					Size:       100,
 				})
 				require.NoError(t, err)
 				require.NotEmpty(t, serverRows)
@@ -614,14 +667,17 @@ func TestDbSyncWriter_Store(t *testing.T) {
 			}),
 			expectError: false,
 			//nolint:thelper // We want to see these lines in the test output
-			validateFunc: func(t *testing.T, pool *pgxpool.Pool, _ string) {
+			validateFunc: func(t *testing.T, pool *pgxpool.Pool, registryName string) {
 				ctx := context.Background()
 				queries := sqlc.New(pool)
+				regID := getTestRegistryID(t, pool, registryName)
 
 				// Version 2.0.0 should be latest
 				serverRows, err := queries.GetServerVersion(ctx, sqlc.GetServerVersionParams{
-					Name:    "test.org/server",
-					Version: "2.0.0",
+					RegistryID: regID,
+					Name:       "test.org/server",
+					Version:    "2.0.0",
+					Size:       100,
 				})
 				require.NoError(t, err)
 				require.NotEmpty(t, serverRows)
@@ -630,8 +686,10 @@ func TestDbSyncWriter_Store(t *testing.T) {
 
 				// Version 1.0.0 should not be latest
 				serverRows, err = queries.GetServerVersion(ctx, sqlc.GetServerVersionParams{
-					Name:    "test.org/server",
-					Version: "1.0.0",
+					RegistryID: regID,
+					Name:       "test.org/server",
+					Version:    "1.0.0",
+					Size:       100,
 				})
 				require.NoError(t, err)
 				require.NotEmpty(t, serverRows)
@@ -640,8 +698,10 @@ func TestDbSyncWriter_Store(t *testing.T) {
 
 				// Version 1.5.0 should not be latest
 				serverRows, err = queries.GetServerVersion(ctx, sqlc.GetServerVersionParams{
-					Name:    "test.org/server",
-					Version: "1.5.0",
+					RegistryID: regID,
+					Name:       "test.org/server",
+					Version:    "1.5.0",
+					Size:       100,
 				})
 				require.NoError(t, err)
 				require.NotEmpty(t, serverRows)
@@ -679,13 +739,15 @@ func TestDbSyncWriter_Store(t *testing.T) {
 			}),
 			expectError: false,
 			//nolint:thelper // We want to see these lines in the test output
-			validateFunc: func(t *testing.T, pool *pgxpool.Pool, _ string) {
+			validateFunc: func(t *testing.T, pool *pgxpool.Pool, registryName string) {
 				ctx := context.Background()
 				queries := sqlc.New(pool)
+				regID := getTestRegistryID(t, pool, registryName)
 
 				versions, err := queries.ListServers(ctx, sqlc.ListServersParams{
-					Name: ptr.String("test.org/server"),
-					Size: 100,
+					RegistryID: regID,
+					Name:       ptr.String("test.org/server"),
+					Size:       100,
 				})
 				require.NoError(t, err)
 				require.Len(t, versions, 3)
@@ -709,13 +771,16 @@ func TestDbSyncWriter_Store(t *testing.T) {
 			}),
 			expectError: false,
 			//nolint:thelper // We want to see these lines in the test output
-			validateFunc: func(t *testing.T, pool *pgxpool.Pool, _ string) {
+			validateFunc: func(t *testing.T, pool *pgxpool.Pool, registryName string) {
 				ctx := context.Background()
 				queries := sqlc.New(pool)
+				regID := getTestRegistryID(t, pool, registryName)
 
 				serverRows, err := queries.GetServerVersion(ctx, sqlc.GetServerVersionParams{
-					Name:    "test.org/minimal",
-					Version: "1.0.0",
+					RegistryID: regID,
+					Name:       "test.org/minimal",
+					Version:    "1.0.0",
+					Size:       100,
 				})
 				require.NoError(t, err)
 				require.NotEmpty(t, serverRows)
@@ -1143,7 +1208,8 @@ func TestDbSyncWriter_Store_IconThemes(t *testing.T) {
 	// Verify servers were created
 	ctx := context.Background()
 	queries := sqlc.New(pool)
-	servers, err := queries.ListServers(ctx, sqlc.ListServersParams{Size: 100})
+	regID := getTestRegistryID(t, pool, "test-registry")
+	servers, err := queries.ListServers(ctx, sqlc.ListServersParams{RegistryID: regID, Size: 100})
 	require.NoError(t, err)
 	require.Len(t, servers, 1)
 }
@@ -1212,8 +1278,9 @@ func TestDbSyncWriter_Store_PackageAcrossServers(t *testing.T) {
 
 	ctx := context.Background()
 	queries := sqlc.New(pool)
+	regID := getTestRegistryID(t, pool, "test-registry")
 
-	serverRows, err := queries.ListServers(ctx, sqlc.ListServersParams{Size: 100})
+	serverRows, err := queries.ListServers(ctx, sqlc.ListServersParams{RegistryID: regID, Size: 100})
 	require.NoError(t, err)
 	require.Len(t, serverRows, 3)
 
@@ -1263,8 +1330,9 @@ func TestDbSyncWriter_Store_MultipleRemotes(t *testing.T) {
 
 	ctx := context.Background()
 	queries := sqlc.New(pool)
+	regID := getTestRegistryID(t, pool, "test-registry")
 
-	servers, err := queries.ListServers(ctx, sqlc.ListServersParams{Size: 100})
+	servers, err := queries.ListServers(ctx, sqlc.ListServersParams{RegistryID: regID, Size: 100})
 	require.NoError(t, err)
 	require.Len(t, servers, 1)
 
@@ -1344,11 +1412,14 @@ func TestDbSyncWriter_Store_LatestVersionDetermination(t *testing.T) {
 
 			ctx := context.Background()
 			queries := sqlc.New(pool)
+			regID := getTestRegistryID(t, pool, tt.registryName)
 
 			for _, version := range tt.versions {
 				serverRows, err := queries.GetServerVersion(ctx, sqlc.GetServerVersionParams{
-					Name:    tt.serverName,
-					Version: version,
+					RegistryID: regID,
+					Name:       tt.serverName,
+					Version:    version,
+					Size:       100,
 				})
 				require.NoError(t, err)
 				require.NotEmpty(t, serverRows)
@@ -1379,6 +1450,7 @@ func TestDbSyncWriter_Store_UUIDStability(t *testing.T) {
 
 	ctx := context.Background()
 	queries := sqlc.New(pool)
+	regID := getTestRegistryID(t, pool, "test-registry")
 
 	// Create UpstreamRegistry with 2 servers
 	registry := createTestUpstreamRegistry([]upstreamv0.ServerJSON{
@@ -1392,16 +1464,20 @@ func TestDbSyncWriter_Store_UUIDStability(t *testing.T) {
 
 	// Query DB and record server UUIDs and created_at timestamps
 	serverA1Rows, err := queries.GetServerVersion(ctx, sqlc.GetServerVersionParams{
-		Name:    "test.org/server-a",
-		Version: "1.0.0",
+		RegistryID: regID,
+		Name:       "test.org/server-a",
+		Version:    "1.0.0",
+		Size:       100,
 	})
 	require.NoError(t, err)
 	require.NotEmpty(t, serverA1Rows)
 	serverA1 := serverA1Rows[0]
 
 	serverB1Rows, err := queries.GetServerVersion(ctx, sqlc.GetServerVersionParams{
-		Name:    "test.org/server-b",
-		Version: "2.0.0",
+		RegistryID: regID,
+		Name:       "test.org/server-b",
+		Version:    "2.0.0",
+		Size:       100,
 	})
 	require.NoError(t, err)
 	require.NotEmpty(t, serverB1Rows)
@@ -1419,16 +1495,20 @@ func TestDbSyncWriter_Store_UUIDStability(t *testing.T) {
 
 	// Query DB again and verify UUIDs are identical
 	serverA2Rows, err := queries.GetServerVersion(ctx, sqlc.GetServerVersionParams{
-		Name:    "test.org/server-a",
-		Version: "1.0.0",
+		RegistryID: regID,
+		Name:       "test.org/server-a",
+		Version:    "1.0.0",
+		Size:       100,
 	})
 	require.NoError(t, err)
 	require.NotEmpty(t, serverA2Rows)
 	serverA2 := serverA2Rows[0]
 
 	serverB2Rows, err := queries.GetServerVersion(ctx, sqlc.GetServerVersionParams{
-		Name:    "test.org/server-b",
-		Version: "2.0.0",
+		RegistryID: regID,
+		Name:       "test.org/server-b",
+		Version:    "2.0.0",
+		Size:       100,
 	})
 	require.NoError(t, err)
 	require.NotEmpty(t, serverB2Rows)
@@ -1462,6 +1542,7 @@ func TestDbSyncWriter_Store_UpdatePreservesUUID(t *testing.T) {
 
 	ctx := context.Background()
 	queries := sqlc.New(pool)
+	regID := getTestRegistryID(t, pool, "test-registry")
 
 	// First sync with original description
 	server := createTestServer("test.org/server", "1.0.0")
@@ -1474,8 +1555,10 @@ func TestDbSyncWriter_Store_UpdatePreservesUUID(t *testing.T) {
 
 	// Query and record original UUID and description
 	serverV1Rows, err := queries.GetServerVersion(ctx, sqlc.GetServerVersionParams{
-		Name:    "test.org/server",
-		Version: "1.0.0",
+		RegistryID: regID,
+		Name:       "test.org/server",
+		Version:    "1.0.0",
+		Size:       100,
 	})
 	require.NoError(t, err)
 	require.NotEmpty(t, serverV1Rows)
@@ -1499,8 +1582,10 @@ func TestDbSyncWriter_Store_UpdatePreservesUUID(t *testing.T) {
 
 	// Query and verify UUID is the same but description is updated
 	serverV2Rows, err := queries.GetServerVersion(ctx, sqlc.GetServerVersionParams{
-		Name:    "test.org/server",
-		Version: "1.0.0",
+		RegistryID: regID,
+		Name:       "test.org/server",
+		Version:    "1.0.0",
+		Size:       100,
 	})
 	require.NoError(t, err)
 	require.NotEmpty(t, serverV2Rows)
@@ -1537,6 +1622,7 @@ func TestDbSyncWriter_Store_OrphanedServerCleanup(t *testing.T) {
 
 	ctx := context.Background()
 	queries := sqlc.New(pool)
+	regID := getTestRegistryID(t, pool, "test-registry")
 
 	// First sync with 3 servers
 	registry := createTestUpstreamRegistry([]upstreamv0.ServerJSON{
@@ -1549,14 +1635,16 @@ func TestDbSyncWriter_Store_OrphanedServerCleanup(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify all 3 servers exist
-	servers, err := queries.ListServers(ctx, sqlc.ListServersParams{Size: 100})
+	servers, err := queries.ListServers(ctx, sqlc.ListServersParams{RegistryID: regID, Size: 100})
 	require.NoError(t, err)
 	require.Len(t, servers, 3, "Should have 3 servers after first sync")
 
 	// Record UUID for server-a to verify it persists
 	serverARows, err := queries.GetServerVersion(ctx, sqlc.GetServerVersionParams{
-		Name:    "test.org/server-a",
-		Version: "1.0.0",
+		RegistryID: regID,
+		Name:       "test.org/server-a",
+		Version:    "1.0.0",
+		Size:       100,
 	})
 	require.NoError(t, err)
 	require.NotEmpty(t, serverARows)
@@ -1573,14 +1661,16 @@ func TestDbSyncWriter_Store_OrphanedServerCleanup(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify only server-a and server-c exist
-	servers, err = queries.ListServers(ctx, sqlc.ListServersParams{Size: 100})
+	servers, err = queries.ListServers(ctx, sqlc.ListServersParams{RegistryID: regID, Size: 100})
 	require.NoError(t, err)
 	require.Len(t, servers, 2, "Should have 2 servers after second sync")
 
 	// Verify server-a still exists with same UUID
 	serverAUpdatedRows, err := queries.GetServerVersion(ctx, sqlc.GetServerVersionParams{
-		Name:    "test.org/server-a",
-		Version: "1.0.0",
+		RegistryID: regID,
+		Name:       "test.org/server-a",
+		Version:    "1.0.0",
+		Size:       100,
 	})
 	require.NoError(t, err)
 	require.NotEmpty(t, serverAUpdatedRows)
@@ -1589,16 +1679,20 @@ func TestDbSyncWriter_Store_OrphanedServerCleanup(t *testing.T) {
 
 	// Verify server-c exists
 	discardRows, err := queries.GetServerVersion(ctx, sqlc.GetServerVersionParams{
-		Name:    "test.org/server-c",
-		Version: "1.0.0",
+		RegistryID: regID,
+		Name:       "test.org/server-c",
+		Version:    "1.0.0",
+		Size:       100,
 	})
 	require.NoError(t, err)
 	require.NotEmpty(t, discardRows)
 
 	// Verify server-b was deleted (should return error)
 	discardRows, err = queries.GetServerVersion(ctx, sqlc.GetServerVersionParams{
-		Name:    "test.org/server-b",
-		Version: "1.0.0",
+		RegistryID: regID,
+		Name:       "test.org/server-b",
+		Version:    "1.0.0",
+		Size:       100,
 	})
 	require.NoError(t, err)
 	require.Empty(t, discardRows, "Server B should have been deleted")
@@ -1620,6 +1714,7 @@ func TestDbSyncWriter_Store_PackageCleanup(t *testing.T) {
 
 	ctx := context.Background()
 	queries := sqlc.New(pool)
+	regID := getTestRegistryID(t, pool, "test-registry")
 
 	// Create server with a package
 	server := createTestServer("test.org/server", "1.0.0")
@@ -1639,7 +1734,7 @@ func TestDbSyncWriter_Store_PackageCleanup(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify package exists
-	servers, err := queries.ListServers(ctx, sqlc.ListServersParams{Size: 100})
+	servers, err := queries.ListServers(ctx, sqlc.ListServersParams{RegistryID: regID, Size: 100})
 	require.NoError(t, err)
 	require.Len(t, servers, 1)
 
@@ -1668,8 +1763,10 @@ func TestDbSyncWriter_Store_PackageCleanup(t *testing.T) {
 
 	// Verify server UUID is preserved
 	serverAfterUpdateRows, err := queries.GetServerVersion(ctx, sqlc.GetServerVersionParams{
-		Name:    "test.org/server",
-		Version: "1.0.0",
+		RegistryID: regID,
+		Name:       "test.org/server",
+		Version:    "1.0.0",
+		Size:       100,
 	})
 	require.NoError(t, err)
 	require.NotEmpty(t, serverAfterUpdateRows)
@@ -1693,8 +1790,10 @@ func TestDbSyncWriter_Store_PackageCleanup(t *testing.T) {
 
 	// Verify server UUID is still preserved
 	serverAfterRemovalRows, err := queries.GetServerVersion(ctx, sqlc.GetServerVersionParams{
-		Name:    "test.org/server",
-		Version: "1.0.0",
+		RegistryID: regID,
+		Name:       "test.org/server",
+		Version:    "1.0.0",
+		Size:       100,
 	})
 	require.NoError(t, err)
 	require.NotEmpty(t, serverAfterRemovalRows)
@@ -1722,6 +1821,7 @@ func TestDbSyncWriter_Store_RemoteCleanup(t *testing.T) {
 
 	ctx := context.Background()
 	queries := sqlc.New(pool)
+	regID := getTestRegistryID(t, pool, "test-registry")
 
 	// Create server with 2 remotes
 	server := createTestServer("test.org/server", "1.0.0")
@@ -1742,7 +1842,7 @@ func TestDbSyncWriter_Store_RemoteCleanup(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify 2 remotes exist
-	servers, err := queries.ListServers(ctx, sqlc.ListServersParams{Size: 100})
+	servers, err := queries.ListServers(ctx, sqlc.ListServersParams{RegistryID: regID, Size: 100})
 	require.NoError(t, err)
 	require.Len(t, servers, 1)
 
@@ -1767,8 +1867,10 @@ func TestDbSyncWriter_Store_RemoteCleanup(t *testing.T) {
 
 	// Verify server UUID is preserved
 	serverAfterUpdateRows, err := queries.GetServerVersion(ctx, sqlc.GetServerVersionParams{
-		Name:    "test.org/server",
-		Version: "1.0.0",
+		RegistryID: regID,
+		Name:       "test.org/server",
+		Version:    "1.0.0",
+		Size:       100,
 	})
 	require.NoError(t, err)
 	require.NotEmpty(t, serverAfterUpdateRows)
@@ -1797,6 +1899,7 @@ func TestDbSyncWriter_Store_IconCleanup(t *testing.T) {
 
 	ctx := context.Background()
 	queries := sqlc.New(pool)
+	regID := getTestRegistryID(t, pool, "test-registry")
 
 	// Create server with 2 icons
 	lightTheme := testThemeLight
@@ -1823,7 +1926,7 @@ func TestDbSyncWriter_Store_IconCleanup(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify server created
-	servers, err := queries.ListServers(ctx, sqlc.ListServersParams{Size: 100})
+	servers, err := queries.ListServers(ctx, sqlc.ListServersParams{RegistryID: regID, Size: 100})
 	require.NoError(t, err)
 	require.Len(t, servers, 1)
 
@@ -1851,8 +1954,10 @@ func TestDbSyncWriter_Store_IconCleanup(t *testing.T) {
 
 	// Verify server UUID is preserved
 	serverAfterUpdateRows, err := queries.GetServerVersion(ctx, sqlc.GetServerVersionParams{
-		Name:    "test.org/server",
-		Version: "1.0.0",
+		RegistryID: regID,
+		Name:       "test.org/server",
+		Version:    "1.0.0",
+		Size:       100,
 	})
 	require.NoError(t, err)
 	require.NotEmpty(t, serverAfterUpdateRows)
@@ -1874,8 +1979,12 @@ func TestDbSyncWriter_Store_RegistryIsolation(t *testing.T) {
 	defer cleanup()
 
 	// Step 1: Create two test registries
-	registryAID := createTestRegistry(t, pool, "registry-A")
-	registryBID := createTestRegistry(t, pool, "registry-B")
+	idsA := createTestRegistry(t, pool, "registry-A")
+	idsB := createTestRegistry(t, pool, "registry-B")
+	registryAID := idsA.sourceID
+	registryBID := idsB.sourceID
+	regIDA := idsA.registryID
+	regIDB := idsB.registryID
 
 	writer, err := NewDBSyncWriter(pool, testMaxMetaSize)
 	require.NoError(t, err)
@@ -1903,9 +2012,11 @@ func TestDbSyncWriter_Store_RegistryIsolation(t *testing.T) {
 	require.NoError(t, err)
 
 	// Step 6: Query DB and verify all 4 servers exist (2 per registry)
-	servers, err := queries.ListServers(ctx, sqlc.ListServersParams{Size: 100})
+	serversA, err := queries.ListServers(ctx, sqlc.ListServersParams{RegistryID: regIDA, Size: 100})
 	require.NoError(t, err)
-	require.Len(t, servers, 4, "Should have 4 servers total after initial sync")
+	serversB, err := queries.ListServers(ctx, sqlc.ListServersParams{RegistryID: regIDB, Size: 100})
+	require.NoError(t, err)
+	require.Equal(t, 4, len(serversA)+len(serversB), "Should have 4 servers total after initial sync")
 
 	// Count servers per registry
 	var countA, countB int
@@ -1919,8 +2030,10 @@ func TestDbSyncWriter_Store_RegistryIsolation(t *testing.T) {
 
 	// Step 7: Record server UUIDs for all 4 servers
 	server1Rows, err := queries.GetServerVersion(ctx, sqlc.GetServerVersionParams{
-		Name:    "test.org/server-1",
-		Version: "1.0.0",
+		RegistryID: regIDA,
+		Name:       "test.org/server-1",
+		Version:    "1.0.0",
+		Size:       100,
 	})
 	require.NoError(t, err)
 	require.NotEmpty(t, server1Rows)
@@ -1928,8 +2041,10 @@ func TestDbSyncWriter_Store_RegistryIsolation(t *testing.T) {
 	uuidServer1 := server1.ID
 
 	server2Rows, err := queries.GetServerVersion(ctx, sqlc.GetServerVersionParams{
-		Name:    "test.org/server-2",
-		Version: "1.0.0",
+		RegistryID: regIDA,
+		Name:       "test.org/server-2",
+		Version:    "1.0.0",
+		Size:       100,
 	})
 	require.NoError(t, err)
 	require.NotEmpty(t, server2Rows)
@@ -1937,8 +2052,10 @@ func TestDbSyncWriter_Store_RegistryIsolation(t *testing.T) {
 	uuidServer2 := server2.ID
 
 	server3Rows, err := queries.GetServerVersion(ctx, sqlc.GetServerVersionParams{
-		Name:    "test.org/server-3",
-		Version: "1.0.0",
+		RegistryID: regIDB,
+		Name:       "test.org/server-3",
+		Version:    "1.0.0",
+		Size:       100,
 	})
 	require.NoError(t, err)
 	require.NotEmpty(t, server3Rows)
@@ -1946,8 +2063,10 @@ func TestDbSyncWriter_Store_RegistryIsolation(t *testing.T) {
 	uuidServer3 := server3.ID
 
 	server4Rows, err := queries.GetServerVersion(ctx, sqlc.GetServerVersionParams{
-		Name:    "test.org/server-4",
-		Version: "1.0.0",
+		RegistryID: regIDB,
+		Name:       "test.org/server-4",
+		Version:    "1.0.0",
+		Size:       100,
 	})
 	require.NoError(t, err)
 	require.NotEmpty(t, server4Rows)
@@ -1971,8 +2090,10 @@ func TestDbSyncWriter_Store_RegistryIsolation(t *testing.T) {
 
 	// Verify server-1 still exists with same UUID
 	server1AfterRows, err := queries.GetServerVersion(ctx, sqlc.GetServerVersionParams{
-		Name:    "test.org/server-1",
-		Version: "1.0.0",
+		RegistryID: regIDA,
+		Name:       "test.org/server-1",
+		Version:    "1.0.0",
+		Size:       100,
 	})
 	require.NoError(t, err)
 	require.NotEmpty(t, server1AfterRows)
@@ -1981,8 +2102,10 @@ func TestDbSyncWriter_Store_RegistryIsolation(t *testing.T) {
 
 	// Verify server-2 was deleted
 	discardRows, err := queries.GetServerVersion(ctx, sqlc.GetServerVersionParams{
-		Name:    "test.org/server-2",
-		Version: "1.0.0",
+		RegistryID: regIDA,
+		Name:       "test.org/server-2",
+		Version:    "1.0.0",
+		Size:       100,
 	})
 	require.NoError(t, err)
 	require.Empty(t, discardRows, "Server 2 should have been deleted from registry A")
@@ -1995,8 +2118,10 @@ func TestDbSyncWriter_Store_RegistryIsolation(t *testing.T) {
 
 	// Verify server-3 still exists with same UUID
 	server3AfterRows, err := queries.GetServerVersion(ctx, sqlc.GetServerVersionParams{
-		Name:    "test.org/server-3",
-		Version: "1.0.0",
+		RegistryID: regIDB,
+		Name:       "test.org/server-3",
+		Version:    "1.0.0",
+		Size:       100,
 	})
 	require.NoError(t, err)
 	require.NotEmpty(t, server3AfterRows)
@@ -2005,8 +2130,10 @@ func TestDbSyncWriter_Store_RegistryIsolation(t *testing.T) {
 
 	// Verify server-4 still exists with same UUID
 	server4AfterRows, err := queries.GetServerVersion(ctx, sqlc.GetServerVersionParams{
-		Name:    "test.org/server-4",
-		Version: "1.0.0",
+		RegistryID: regIDB,
+		Name:       "test.org/server-4",
+		Version:    "1.0.0",
+		Size:       100,
 	})
 	require.NoError(t, err)
 	require.NotEmpty(t, server4AfterRows)
@@ -2014,9 +2141,11 @@ func TestDbSyncWriter_Store_RegistryIsolation(t *testing.T) {
 	assert.Equal(t, uuidServer4, server4After.ID, "Server 4 UUID should be preserved (registry B unaffected)")
 
 	// 10c: Verify total server count is 3
-	servers, err = queries.ListServers(ctx, sqlc.ListServersParams{Size: 100})
+	serversA, err = queries.ListServers(ctx, sqlc.ListServersParams{RegistryID: regIDA, Size: 100})
 	require.NoError(t, err)
-	require.Len(t, servers, 3, "Should have 3 servers total (1 in registry A, 2 in registry B)")
+	serversB, err = queries.ListServers(ctx, sqlc.ListServersParams{RegistryID: regIDB, Size: 100})
+	require.NoError(t, err)
+	require.Equal(t, 3, len(serversA)+len(serversB), "Should have 3 servers total (1 in registry A, 2 in registry B)")
 
 	// Step 11: Do the reverse - remove a server from registry-B and verify registry-A is unaffected
 	registryBUpdated := createTestUpstreamRegistry([]upstreamv0.ServerJSON{
@@ -2034,8 +2163,10 @@ func TestDbSyncWriter_Store_RegistryIsolation(t *testing.T) {
 
 	// Verify server-1 in registry-A still has same UUID
 	server1FinalRows, err := queries.GetServerVersion(ctx, sqlc.GetServerVersionParams{
-		Name:    "test.org/server-1",
-		Version: "1.0.0",
+		RegistryID: regIDA,
+		Name:       "test.org/server-1",
+		Version:    "1.0.0",
+		Size:       100,
 	})
 	require.NoError(t, err)
 	require.NotEmpty(t, server1FinalRows)
@@ -2049,8 +2180,10 @@ func TestDbSyncWriter_Store_RegistryIsolation(t *testing.T) {
 
 	// Verify server-3 still exists with same UUID
 	server3FinalRows, err := queries.GetServerVersion(ctx, sqlc.GetServerVersionParams{
-		Name:    "test.org/server-3",
-		Version: "1.0.0",
+		RegistryID: regIDB,
+		Name:       "test.org/server-3",
+		Version:    "1.0.0",
+		Size:       100,
 	})
 	require.NoError(t, err)
 	require.NotEmpty(t, server3FinalRows)
@@ -2059,16 +2192,20 @@ func TestDbSyncWriter_Store_RegistryIsolation(t *testing.T) {
 
 	// Verify server-4 was deleted
 	discardRows, err = queries.GetServerVersion(ctx, sqlc.GetServerVersionParams{
-		Name:    "test.org/server-4",
-		Version: "1.0.0",
+		RegistryID: regIDB,
+		Name:       "test.org/server-4",
+		Version:    "1.0.0",
+		Size:       100,
 	})
 	require.NoError(t, err)
 	require.Empty(t, discardRows, "Server 4 should have been deleted from registry B")
 
 	// Final verification: total server count is 2
-	servers, err = queries.ListServers(ctx, sqlc.ListServersParams{Size: 100})
+	serversA, err = queries.ListServers(ctx, sqlc.ListServersParams{RegistryID: regIDA, Size: 100})
 	require.NoError(t, err)
-	require.Len(t, servers, 2, "Should have 2 servers total (1 in each registry)")
+	serversB, err = queries.ListServers(ctx, sqlc.ListServersParams{RegistryID: regIDB, Size: 100})
+	require.NoError(t, err)
+	require.Equal(t, 2, len(serversA)+len(serversB), "Should have 2 servers total (1 in each registry)")
 }
 
 // TestDbSyncWriter_Store_ServerWithMultiplePackages tests that a server can have multiple packages.
@@ -2085,6 +2222,7 @@ func TestDbSyncWriter_Store_ServerWithMultiplePackages(t *testing.T) {
 
 	ctx := context.Background()
 	queries := sqlc.New(pool)
+	regID := getTestRegistryID(t, pool, "test-registry")
 
 	// Create a server with 3 different packages (different registry types and identifiers)
 	server := createTestServer("test.org/server", "1.0.0")
@@ -2133,7 +2271,7 @@ func TestDbSyncWriter_Store_ServerWithMultiplePackages(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify all 3 packages exist
-	servers, err := queries.ListServers(ctx, sqlc.ListServersParams{Size: 100})
+	servers, err := queries.ListServers(ctx, sqlc.ListServersParams{RegistryID: regID, Size: 100})
 	require.NoError(t, err)
 	require.Len(t, servers, 1)
 
@@ -2166,6 +2304,7 @@ func TestDbSyncWriter_Store_MultiplePackagesOrphanedCleanup(t *testing.T) {
 
 	ctx := context.Background()
 	queries := sqlc.New(pool)
+	regID := getTestRegistryID(t, pool, "test-registry")
 
 	// First sync: server with 3 packages
 	server := createTestServer("test.org/server", "1.0.0")
@@ -2198,7 +2337,7 @@ func TestDbSyncWriter_Store_MultiplePackagesOrphanedCleanup(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify all 3 packages exist
-	servers, err := queries.ListServers(ctx, sqlc.ListServersParams{Size: 100})
+	servers, err := queries.ListServers(ctx, sqlc.ListServersParams{RegistryID: regID, Size: 100})
 	require.NoError(t, err)
 	require.Len(t, servers, 1)
 	serverID := servers[0].ID
@@ -2239,8 +2378,10 @@ func TestDbSyncWriter_Store_MultiplePackagesOrphanedCleanup(t *testing.T) {
 
 	// Verify server UUID is preserved
 	serverAfterUpdateRows, err := queries.GetServerVersion(ctx, sqlc.GetServerVersionParams{
-		Name:    "test.org/server",
-		Version: "1.0.0",
+		RegistryID: regID,
+		Name:       "test.org/server",
+		Version:    "1.0.0",
+		Size:       100,
 	})
 	require.NoError(t, err)
 	require.NotEmpty(t, serverAfterUpdateRows)
@@ -2291,6 +2432,7 @@ func TestDbSyncWriter_Store_PackageUpdate(t *testing.T) {
 
 	ctx := context.Background()
 	queries := sqlc.New(pool)
+	regID := getTestRegistryID(t, pool, "test-registry")
 
 	// First sync: server with 1 package
 	server := createTestServer("test.org/server", "1.0.0")
@@ -2310,7 +2452,7 @@ func TestDbSyncWriter_Store_PackageUpdate(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify package exists with version 1.0.0
-	servers, err := queries.ListServers(ctx, sqlc.ListServersParams{Size: 100})
+	servers, err := queries.ListServers(ctx, sqlc.ListServersParams{RegistryID: regID, Size: 100})
 	require.NoError(t, err)
 	require.Len(t, servers, 1)
 	serverID := servers[0].ID
@@ -2362,6 +2504,7 @@ func TestDbSyncWriter_Store_ComplexSyncScenario(t *testing.T) {
 
 	ctx := context.Background()
 	queries := sqlc.New(pool)
+	regID := getTestRegistryID(t, pool, "test-registry")
 
 	// First sync: 3 servers (A v1.0, B v1.0, C v1.0) each with packages/remotes
 	serverA := createTestServer("test.org/server-a", "1.0.0")
@@ -2404,8 +2547,10 @@ func TestDbSyncWriter_Store_ComplexSyncScenario(t *testing.T) {
 
 	// Record all UUIDs
 	serverAV1Rows, err := queries.GetServerVersion(ctx, sqlc.GetServerVersionParams{
-		Name:    "test.org/server-a",
-		Version: "1.0.0",
+		RegistryID: regID,
+		Name:       "test.org/server-a",
+		Version:    "1.0.0",
+		Size:       100,
 	})
 	require.NoError(t, err)
 	require.NotEmpty(t, serverAV1Rows)
@@ -2413,8 +2558,10 @@ func TestDbSyncWriter_Store_ComplexSyncScenario(t *testing.T) {
 	uuidA := serverAV1.ID
 
 	serverBV1Rows, err := queries.GetServerVersion(ctx, sqlc.GetServerVersionParams{
-		Name:    "test.org/server-b",
-		Version: "1.0.0",
+		RegistryID: regID,
+		Name:       "test.org/server-b",
+		Version:    "1.0.0",
+		Size:       100,
 	})
 	require.NoError(t, err)
 	require.NotEmpty(t, serverBV1Rows)
@@ -2422,8 +2569,10 @@ func TestDbSyncWriter_Store_ComplexSyncScenario(t *testing.T) {
 	_ = serverBV1.ID // Server B will be deleted
 
 	serverCV1Rows, err := queries.GetServerVersion(ctx, sqlc.GetServerVersionParams{
-		Name:    "test.org/server-c",
-		Version: "1.0.0",
+		RegistryID: regID,
+		Name:       "test.org/server-c",
+		Version:    "1.0.0",
+		Size:       100,
 	})
 	require.NoError(t, err)
 	require.NotEmpty(t, serverCV1Rows)
@@ -2467,8 +2616,10 @@ func TestDbSyncWriter_Store_ComplexSyncScenario(t *testing.T) {
 	// Verify results
 	// Server A: same UUID, updated description
 	serverAV2Rows, err := queries.GetServerVersion(ctx, sqlc.GetServerVersionParams{
-		Name:    "test.org/server-a",
-		Version: "1.0.0",
+		RegistryID: regID,
+		Name:       "test.org/server-a",
+		Version:    "1.0.0",
+		Size:       100,
 	})
 	require.NoError(t, err)
 	require.NotEmpty(t, serverAV2Rows)
@@ -2488,16 +2639,20 @@ func TestDbSyncWriter_Store_ComplexSyncScenario(t *testing.T) {
 
 	// Server B: deleted
 	discardRows, err := queries.GetServerVersion(ctx, sqlc.GetServerVersionParams{
-		Name:    "test.org/server-b",
-		Version: "1.0.0",
+		RegistryID: regID,
+		Name:       "test.org/server-b",
+		Version:    "1.0.0",
+		Size:       100,
 	})
 	require.NoError(t, err)
 	require.Empty(t, discardRows, "Server B should have been deleted")
 
 	// Server C: same UUID, no changes
 	serverCV2Rows, err := queries.GetServerVersion(ctx, sqlc.GetServerVersionParams{
-		Name:    "test.org/server-c",
-		Version: "1.0.0",
+		RegistryID: regID,
+		Name:       "test.org/server-c",
+		Version:    "1.0.0",
+		Size:       100,
 	})
 	require.NoError(t, err)
 	require.NotEmpty(t, serverCV2Rows)
@@ -2508,8 +2663,10 @@ func TestDbSyncWriter_Store_ComplexSyncScenario(t *testing.T) {
 
 	// Server D: new UUID, inserted
 	serverDV1Rows, err := queries.GetServerVersion(ctx, sqlc.GetServerVersionParams{
-		Name:    "test.org/server-d",
-		Version: "1.0.0",
+		RegistryID: regID,
+		Name:       "test.org/server-d",
+		Version:    "1.0.0",
+		Size:       100,
 	})
 	require.NoError(t, err)
 	require.NotEmpty(t, serverDV1Rows)
@@ -2519,7 +2676,7 @@ func TestDbSyncWriter_Store_ComplexSyncScenario(t *testing.T) {
 	assert.Equal(t, "Server D new", *serverDV1.Description)
 
 	// Verify total server count
-	servers, err := queries.ListServers(ctx, sqlc.ListServersParams{Size: 100})
+	servers, err := queries.ListServers(ctx, sqlc.ListServersParams{RegistryID: regID, Size: 100})
 	require.NoError(t, err)
 	require.Len(t, servers, 3, "Should have 3 servers (A, C, D)")
 }


### PR DESCRIPTION
Add cursor-based pagination `(position, source_id)` to `GetServerVersion` and `GetSkillVersion`, replacing full-table scans with indexed seeks. Add two supporting indexes: one on `registry_source(registry_id, position, source_id)` to drive the cursor seek, and one on `latest_entry_version(latest_version_id)` to eliminate a nested-loop seq scan that produced many row comparisons. Also drive the join from `entry_version` rather than `registry_entry` to give the planner a better leading table for the version filter.

Improves on #444