### PR TITLE
fix: rename catalog artifacts to registry-legacy and registry-upstream

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ sources:
     git:
       repository: https://github.com/stacklok/toolhive-catalog.git
       branch: main
-      path: pkg/catalog/toolhive/data/registry.json
+      path: pkg/catalog/toolhive/data/registry-legacy.json
     syncPolicy:
       interval: '30m'
 
@@ -288,7 +288,7 @@ auth:
 #     git:
 #       repository: https://github.com/stacklok/toolhive-catalog.git
 #       branch: main
-#       path: pkg/catalog/toolhive/data/registry.json
+#       path: pkg/catalog/toolhive/data/registry-legacy.json
 #     syncPolicy:
 #       interval: "30m"
 # registries:

--- a/deploy/charts/toolhive-registry-server/README.md
+++ b/deploy/charts/toolhive-registry-server/README.md
@@ -64,7 +64,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | config.registries[0].sources[0] | string | `"toolhive"` |  |
 | config.sources[0].format | string | `"toolhive"` |  |
 | config.sources[0].git.branch | string | `"main"` |  |
-| config.sources[0].git.path | string | `"pkg/catalog/toolhive/data/registry.json"` |  |
+| config.sources[0].git.path | string | `"pkg/catalog/toolhive/data/registry-legacy.json"` |  |
 | config.sources[0].git.repository | string | `"https://github.com/stacklok/toolhive-catalog.git"` |  |
 | config.sources[0].name | string | `"toolhive"` |  |
 | config.sources[0].syncPolicy.interval | string | `"30m"` |  |

--- a/deploy/charts/toolhive-registry-server/ci/ci-values.yaml
+++ b/deploy/charts/toolhive-registry-server/ci/ci-values.yaml
@@ -78,7 +78,7 @@ config:
       git:
         repository: https://github.com/stacklok/toolhive-catalog.git
         branch: main
-        path: pkg/catalog/toolhive/data/registry.json
+        path: pkg/catalog/toolhive/data/registry-legacy.json
       syncPolicy:
         interval: "30m"
 

--- a/deploy/charts/toolhive-registry-server/ci/postgres-values.yaml
+++ b/deploy/charts/toolhive-registry-server/ci/postgres-values.yaml
@@ -78,7 +78,7 @@ config:
       git:
         repository: https://github.com/stacklok/toolhive-catalog.git
         branch: main
-        path: pkg/catalog/toolhive/data/registry.json
+        path: pkg/catalog/toolhive/data/registry-legacy.json
       syncPolicy:
         interval: "30m"
 

--- a/deploy/charts/toolhive-registry-server/values.yaml
+++ b/deploy/charts/toolhive-registry-server/values.yaml
@@ -136,7 +136,7 @@ config:
       git:
         repository: https://github.com/stacklok/toolhive-catalog.git
         branch: main
-        path: pkg/catalog/toolhive/data/registry.json
+        path: pkg/catalog/toolhive/data/registry-legacy.json
       syncPolicy:
         interval: "30m"
 
@@ -167,7 +167,7 @@ config:
 #       git:
 #         repository: https://github.com/stacklok/toolhive-catalog.git
 #         tag: v1.0.0
-#         path: pkg/catalog/toolhive/data/registry.json
+#         path: pkg/catalog/toolhive/data/registry-legacy.json
 #         # auth:
 #         #   username: git-user
 #         #   passwordFile: /secrets/git-token

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -63,7 +63,7 @@ sources:
     git:
       repository: https://github.com/stacklok/toolhive-catalog.git
       branch: main
-      path: pkg/catalog/toolhive/data/registry.json
+      path: pkg/catalog/toolhive/data/registry-legacy.json
     syncPolicy:
       interval: "30m"
     filter:
@@ -152,7 +152,7 @@ git:
   branch: main                    # Optional: defaults to default branch
   tag: v1.0.0                     # Optional: use specific tag
   commit: abc123                  # Optional: pin to specific commit
-  path: pkg/catalog/toolhive/data/registry.json
+  path: pkg/catalog/toolhive/data/registry-legacy.json
   auth:                           # Optional: for private repos
     username: user
     passwordFile: /secrets/git-password
@@ -426,7 +426,7 @@ sources:
     git:
       repository: https://github.com/stacklok/toolhive-catalog.git
       branch: main
-      path: pkg/catalog/toolhive/data/registry.json
+      path: pkg/catalog/toolhive/data/registry-legacy.json
     syncPolicy:
       interval: "15m"
     filter:
@@ -470,7 +470,7 @@ sources:
     git:
       repository: https://github.com/stacklok/toolhive-catalog.git
       branch: main
-      path: pkg/catalog/toolhive/data/registry.json
+      path: pkg/catalog/toolhive/data/registry-legacy.json
     syncPolicy:
       interval: "30m"
 

--- a/docs/deployment-kubernetes.md
+++ b/docs/deployment-kubernetes.md
@@ -49,7 +49,7 @@ data:
         git:
           repository: https://github.com/stacklok/toolhive-catalog.git
           branch: main
-          path: pkg/catalog/toolhive/data/registry.json
+          path: pkg/catalog/toolhive/data/registry-legacy.json
         syncPolicy:
           interval: "15m"
     registries:
@@ -198,7 +198,7 @@ data:
         git:
           repository: https://github.com/stacklok/toolhive-catalog.git
           branch: main
-          path: pkg/catalog/toolhive/data/registry.json
+          path: pkg/catalog/toolhive/data/registry-legacy.json
         syncPolicy:
           interval: "15m"
     registries:

--- a/examples/README.md
+++ b/examples/README.md
@@ -55,7 +55,7 @@ registries:
     git:
       repository: https://github.com/stacklok/toolhive-catalog.git
       branch: main
-      path: pkg/catalog/toolhive/data/registry.json
+      path: pkg/catalog/toolhive/data/registry-legacy.json
     syncPolicy:
       interval: "30m"
 ```
@@ -63,7 +63,7 @@ registries:
 **What happens when you start:**
 1. Background sync coordinator starts immediately
 2. Clones `https://github.com/stacklok/toolhive-catalog.git` (shallow, depth=1)
-3. Extracts `pkg/catalog/toolhive/data/registry.json` from the `main` branch
+3. Extracts `pkg/catalog/toolhive/data/registry-legacy.json` from the `main` branch
 4. Stores synced data in the PostgreSQL database
 5. Repeats every 30 minutes
 
@@ -280,7 +280,7 @@ registries:
       # Option 3: Pin to exact commit
       commit: abc123def456
 
-      path: pkg/catalog/toolhive/data/registry.json
+      path: pkg/catalog/toolhive/data/registry-legacy.json
     syncPolicy:
       interval: "30m"
 ```
@@ -373,7 +373,7 @@ registries:
     git:
       repository: https://github.com/stacklok/toolhive-catalog.git
       branch: develop  # Use dev branch
-      path: pkg/catalog/toolhive/data/registry.json
+      path: pkg/catalog/toolhive/data/registry-legacy.json
     syncPolicy:
       interval: "1m"  # Very frequent for testing
 ```

--- a/examples/cnpg/helm-values.yaml
+++ b/examples/cnpg/helm-values.yaml
@@ -59,7 +59,7 @@ config:
       git:
         repository: https://github.com/stacklok/toolhive-catalog.git
         branch: main
-        path: pkg/catalog/toolhive/data/registry.json
+        path: pkg/catalog/toolhive/data/registry-legacy.json
       syncPolicy:
         interval: "5m"
 

--- a/examples/config-complete.yaml
+++ b/examples/config-complete.yaml
@@ -41,7 +41,7 @@ sources:
       # commit: abc123def456789
 
       # Path to registry file within repository (Required)
-      path: pkg/catalog/toolhive/data/registry.json
+      path: pkg/catalog/toolhive/data/registry-legacy.json
 
     # Per-registry synchronization policy
     syncPolicy:

--- a/examples/config-database-dev.yaml
+++ b/examples/config-database-dev.yaml
@@ -35,7 +35,7 @@ sources:
     git:
       repository: https://github.com/stacklok/toolhive-catalog.git
       branch: main
-      path: pkg/catalog/toolhive/data/registry.json
+      path: pkg/catalog/toolhive/data/registry-legacy.json
 
     # Per-registry automatic synchronization policy
     syncPolicy:

--- a/examples/config-database-passwordfile.yaml
+++ b/examples/config-database-passwordfile.yaml
@@ -72,7 +72,7 @@ sources:
     git:
       repository: https://github.com/stacklok/toolhive-catalog.git
       branch: main
-      path: pkg/catalog/toolhive/data/registry.json
+      path: pkg/catalog/toolhive/data/registry-legacy.json
 
     # Per-registry automatic synchronization policy
     syncPolicy:

--- a/examples/config-database-prod.yaml
+++ b/examples/config-database-prod.yaml
@@ -51,7 +51,7 @@ sources:
       repository: https://github.com/stacklok/toolhive-catalog.git
       # Use a specific tag for production stability
       tag: v1.0.0
-      path: pkg/catalog/toolhive/data/registry.json
+      path: pkg/catalog/toolhive/data/registry-legacy.json
 
     # Per-registry automatic synchronization policy
     syncPolicy:

--- a/examples/config-docker-multiple.yaml
+++ b/examples/config-docker-multiple.yaml
@@ -58,7 +58,7 @@ sources:
     git:
       repository: https://github.com/stacklok/toolhive-catalog.git
       branch: main
-      path: pkg/catalog/toolhive/data/official-registry.json
+      path: pkg/catalog/toolhive/data/registry-upstream.json
     syncPolicy:
       interval: "5m"  # Longer interval for Git operations
     # Optional: Per-registry filter for ToolHive servers

--- a/examples/config-git.yaml
+++ b/examples/config-git.yaml
@@ -27,7 +27,7 @@ sources:
       # commit: abc123def456
 
       # Path to registry file within the repository
-      path: pkg/catalog/toolhive/data/registry.json
+      path: pkg/catalog/toolhive/data/registry-legacy.json
 
     # Per-registry automatic synchronization policy
     syncPolicy:

--- a/examples/config-oauth.yaml
+++ b/examples/config-oauth.yaml
@@ -28,7 +28,7 @@ sources:
       # commit: abc123def456
 
       # Path to registry file within the repository
-      path: pkg/catalog/toolhive/data/registry.json
+      path: pkg/catalog/toolhive/data/registry-legacy.json
 
     # Per-registry automatic synchronization policy
     syncPolicy:


### PR DESCRIPTION
> **Do not merge this week.** This is part of a coordinated rename across multiple repos — all PRs need to land together.

## Summary
- Update `pkg/catalog/` path references to match renamed artifacts in toolhive-catalog
- `registry.json` → `registry-legacy.json`, `official-registry.json` → `registry-upstream.json`
- Updates docs, examples, Helm values, and CI configs
- Depends on stacklok/toolhive-catalog#1016

## Test plan
- [ ] CI passes
- [ ] Helm chart linting passes
- [ ] Verify paths match the new catalog artifact names

🤖 Generated with [Claude Code](https://claude.com/claude-code)