### PR TITLE
Enforce strict claim equality on subsequent publishes

### DIFF
--- a/internal/service/db/impl_mcp.go
+++ b/internal/service/db/impl_mcp.go
@@ -389,7 +389,7 @@ func insertServerVersionData(
 			var existingClaims, incoming map[string]any
 			_ = json.Unmarshal(existing.Claims, &existingClaims)
 			_ = json.Unmarshal(claimsJSON, &incoming)
-			if !claimsContain(incoming, existingClaims) {
+			if !claimsEqual(incoming, existingClaims) {
 				return uuid.Nil, fmt.Errorf("%w: claims do not match existing entry", service.ErrClaimsMismatch)
 			}
 		}
@@ -955,6 +955,17 @@ func cleanupOrphanedEntry(
 // by the record must appear in the caller's value(s) for K.
 // Both plain strings and []string values are supported.
 func claimsContain(caller, record map[string]any) bool {
+	return claimsContainOneWay(caller, record)
+}
+
+// claimsEqual returns true when a and b have exactly the same keys and values.
+// Used to enforce strict claim consistency on subsequent publishes of the same entry name.
+func claimsEqual(a, b map[string]any) bool {
+	return claimsContainOneWay(a, b) && claimsContainOneWay(b, a)
+}
+
+// claimsContainOneWay reports whether caller satisfies every claim in record.
+func claimsContainOneWay(caller, record map[string]any) bool {
 	for k, rv := range record {
 		cv, ok := caller[k]
 		if !ok {

--- a/internal/service/db/impl_skills.go
+++ b/internal/service/db/impl_skills.go
@@ -452,7 +452,7 @@ func (s *dbService) executePublishSkillTransaction(
 			var existingClaims, incoming map[string]any
 			_ = json.Unmarshal(existing.Claims, &existingClaims)
 			_ = json.Unmarshal(claimsJSON, &incoming)
-			if !claimsContain(incoming, existingClaims) {
+			if !claimsEqual(incoming, existingClaims) {
 				return "", fmt.Errorf("%w: claims do not match existing entry", service.ErrClaimsMismatch)
 			}
 		}


### PR DESCRIPTION
## Summary

Fix behavioral mismatch with the v2 design doc (Section 2.6): subsequent versions of the same entry must carry the **same** claims as the first publish.

The implementation was using `claimsContain(incoming, existing)` (superset check), which allowed adding new claim keys on later versions — silently narrowing visibility. For example, publishing v1 with `{org: "acme"}` then v2 with `{org: "acme", team: "platform"}` was accepted, but v2 would only be visible to the platform team.

### Change

- Extract `claimsContainOneWay` as the shared containment primitive
- `claimsContain` (existing) delegates to it — used for access checks (caller must cover resource)
- Add `claimsEqual` — bidirectional containment, used for publish claim consistency
- Replace the two publish consistency checks (servers + skills) to use `claimsEqual`

### Affected paths

- `impl_mcp.go` `insertServerVersionData` — server publish consistency
- `impl_skills.go` `executePublishSkillTransaction` — skill publish consistency

## Test plan

- [x] `task lint-fix` — 0 issues
- [x] `task test` — all tests pass
- [x] Existing publish tests still pass (they use matching claims)

🤖 Generated with [Claude Code](https://claude.com/claude-code)