### PR TITLE
Add `WithSkipAuthz` to bypass claims filtering in auth-only mode

### DIFF
--- a/internal/app/storage/database_factory.go
+++ b/internal/app/storage/database_factory.go
@@ -102,6 +102,12 @@ func (d *DatabaseFactory) CreateRegistryService(_ context.Context) (service.Regi
 		slog.Debug("Database service tracing enabled")
 	}
 
+	// When authz is not configured, skip per-entry claims filtering and
+	// registry-level claims gating (auth-only mode).
+	if d.config.Auth == nil || d.config.Auth.Authz == nil {
+		opts = append(opts, database.WithSkipAuthz())
+	}
+
 	return database.New(opts...)
 }
 

--- a/internal/service/db/impl.go
+++ b/internal/service/db/impl.go
@@ -38,6 +38,7 @@ type options struct {
 	pool        *pgxpool.Pool
 	tracer      trace.Tracer
 	maxMetaSize int
+	skipAuthz   bool
 }
 
 // Option is a functional option for configuring the database service
@@ -77,11 +78,21 @@ func WithMaxMetaSize(maxMetaSize int) Option {
 	}
 }
 
+// WithSkipAuthz disables per-entry claims filtering and registry-level
+// claims gating. Use when authz is not configured (auth-only mode).
+func WithSkipAuthz() Option {
+	return func(o *options) error {
+		o.skipAuthz = true
+		return nil
+	}
+}
+
 // dbService implements the RegistryService interface using a database backend
 type dbService struct {
 	pool        *pgxpool.Pool
 	tracer      trace.Tracer
 	maxMetaSize int
+	skipAuthz   bool
 }
 
 var _ service.RegistryService = (*dbService)(nil)
@@ -100,6 +111,7 @@ func New(opts ...Option) (service.RegistryService, error) {
 		pool:        o.pool,
 		tracer:      o.tracer,
 		maxMetaSize: o.maxMetaSize,
+		skipAuthz:   o.skipAuthz,
 	}, nil
 }
 

--- a/internal/service/db/impl_mcp.go
+++ b/internal/service/db/impl_mcp.go
@@ -58,7 +58,11 @@ func (s *dbService) ListServers(
 	}
 	span.SetAttributes(otel.AttrRegistryName.String(options.RegistryName))
 
-	registryID, err := lookupRegistryIDWithGate(ctx, s.pool, options.RegistryName, options.Claims)
+	gateClaims := options.Claims
+	if s.skipAuthz {
+		gateClaims = nil
+	}
+	registryID, err := lookupRegistryIDWithGate(ctx, s.pool, options.RegistryName, gateClaims)
 	if err != nil {
 		otel.RecordError(span, err)
 		return nil, err
@@ -124,6 +128,9 @@ func (s *dbService) ListServers(
 			return h.Claims, ok
 		},
 	)
+	if s.skipAuthz {
+		claimsFilter = nil
+	}
 	results, lastCursor, err := s.sharedListServersWithCursor(ctx, querierFunc, options.Limit, claimsFilter)
 	if err != nil {
 		otel.RecordError(span, err)
@@ -182,7 +189,11 @@ func (s *dbService) ListServerVersions(
 	}
 	span.SetAttributes(otel.AttrRegistryName.String(options.RegistryName))
 
-	registryIDForVersions, err := lookupRegistryIDWithGate(ctx, s.pool, options.RegistryName, options.Claims)
+	gateClaims := options.Claims
+	if s.skipAuthz {
+		gateClaims = nil
+	}
+	registryIDForVersions, err := lookupRegistryIDWithGate(ctx, s.pool, options.RegistryName, gateClaims)
 	if err != nil {
 		otel.RecordError(span, err)
 		return nil, err
@@ -218,6 +229,9 @@ func (s *dbService) ListServerVersions(
 			return h.Claims, ok
 		},
 	)
+	if s.skipAuthz {
+		claimsFilter = nil
+	}
 	results, err := s.sharedListServers(ctx, querierFunc, claimsFilter)
 	if err != nil {
 		otel.RecordError(span, err)
@@ -234,6 +248,8 @@ func (s *dbService) ListServerVersions(
 }
 
 // GetServer returns a specific server by name
+//
+//nolint:gocyclo
 func (s *dbService) GetServerVersion(
 	ctx context.Context,
 	opts ...service.Option,
@@ -261,7 +277,11 @@ func (s *dbService) GetServerVersion(
 		otel.AttrRegistryName.String(options.RegistryName),
 	)
 
-	registryID, err := lookupRegistryIDWithGate(ctx, s.pool, options.RegistryName, options.Claims)
+	gateClaims := options.Claims
+	if s.skipAuthz {
+		gateClaims = nil
+	}
+	registryID, err := lookupRegistryIDWithGate(ctx, s.pool, options.RegistryName, gateClaims)
 	if err != nil {
 		otel.RecordError(span, err)
 		return nil, err
@@ -312,6 +332,9 @@ func (s *dbService) GetServerVersion(
 			return h.Claims, ok
 		},
 	)
+	if s.skipAuthz {
+		claimsFilter = nil
+	}
 	res, err := s.sharedListServers(ctx, querierFunc, claimsFilter)
 	if err != nil {
 		otel.RecordError(span, err)

--- a/internal/service/db/impl_skills.go
+++ b/internal/service/db/impl_skills.go
@@ -49,7 +49,11 @@ func (s *dbService) ListSkills(
 		options.Limit = service.MaxPageSize
 	}
 
-	registryID, err := lookupRegistryIDWithGate(ctx, s.pool, options.RegistryName, options.Claims)
+	gateClaims := options.Claims
+	if s.skipAuthz {
+		gateClaims = nil
+	}
+	registryID, err := lookupRegistryIDWithGate(ctx, s.pool, options.RegistryName, gateClaims)
 	if err != nil {
 		otel.RecordError(span, err)
 		return nil, err
@@ -87,6 +91,9 @@ func (s *dbService) ListSkills(
 			return r.Claims, ok
 		},
 	)
+	if s.skipAuthz {
+		claimsFilter = nil
+	}
 	listRows, nextCursor, err := streamSkillRows(ctx, querier, params, claimsFilter, options.Limit)
 	if err != nil {
 		otel.RecordError(span, err)
@@ -174,7 +181,11 @@ func (s *dbService) GetSkillVersion(
 
 	span.SetAttributes(otel.AttrRegistryName.String(options.RegistryName))
 
-	registryID, err := lookupRegistryIDWithGate(ctx, s.pool, options.RegistryName, options.Claims)
+	gateClaims := options.Claims
+	if s.skipAuthz {
+		gateClaims = nil
+	}
+	registryID, err := lookupRegistryIDWithGate(ctx, s.pool, options.RegistryName, gateClaims)
 	if err != nil {
 		otel.RecordError(span, err)
 		return nil, err
@@ -209,7 +220,7 @@ func (s *dbService) GetSkillVersion(
 	var row sqlc.GetSkillVersionRow
 	found := false
 	for _, r := range rows {
-		if callerJSON == nil || checkClaims(callerJSON, r.Claims) {
+		if s.skipAuthz || callerJSON == nil || checkClaims(callerJSON, r.Claims) {
 			row = r
 			found = true
 			break


### PR DESCRIPTION
Add `skipAuthz bool` to `dbService` and a `WithSkipAuthz()` constructor option. When set, both the registry-level claims gate in `lookupRegistryIDWithGate` and the per-entry `newClaimsFilterWith` filter are bypassed, so authenticated callers see all entries regardless of stored claims. The service still enforces claims by default (fail-close).

`DatabaseFactory.CreateRegistryService` wires `WithSkipAuthz()` automatically when `Auth.Authz` is nil (auth-only mode), making the configuration transparent to the API layer.