### PR TITLE
Add commit message conventions to agents

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -43,6 +43,7 @@ Do NOT invoke for:
 - [ ] Appropriate use of context.Context
 - [ ] No unnecessary goroutines or concurrency issues
 - [ ] Proper resource cleanup (defer, Close())
+- [ ] Functional options are declared as `func(*T) error`, not `func(*T)` — flag any void option type as a required change
 
 ### Security Considerations
 - [ ] Container isolation properly implemented
@@ -68,7 +69,7 @@ Do NOT invoke for:
 - [ ] Public APIs have godoc comments
 - [ ] Complex logic has explanatory comments
 - [ ] README/docs updated if behavior changes
-- [ ] Commit messages follow CONTRIBUTING.md guidelines
+- [ ] Commit messages follow CONTRIBUTING.md guidelines: no conventional prefixes (`feat:`, `fix:`, etc.), subject ≤ 50 chars in imperative mood with backtick-quoted identifiers, body in plain technical prose, GitHub issue ref at the end when applicable
 
 ### Performance
 - [ ] No unnecessary allocations in hot paths

--- a/.claude/agents/golang-code-writer.md
+++ b/.claude/agents/golang-code-writer.md
@@ -26,6 +26,7 @@ When writing Go code, you will:
 - Follow Go's memory management best practices
 - Implement interfaces when abstraction adds value
 - Use struct embedding and method sets effectively
+- **Option pattern**: Always define functional options as `type XxxOption func(*T) error`, never as `func(*T)`. This allows individual options to signal validation failures without panicking. Apply options in a constructor by ranging over them and returning on the first error.
 
 **Code Structure:**
 - Organize code into logical packages with clear responsibilities following SOLID principles
@@ -48,3 +49,22 @@ When writing Go code, you will:
 - Include usage examples when helpful
 
 Always ask for clarification if requirements are ambiguous, and provide code that is production-ready, well-structured, and follows Go best practices. When working within existing codebases, maintain consistency with established patterns and conventions.
+
+**Commit Messages:**
+- No conventional commit prefixes (`feat:`, `fix:`, `chore:`, etc.)
+- Subject line: max 50 characters, imperative mood, backtick-quote identifiers and code names (e.g., `` Improve `GetServerVersion` query performance ``)
+- Blank line between subject and body
+- Body: explain *what* changed and *why* in plain technical prose — paragraph form, not bullets
+- End with a GitHub issue reference when applicable (`Fixes #123`, `Improves on #444`)
+
+Example:
+```
+Improve `GetServerVersion`/`GetSkillVersion` query performance
+
+Add cursor-based pagination `(position, source_id)` to
+`GetServerVersion` and `GetSkillVersion`, replacing full-table scans
+with indexed seeks. Add two supporting indexes to eliminate nested-loop
+seq scans.
+
+Improves on #444
+```

--- a/.claude/agents/tech-lead-orchestrator.md
+++ b/.claude/agents/tech-lead-orchestrator.md
@@ -61,3 +61,22 @@ Your core responsibilities:
 - Indicate priority and dependencies
 
 Always approach problems with a systems thinking mindset, considering both immediate requirements and long-term maintainability. Your goal is to ensure that all code produced meets high standards of quality, follows established patterns, and contributes to a cohesive, well-architected system.
+
+**Commit Messages:**
+- No conventional commit prefixes (`feat:`, `fix:`, `chore:`, etc.)
+- Subject line: max 50 characters, imperative mood, backtick-quote identifiers and code names (e.g., `` Improve `GetServerVersion` query performance ``)
+- Blank line between subject and body
+- Body: explain *what* changed and *why* in plain technical prose — paragraph form, not bullets
+- End with a GitHub issue reference when applicable (`Fixes #123`, `Improves on #444`)
+
+Example:
+```
+Improve `GetServerVersion`/`GetSkillVersion` query performance
+
+Add cursor-based pagination `(position, source_id)` to
+`GetServerVersion` and `GetSkillVersion`, replacing full-table scans
+with indexed seeks. Add two supporting indexes to eliminate nested-loop
+seq scans.
+
+Improves on #444
+```


### PR DESCRIPTION
Add a Commit Messages section to `golang-code-writer` and `tech-lead-orchestrator` specifying: no conventional prefixes, subject ≤ 50 chars in imperative mood with backtick-quoted identifiers, prose body, and optional GitHub issue reference. Expand the `code-reviewer` checklist to enforce the same rules. Also add the functional-options checklist item to `code-reviewer`.