### PR TITLE
Add tests and warn log for skipAuthz auth-only mode

### DIFF
--- a/internal/app/storage/database_factory.go
+++ b/internal/app/storage/database_factory.go
@@ -105,6 +105,7 @@ func (d *DatabaseFactory) CreateRegistryService(_ context.Context) (service.Regi
 	// When authz is not configured, skip per-entry claims filtering and
 	// registry-level claims gating (auth-only mode).
 	if d.config.Auth == nil || d.config.Auth.Authz == nil {
+		slog.Warn("Authorization not configured, per-entry claims filtering disabled (auth-only mode)")
 		opts = append(opts, database.WithSkipAuthz())
 	}
 

--- a/internal/service/db/skip_authz_test.go
+++ b/internal/service/db/skip_authz_test.go
@@ -1,0 +1,292 @@
+package database
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/aws/smithy-go/ptr"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stacklok/toolhive-registry-server/database"
+	"github.com/stacklok/toolhive-registry-server/internal/config"
+	"github.com/stacklok/toolhive-registry-server/internal/db/sqlc"
+	"github.com/stacklok/toolhive-registry-server/internal/service"
+)
+
+func setupTestServiceWithSkipAuthz(t *testing.T) (*dbService, func()) {
+	t.Helper()
+
+	ctx := context.Background()
+	db, cleanupFunc := database.SetupTestDB(t)
+	t.Cleanup(cleanupFunc)
+
+	connStr := db.Config().ConnString()
+
+	pool, err := pgxpool.New(ctx, connStr)
+	require.NoError(t, err)
+
+	serviceCleanup := func() {
+		pool.Close()
+		cleanupFunc()
+	}
+
+	svc := &dbService{
+		pool:        pool,
+		maxMetaSize: config.DefaultMaxMetaSize,
+		skipAuthz:   true,
+	}
+
+	return svc, serviceCleanup
+}
+
+func TestListServers_SkipAuthz(t *testing.T) {
+	t.Parallel()
+
+	callerClaims := map[string]any{"org": "caller-org"}
+
+	tests := []struct {
+		name          string
+		skipAuthz     bool
+		entryClaims   []byte
+		expectVisible bool
+	}{
+		{
+			name:          "skipAuthz true - nil entry claims visible",
+			skipAuthz:     true,
+			entryClaims:   nil,
+			expectVisible: true,
+		},
+		{
+			name:          "skipAuthz true - non-matching entry claims visible",
+			skipAuthz:     true,
+			entryClaims:   []byte(`{"org":"other-org"}`),
+			expectVisible: true,
+		},
+		{
+			name:          "skipAuthz false - nil entry claims invisible",
+			skipAuthz:     false,
+			entryClaims:   nil,
+			expectVisible: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var svc *dbService
+			var cleanup func()
+			if tt.skipAuthz {
+				svc, cleanup = setupTestServiceWithSkipAuthz(t)
+			} else {
+				svc, cleanup = setupTestService(t)
+			}
+			defer cleanup()
+
+			ctx := t.Context()
+			queries := sqlc.New(svc.pool)
+			now := time.Now().UTC()
+
+			regName := "sa-srv-reg-" + tt.name
+			srcName := "sa-srv-src-" + tt.name
+			entryName := "com.skipauth/" + tt.name
+
+			src, err := queries.InsertSource(ctx, sqlc.InsertSourceParams{
+				Name:         srcName,
+				CreationType: sqlc.CreationTypeCONFIG,
+				SourceType:   "git",
+				Syncable:     true,
+				CreatedAt:    &now,
+				UpdatedAt:    &now,
+			})
+			require.NoError(t, err)
+
+			reg, err := queries.UpsertRegistry(ctx, sqlc.UpsertRegistryParams{
+				Name:         regName,
+				CreationType: sqlc.CreationTypeCONFIG,
+				CreatedAt:    &now,
+				UpdatedAt:    &now,
+			})
+			require.NoError(t, err)
+
+			err = queries.LinkRegistrySource(ctx, sqlc.LinkRegistrySourceParams{
+				RegistryID: reg.ID,
+				SourceID:   src.ID,
+				Position:   0,
+			})
+			require.NoError(t, err)
+
+			entryID, err := queries.InsertRegistryEntry(ctx, sqlc.InsertRegistryEntryParams{
+				SourceID:  src.ID,
+				EntryType: sqlc.EntryTypeMCP,
+				Name:      entryName,
+				Claims:    tt.entryClaims,
+				CreatedAt: &now,
+				UpdatedAt: &now,
+			})
+			require.NoError(t, err)
+
+			versionID, err := queries.InsertEntryVersion(ctx, sqlc.InsertEntryVersionParams{
+				EntryID:     entryID,
+				Name:        entryName,
+				Version:     "1.0.0",
+				Title:       ptr.String("Test Server"),
+				Description: ptr.String("A test server"),
+				CreatedAt:   &now,
+				UpdatedAt:   &now,
+			})
+			require.NoError(t, err)
+
+			_, err = queries.InsertServerVersion(ctx, sqlc.InsertServerVersionParams{
+				VersionID:    versionID,
+				UpstreamMeta: []byte(`{}`),
+				ServerMeta:   []byte(`{}`),
+			})
+			require.NoError(t, err)
+
+			result, err := svc.ListServers(ctx,
+				service.WithRegistryName(regName),
+				service.WithClaims(callerClaims),
+				service.WithLimit(10),
+			)
+			require.NoError(t, err)
+
+			if tt.expectVisible {
+				require.Len(t, result.Servers, 1)
+				require.Equal(t, entryName, result.Servers[0].Name)
+			} else {
+				require.Empty(t, result.Servers)
+			}
+		})
+	}
+}
+
+func TestListSkills_SkipAuthz(t *testing.T) {
+	t.Parallel()
+
+	callerClaims := map[string]any{"org": "caller-org"}
+
+	tests := []struct {
+		name          string
+		skipAuthz     bool
+		entryClaims   []byte
+		expectVisible bool
+	}{
+		{
+			name:          "skipAuthz true - nil entry claims visible",
+			skipAuthz:     true,
+			entryClaims:   nil,
+			expectVisible: true,
+		},
+		{
+			name:          "skipAuthz true - non-matching entry claims visible",
+			skipAuthz:     true,
+			entryClaims:   []byte(`{"org":"other-org"}`),
+			expectVisible: true,
+		},
+		{
+			name:          "skipAuthz false - nil entry claims invisible",
+			skipAuthz:     false,
+			entryClaims:   nil,
+			expectVisible: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var svc *dbService
+			var cleanup func()
+			if tt.skipAuthz {
+				svc, cleanup = setupTestServiceWithSkipAuthz(t)
+			} else {
+				svc, cleanup = setupTestService(t)
+			}
+			defer cleanup()
+
+			ctx := t.Context()
+			queries := sqlc.New(svc.pool)
+			now := time.Now().UTC()
+
+			regName := "sa-skl-reg-" + tt.name
+			srcName := "sa-skl-src-" + tt.name
+			entryName := "com.skipauth/" + tt.name
+
+			src, err := queries.InsertSource(ctx, sqlc.InsertSourceParams{
+				Name:         srcName,
+				CreationType: sqlc.CreationTypeCONFIG,
+				SourceType:   "git",
+				Syncable:     true,
+				CreatedAt:    &now,
+				UpdatedAt:    &now,
+			})
+			require.NoError(t, err)
+
+			reg, err := queries.UpsertRegistry(ctx, sqlc.UpsertRegistryParams{
+				Name:         regName,
+				CreationType: sqlc.CreationTypeCONFIG,
+				CreatedAt:    &now,
+				UpdatedAt:    &now,
+			})
+			require.NoError(t, err)
+
+			err = queries.LinkRegistrySource(ctx, sqlc.LinkRegistrySourceParams{
+				RegistryID: reg.ID,
+				SourceID:   src.ID,
+				Position:   0,
+			})
+			require.NoError(t, err)
+
+			entryID, err := queries.InsertRegistryEntry(ctx, sqlc.InsertRegistryEntryParams{
+				SourceID:  src.ID,
+				EntryType: sqlc.EntryTypeSKILL,
+				Name:      entryName,
+				Claims:    tt.entryClaims,
+				CreatedAt: &now,
+				UpdatedAt: &now,
+			})
+			require.NoError(t, err)
+
+			versionID, err := queries.InsertEntryVersion(ctx, sqlc.InsertEntryVersionParams{
+				EntryID:     entryID,
+				Name:        entryName,
+				Version:     "1.0.0",
+				Title:       ptr.String("Test Skill"),
+				Description: ptr.String("A test skill"),
+				CreatedAt:   &now,
+				UpdatedAt:   &now,
+			})
+			require.NoError(t, err)
+
+			_, err = queries.InsertSkillVersion(ctx, sqlc.InsertSkillVersionParams{
+				VersionID:     versionID,
+				Namespace:     "com.skipauth",
+				Status:        sqlc.NullSkillStatus{},
+				AllowedTools:  nil,
+				Repository:    []byte("null"),
+				Icons:         []byte("null"),
+				Metadata:      []byte("null"),
+				ExtensionMeta: []byte("null"),
+			})
+			require.NoError(t, err)
+
+			result, err := svc.ListSkills(ctx,
+				service.WithRegistryName(regName),
+				service.WithNamespace("com.skipauth"),
+				service.WithClaims(callerClaims),
+				service.WithLimit(10),
+			)
+			require.NoError(t, err)
+
+			if tt.expectVisible {
+				require.Len(t, result.Skills, 1)
+				require.Equal(t, entryName, result.Skills[0].Name)
+			} else {
+				require.Empty(t, result.Skills)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Follow-up to #697. Addresses two gaps identified during review:

- **Tests**: Adds unit tests for `skipAuthz` behavior covering `ListServers` and `ListSkills`. Verifies that entries with nil or non-matching claims are visible when `skipAuthz=true` (auth-only mode), and confirms existing filtering behavior when `skipAuthz=false`. Without these tests, the bug fixed in #697 could silently regress.
- **Warn log**: Emits `slog.Warn` at startup when authorization is not configured and `WithSkipAuthz()` is activated, giving operators visibility into the claims filtering bypass.

## Test plan

- [x] `task lint-fix` passes (0 issues)
- [x] New tests pass: `go test -run 'TestListServers_SkipAuthz|TestListSkills_SkipAuthz' ./internal/service/db/` (6/6 pass)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)