### PR TITLE
Add internal server for probe endpoints

### DIFF
--- a/cmd/thv-registry-api/app/serve.go
+++ b/cmd/thv-registry-api/app/serve.go
@@ -44,12 +44,18 @@ const (
 
 func init() {
 	serveCmd.Flags().String("address", ":8080", "Address to listen on")
+	serveCmd.Flags().String("internal-address", ":8081", "Address to listen on for internal endpoints (health, readiness, version)")
 	serveCmd.Flags().String("config", "", "Path to configuration file (YAML format, required)")
 	serveCmd.Flags().String("auth-mode", "", "Override auth mode from config (anonymous or oauth)")
 
 	err := viper.BindPFlag("address", serveCmd.Flags().Lookup("address"))
 	if err != nil {
 		slog.Error("Failed to bind address flag", "error", err)
+		os.Exit(1)
+	}
+	err = viper.BindPFlag("internal-address", serveCmd.Flags().Lookup("internal-address"))
+	if err != nil {
+		slog.Error("Failed to bind internal-address flag", "error", err)
 		os.Exit(1)
 	}
 	err = viper.BindPFlag("config", serveCmd.Flags().Lookup("config"))
@@ -136,10 +142,12 @@ func runServe(cmd *cobra.Command, _ []string) error {
 
 	// Build application using the builder pattern
 	address := viper.GetString("address")
+	internalAddress := viper.GetString("internal-address")
 	app, err := registryapp.NewRegistryApp(
 		ctx,
 		registryapp.WithConfig(cfg),
 		registryapp.WithAddress(address),
+		registryapp.WithInternalAddress(internalAddress),
 		registryapp.WithMeterProvider(tel.MeterProvider()),
 		registryapp.WithTracerProvider(tel.TracerProvider()),
 	)

--- a/deploy/charts/toolhive-registry-server/README.md
+++ b/deploy/charts/toolhive-registry-server/README.md
@@ -77,7 +77,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | image.registryServerUrl | string | `"ghcr.io/stacklok/thv-registry-api:v1.0.2"` | URL of the registry server image |
 | imagePullSecrets | list | `[]` | Image pull secrets for private registries |
 | initContainers | list | `[]` | Init containers to run before the main container Use this for setup tasks like preparing pgpass files, waiting for dependencies, etc. Init containers share the same volumes as the main container (extraVolumes) |
-| livenessProbe | object | `{"httpGet":{"path":"/health","port":"http"},"initialDelaySeconds":30,"periodSeconds":10}` | Liveness probe configuration |
+| livenessProbe | object | `{"httpGet":{"path":"/health","port":"internal-http"},"initialDelaySeconds":30,"periodSeconds":10}` | Liveness probe configuration |
 | nameOverride | string | `""` | Override the name of the chart |
 | nodeSelector | object | `{}` | Node selector for pod scheduling |
 | podAnnotations | object | `{}` | Annotations to add to the pod |
@@ -86,7 +86,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | rbac | object | `{"allowedNamespaces":[],"scope":"cluster"}` | RBAC configuration for the registry server |
 | rbac.allowedNamespaces | list | `[]` | List of namespaces that the registry server is allowed to watch. Only used if scope is set to "namespace". |
 | rbac.scope | string | `"cluster"` | Scope of the RBAC configuration. - cluster: The registry server will have cluster-wide permissions via ClusterRole and ClusterRoleBinding. - namespace: The registry server will have permissions to watch resources in the namespaces specified in `allowedNamespaces`.   The registry server will have a ClusterRole and RoleBinding for each namespace in `allowedNamespaces`. |
-| readinessProbe | object | `{"httpGet":{"path":"/readiness","port":"http"},"initialDelaySeconds":5,"periodSeconds":5}` | Readiness probe configuration |
+| readinessProbe | object | `{"httpGet":{"path":"/readiness","port":"internal-http"},"initialDelaySeconds":5,"periodSeconds":5}` | Readiness probe configuration |
 | replicaCount | int | `1` | Number of replicas |
 | resources | object | `{"limits":{"cpu":"500m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | Resource requests and limits (matching operator defaults) |
 | securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsNonRoot":true,"runAsUser":65535,"seccompProfile":{"type":"RuntimeDefault"}}` | Container security context |

--- a/deploy/charts/toolhive-registry-server/ci/ci-values.yaml
+++ b/deploy/charts/toolhive-registry-server/ci/ci-values.yaml
@@ -18,14 +18,14 @@ resources:
 livenessProbe:
   httpGet:
     path: /health
-    port: http
+    port: internal-http
   initialDelaySeconds: 15
   periodSeconds: 5
 
 readinessProbe:
   httpGet:
     path: /readiness
-    port: http
+    port: internal-http
   initialDelaySeconds: 10
   periodSeconds: 3
 

--- a/deploy/charts/toolhive-registry-server/ci/postgres-values.yaml
+++ b/deploy/charts/toolhive-registry-server/ci/postgres-values.yaml
@@ -18,14 +18,14 @@ resources:
 livenessProbe:
   httpGet:
     path: /health
-    port: http
+    port: internal-http
   initialDelaySeconds: 15
   periodSeconds: 5
 
 readinessProbe:
   httpGet:
     path: /readiness
-    port: http
+    port: internal-http
   initialDelaySeconds: 10
   periodSeconds: 3
 

--- a/deploy/charts/toolhive-registry-server/templates/deployment.yaml
+++ b/deploy/charts/toolhive-registry-server/templates/deployment.yaml
@@ -51,6 +51,9 @@ spec:
             - name: http
               containerPort: 8080
               protocol: TCP
+            - name: internal-http
+              containerPort: 8081
+              protocol: TCP
           {{- with .Values.livenessProbe }}
           livenessProbe:
             {{- toYaml . | nindent 12 }}

--- a/deploy/charts/toolhive-registry-server/values.yaml
+++ b/deploy/charts/toolhive-registry-server/values.yaml
@@ -69,7 +69,7 @@ resources:
 livenessProbe:
   httpGet:
     path: /health
-    port: http
+    port: internal-http
   initialDelaySeconds: 30
   periodSeconds: 10
 
@@ -77,7 +77,7 @@ livenessProbe:
 readinessProbe:
   httpGet:
     path: /readiness
-    port: http
+    port: internal-http
   initialDelaySeconds: 5
   periodSeconds: 5
 

--- a/docs/cli/thv-registry-api_serve.md
+++ b/docs/cli/thv-registry-api_serve.md
@@ -34,10 +34,11 @@ thv-registry-api serve [flags]
 ### Options
 
 ```
-      --address string     Address to listen on (default ":8080")
-      --auth-mode string   Override auth mode from config (anonymous or oauth)
-      --config string      Path to configuration file (YAML format, required)
-  -h, --help               help for serve
+      --address string            Address to listen on (default ":8080")
+      --auth-mode string          Override auth mode from config (anonymous or oauth)
+      --config string             Path to configuration file (YAML format, required)
+  -h, --help                      help for serve
+      --internal-address string   Address to listen on for internal endpoints (health, readiness, version) (default ":8081")
 ```
 
 ### Options inherited from parent commands

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -72,11 +72,6 @@ func NewServer(svc service.RegistryService, opts ...ServerOption) *chi.Mux {
 		r.Use(mw)
 	}
 
-	// Mount operational endpoints at root
-	r.Get("/health", healthHandler)
-	r.Get("/readiness", readinessHandler(svc))
-	r.Get("/version", versionHandler)
-
 	// Mount OpenAPI endpoint
 	r.Get("/openapi.json", openAPIHandler)
 
@@ -92,15 +87,21 @@ func NewServer(svc service.RegistryService, opts ...ServerOption) *chi.Mux {
 	return r
 }
 
+// NewInternalServer creates a minimal HTTP router for internal operational
+// endpoints (health, readiness, version). These endpoints are intended to
+// run on a separate port so that Kubernetes probes hit a dedicated server
+// that carries no authentication or application middleware.
+func NewInternalServer(svc service.RegistryService) *chi.Mux {
+	r := chi.NewRouter()
+	r.Get("/health", healthHandler)
+	r.Get("/readiness", readinessHandler(svc))
+	r.Get("/version", versionHandler)
+	return r
+}
+
 // LoggingMiddleware logs HTTP requests
 func LoggingMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Skip logging for health and readiness endpoints
-		if r.URL.Path == "/health" || r.URL.Path == "/readiness" {
-			next.ServeHTTP(w, r)
-			return
-		}
-
 		start := time.Now()
 		ww := middleware.NewWrapResponseWriter(w, r.ProtoMajor)
 

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -22,7 +22,7 @@ func TestHealthEndpoint(t *testing.T) {
 
 	mockSvc := mocks.NewMockRegistryService(ctrl)
 	// No expectations needed - health check doesn't call service
-	server := api.NewServer(mockSvc)
+	server := api.NewInternalServer(mockSvc)
 
 	req, err := http.NewRequest("GET", "/health", nil)
 	require.NoError(t, err)
@@ -75,7 +75,7 @@ func TestReadinessEndpoint(t *testing.T) {
 			mockSvc := mocks.NewMockRegistryService(ctrl)
 			tt.setupMock(mockSvc)
 
-			server := api.NewServer(mockSvc)
+			server := api.NewInternalServer(mockSvc)
 
 			req, err := http.NewRequest("GET", "/readiness", nil)
 			require.NoError(t, err)
@@ -106,7 +106,7 @@ func TestVersionEndpoint(t *testing.T) {
 
 	mockSvc := mocks.NewMockRegistryService(ctrl)
 	// No expectations needed - version check doesn't call service
-	server := api.NewServer(mockSvc)
+	server := api.NewInternalServer(mockSvc)
 
 	req, err := http.NewRequest("GET", "/version", nil)
 	require.NoError(t, err)

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -15,9 +15,10 @@ import (
 // RegistryApp encapsulates all components needed to run the registry API server
 // It provides lifecycle management and graceful shutdown capabilities
 type RegistryApp struct {
-	config     *config.Config
-	components *AppComponents
-	httpServer *http.Server
+	config             *config.Config
+	components         *AppComponents
+	httpServer         *http.Server
+	internalHTTPServer *http.Server
 
 	// Lifecycle management
 	ctx        context.Context
@@ -31,6 +32,14 @@ func (app *RegistryApp) Start() error {
 	go func() {
 		if err := app.components.SyncCoordinator.Start(app.ctx); err != nil {
 			slog.Error("Sync coordinator failed", "error", err)
+		}
+	}()
+
+	// Start internal HTTP server in background
+	go func() {
+		slog.Info("Internal server listening", "address", app.internalHTTPServer.Addr)
+		if err := app.internalHTTPServer.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			slog.Error("Internal HTTP server failed", "error", err)
 		}
 	}()
 
@@ -62,8 +71,22 @@ func (app *RegistryApp) Stop(timeout time.Duration) error {
 	shutdownCtx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
+	var shutdownErr error
 	if err := app.httpServer.Shutdown(shutdownCtx); err != nil {
-		return fmt.Errorf("server forced to shutdown: %w", err)
+		shutdownErr = fmt.Errorf("server forced to shutdown: %w", err)
+	}
+
+	if err := app.internalHTTPServer.Shutdown(shutdownCtx); err != nil {
+		internalErr := fmt.Errorf("internal server forced to shutdown: %w", err)
+		if shutdownErr != nil {
+			shutdownErr = errors.Join(shutdownErr, internalErr)
+		} else {
+			shutdownErr = internalErr
+		}
+	}
+
+	if shutdownErr != nil {
+		return shutdownErr
 	}
 
 	slog.Info("Server shutdown complete")
@@ -78,4 +101,9 @@ func (app *RegistryApp) GetConfig() *config.Config {
 // GetHTTPServer returns the HTTP server (useful for testing to get the actual port)
 func (app *RegistryApp) GetHTTPServer() *http.Server {
 	return app.httpServer
+}
+
+// GetInternalHTTPServer returns the internal HTTP server (useful for testing to get the actual port)
+func (app *RegistryApp) GetInternalHTTPServer() *http.Server {
+	return app.internalHTTPServer
 }

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -79,17 +79,20 @@ func createTestApp(t *testing.T, ctrl *gomock.Controller, addr string) *Registry
 
 	// Build the HTTP server with test configuration
 	appCfg := &registryAppConfig{
-		config:         cfg,
-		address:        addr,
-		requestTimeout: 10 * time.Second,
-		readTimeout:    10 * time.Second,
-		writeTimeout:   15 * time.Second,
-		idleTimeout:    60 * time.Second,
-		authMiddleware: func(next http.Handler) http.Handler { return next },
+		config:          cfg,
+		address:         addr,
+		internalAddress: ":0",
+		requestTimeout:  10 * time.Second,
+		readTimeout:     10 * time.Second,
+		writeTimeout:    15 * time.Second,
+		idleTimeout:     60 * time.Second,
+		authMiddleware:  func(next http.Handler) http.Handler { return next },
 	}
 
 	server, err := buildHTTPServer(ctx, appCfg, mockSvc, nil)
 	require.NoError(t, err)
+
+	internalServer := buildInternalHTTPServer(appCfg, mockSvc)
 
 	return &RegistryApp{
 		config: cfg,
@@ -97,9 +100,10 @@ func createTestApp(t *testing.T, ctrl *gomock.Controller, addr string) *Registry
 			SyncCoordinator: mockCoord,
 			RegistryService: mockSvc,
 		},
-		httpServer: server,
-		ctx:        appCtx,
-		cancelFunc: cancel,
+		httpServer:         server,
+		internalHTTPServer: internalServer,
+		ctx:                appCtx,
+		cancelFunc:         cancel,
 	}
 }
 
@@ -207,14 +211,20 @@ func TestRegistryApp_StartWithListener(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	app := createTestApp(t, ctrl, ":0")
 
-	// Create a listener to get an actual port
-	listener, err := net.Listen("tcp", ":0")
+	// Create listeners to get actual ports for both servers
+	mainListener, err := net.Listen("tcp", ":0")
 	require.NoError(t, err)
-	actualAddr := listener.Addr().String()
-	listener.Close()
+	mainAddr := mainListener.Addr().String()
+	mainListener.Close()
 
-	// Update the server address to use the now-free port
-	app.httpServer.Addr = actualAddr
+	internalListener, err := net.Listen("tcp", ":0")
+	require.NoError(t, err)
+	internalAddr := internalListener.Addr().String()
+	internalListener.Close()
+
+	// Update the server addresses to use the now-free ports
+	app.httpServer.Addr = mainAddr
+	app.internalHTTPServer.Addr = internalAddr
 
 	// Start server in goroutine
 	errChan := make(chan error, 1)
@@ -225,8 +235,8 @@ func TestRegistryApp_StartWithListener(t *testing.T) {
 	// Wait for server to start
 	time.Sleep(100 * time.Millisecond)
 
-	// Make a health check request
-	resp, err := http.Get("http://" + actualAddr + "/health")
+	// Make a health check request against the internal server
+	resp, err := http.Get("http://" + internalAddr + "/health")
 	if err == nil {
 		resp.Body.Close()
 		assert.Equal(t, http.StatusOK, resp.StatusCode)

--- a/internal/app/builder.go
+++ b/internal/app/builder.go
@@ -28,15 +28,16 @@ import (
 )
 
 const (
-	defaultHTTPAddress    = ":8080"
-	defaultRequestTimeout = 10 * time.Second
-	defaultReadTimeout    = 10 * time.Second
-	defaultWriteTimeout   = 15 * time.Second
-	defaultIdleTimeout    = 60 * time.Second
+	defaultHTTPAddress         = ":8080"
+	defaultInternalHTTPAddress = ":8081"
+	defaultRequestTimeout      = 10 * time.Second
+	defaultReadTimeout         = 10 * time.Second
+	defaultWriteTimeout        = 15 * time.Second
+	defaultIdleTimeout         = 60 * time.Second
 )
 
 // defaultPublicPaths are paths that never require authentication
-var defaultPublicPaths = []string{"/health", "/readiness", "/version", "/openapi.json", "/.well-known"}
+var defaultPublicPaths = []string{"/openapi.json", "/.well-known"}
 
 // RegistryAppOptions is a function that configures the registry app builder
 type RegistryAppOptions func(*registryAppConfig) error
@@ -52,12 +53,13 @@ type registryAppConfig struct {
 	storageFactory         storage.Factory // Replaces: storageManager, statusPersistence, registryProvider
 
 	// HTTP server options
-	address        string
-	middlewares    []func(http.Handler) http.Handler
-	requestTimeout time.Duration
-	readTimeout    time.Duration
-	writeTimeout   time.Duration
-	idleTimeout    time.Duration
+	address         string
+	internalAddress string
+	middlewares     []func(http.Handler) http.Handler
+	requestTimeout  time.Duration
+	readTimeout     time.Duration
+	writeTimeout    time.Duration
+	idleTimeout     time.Duration
 
 	// Auth components
 	authMiddleware  func(http.Handler) http.Handler
@@ -73,11 +75,12 @@ type registryAppConfig struct {
 
 func baseConfig(opts ...RegistryAppOptions) (*registryAppConfig, error) {
 	cfg := &registryAppConfig{
-		address:        defaultHTTPAddress,
-		requestTimeout: defaultRequestTimeout,
-		readTimeout:    defaultReadTimeout,
-		writeTimeout:   defaultWriteTimeout,
-		idleTimeout:    defaultIdleTimeout,
+		address:         defaultHTTPAddress,
+		internalAddress: defaultInternalHTTPAddress,
+		requestTimeout:  defaultRequestTimeout,
+		readTimeout:     defaultReadTimeout,
+		writeTimeout:    defaultWriteTimeout,
+		idleTimeout:     defaultIdleTimeout,
 	}
 
 	// Apply options
@@ -149,6 +152,9 @@ func NewRegistryApp(
 		return nil, fmt.Errorf("failed to build HTTP server: %w", err)
 	}
 
+	// Build internal HTTP server for health/readiness/version
+	internalHTTPServer := buildInternalHTTPServer(cfg, registryService)
+
 	// Create application context
 	appCtx, cancel := context.WithCancel(ctx) //nolint:gosec // G118 false positive: cancel is called in cancelFunc below
 
@@ -171,9 +177,10 @@ func NewRegistryApp(
 			SyncCoordinator: syncCoordinator,
 			RegistryService: registryService,
 		},
-		httpServer: httpServer,
-		ctx:        appCtx,
-		cancelFunc: cancelFunc,
+		httpServer:         httpServer,
+		internalHTTPServer: internalHTTPServer,
+		ctx:                appCtx,
+		cancelFunc:         cancelFunc,
 	}, nil
 }
 
@@ -211,6 +218,36 @@ func WithAddress(addr string) RegistryAppOptions {
 		}
 
 		cfg.address = addr
+		return nil
+	}
+}
+
+// WithInternalAddress sets the internal HTTP server address for health, readiness, and version endpoints
+func WithInternalAddress(addr string) RegistryAppOptions {
+	return func(cfg *registryAppConfig) error {
+		if addr == "" {
+			return fmt.Errorf("internal address cannot be empty")
+		}
+
+		parts := strings.SplitN(addr, ":", 2)
+		host := parts[0]
+		port := parts[1]
+
+		if port == "" {
+			return fmt.Errorf("internal address is not a valid port: %s", addr)
+		}
+		if host == "localhost" {
+			host = "127.0.0.1"
+		}
+		if host == "" {
+			host = "0.0.0.0"
+		}
+
+		if _, err := netip.ParseAddrPort(host + ":" + port); err != nil {
+			return fmt.Errorf("internal address is not a valid port: %w", err)
+		}
+
+		cfg.internalAddress = addr
 		return nil
 	}
 }
@@ -469,6 +506,18 @@ func buildHTTPServer(
 
 	slog.Info("HTTP server configured", "address", b.address)
 	return server, nil
+}
+
+// buildInternalHTTPServer builds the internal HTTP server for health, readiness, and version endpoints
+func buildInternalHTTPServer(b *registryAppConfig, svc service.RegistryService) *http.Server {
+	router := api.NewInternalServer(svc)
+	return &http.Server{
+		Addr:         b.internalAddress,
+		Handler:      router,
+		ReadTimeout:  b.readTimeout,
+		WriteTimeout: b.writeTimeout,
+		IdleTimeout:  b.idleTimeout,
+	}
 }
 
 // ensureStorageFactory creates the storage factory if not already injected.


### PR DESCRIPTION
Move `/health`, `/readiness`, and `/version` onto a dedicated HTTP server (default `:8081`) so Kubernetes probe traffic is separated from the main API port. Adds `NewInternalServer`, `WithInternalAddress`, and `--internal-address` flag. Updates the Helm chart to expose the `internal-http` container port and point the default probes at it.