### PR TITLE
Fix integration test port contention

### DIFF
--- a/internal/authz/authz_anonymous_test.go
+++ b/internal/authz/authz_anonymous_test.go
@@ -30,18 +30,23 @@ func TestAuthzIntegration_AnonymousMode(t *testing.T) {
 		method     string
 		path       string
 		wantStatus int
+		internal   bool
 	}{
-		{"health", "GET", "/health", 200},
-		{"readiness", "GET", "/readiness", 200},
-		{"list servers without token", "GET", "/registry/acme-all/v0.1/servers", 200},
-		{"list sources without token", "GET", "/v1/sources", 200},
-		{"list registries without token", "GET", "/v1/registries", 200},
+		{"health", "GET", "/health", 200, true},
+		{"readiness", "GET", "/readiness", 200, true},
+		{"list servers without token", "GET", "/registry/acme-all/v0.1/servers", 200, false},
+		{"list sources without token", "GET", "/v1/sources", 200, false},
+		{"list registries without token", "GET", "/v1/registries", 200, false},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			resp := doRequest(t, tt.method, env.baseURL+tt.path, "", nil)
+			base := env.baseURL
+			if tt.internal {
+				base = env.internalURL
+			}
+			resp := doRequest(t, tt.method, base+tt.path, "", nil)
 			assertStatus(t, resp, tt.wantStatus)
 		})
 	}

--- a/internal/authz/authz_authonly_test.go
+++ b/internal/authz/authz_authonly_test.go
@@ -33,21 +33,26 @@ func TestAuthzIntegration_AuthOnlyMode(t *testing.T) {
 		path       string
 		token      string
 		wantStatus int
+		internal   bool
 	}{
-		{"health no token", "GET", "/health", "", 200},
-		{"readiness no token", "GET", "/readiness", "", 200},
-		{"servers no token", "GET", "/registry/acme-all/v0.1/servers", "", 401},
-		{"sources no token", "GET", "/v1/sources", "", 401},
-		{"registries no token", "GET", "/v1/registries", "", 401},
-		{"servers valid token", "GET", "/registry/acme-all/v0.1/servers", validToken, 200},
-		{"sources valid token", "GET", "/v1/sources", validToken, 200},
-		{"registries valid token", "GET", "/v1/registries", validToken, 200},
+		{"health no token", "GET", "/health", "", 200, true},
+		{"readiness no token", "GET", "/readiness", "", 200, true},
+		{"servers no token", "GET", "/registry/acme-all/v0.1/servers", "", 401, false},
+		{"sources no token", "GET", "/v1/sources", "", 401, false},
+		{"registries no token", "GET", "/v1/registries", "", 401, false},
+		{"servers valid token", "GET", "/registry/acme-all/v0.1/servers", validToken, 200, false},
+		{"sources valid token", "GET", "/v1/sources", validToken, 200, false},
+		{"registries valid token", "GET", "/v1/registries", validToken, 200, false},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			resp := doRequest(t, tt.method, env.baseURL+tt.path, tt.token, nil)
+			base := env.baseURL
+			if tt.internal {
+				base = env.internalURL
+			}
+			resp := doRequest(t, tt.method, base+tt.path, tt.token, nil)
 			assertStatus(t, resp, tt.wantStatus)
 		})
 	}

--- a/internal/authz/authz_full_test.go
+++ b/internal/authz/authz_full_test.go
@@ -47,14 +47,19 @@ func TestAuthzIntegration_FullAuthzMode(t *testing.T) {
 			name       string
 			path       string
 			wantStatus int
+			internal   bool
 		}{
-			{"health", "/health", 200},
-			{"readiness", "/readiness", 200},
-			{"oauth-protected-resource", "/.well-known/oauth-protected-resource", 200},
+			{"health", "/health", 200, true},
+			{"readiness", "/readiness", 200, true},
+			{"oauth-protected-resource", "/.well-known/oauth-protected-resource", 200, false},
 		}
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
-				resp := doRequest(t, "GET", env.baseURL+tt.path, "", nil)
+				base := env.baseURL
+				if tt.internal {
+					base = env.internalURL
+				}
+				resp := doRequest(t, "GET", base+tt.path, "", nil)
 				assertStatus(t, resp, tt.wantStatus)
 			})
 		}

--- a/internal/authz/authz_helpers_test.go
+++ b/internal/authz/authz_helpers_test.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"math/big"
 	"net"
 	"net/http"
@@ -214,8 +215,9 @@ func dbConfigFromConnStr(t *testing.T, connStr string) *config.DatabaseConfig {
 // ---------------------------------------------------------------------------
 
 type testEnv struct {
-	baseURL string
-	oidc    *mockOIDCServer
+	baseURL     string
+	internalURL string
+	oidc        *mockOIDCServer
 }
 
 func setupEnv(t *testing.T, authCfg *config.AuthConfig) *testEnv {
@@ -225,6 +227,13 @@ func setupEnv(t *testing.T, authCfg *config.AuthConfig) *testEnv {
 
 func setupEnvCustom(t *testing.T, authCfg *config.AuthConfig, sources []config.SourceConfig, registries []config.RegistryConfig) *testEnv {
 	t.Helper()
+
+	// Silence application slog output — the server emits many INFO messages
+	// (startup, sync, HTTP requests) that clutter test output without adding
+	// diagnostic value.
+	orig := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(io.Discard, nil)))
+	t.Cleanup(func() { slog.SetDefault(orig) })
 
 	db, cleanup := database.SetupTestDB(t)
 	t.Cleanup(cleanup)
@@ -259,17 +268,24 @@ func setupEnvCustom(t *testing.T, authCfg *config.AuthConfig, sources []config.S
 	app, err := registryapp.NewRegistryApp(ctx,
 		registryapp.WithConfig(cfg),
 		registryapp.WithAddress(":0"),
+		registryapp.WithInternalAddress(":0"),
 		registryapp.WithCoordinatorOptions(coordinator.TestingWithPollingInterval(500*time.Millisecond)),
 	)
 	require.NoError(t, err)
 
-	// Get a random free port, assign it, and start the server
+	// Get random free ports for both the main and internal servers.
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 	addr := listener.Addr().String()
 	listener.Close()
 
+	internalListener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	internalAddr := internalListener.Addr().String()
+	internalListener.Close()
+
 	app.GetHTTPServer().Addr = addr
+	app.GetInternalHTTPServer().Addr = internalAddr
 
 	errCh := make(chan error, 1)
 	go func() { errCh <- app.Start() }()
@@ -279,11 +295,13 @@ func setupEnvCustom(t *testing.T, authCfg *config.AuthConfig, sources []config.S
 	})
 
 	baseURL := "http://" + addr
-	waitForReady(t, baseURL)
+	internalURL := "http://" + internalAddr
+	waitForReady(t, internalURL)
 
 	return &testEnv{
-		baseURL: baseURL,
-		oidc:    oidcServer,
+		baseURL:     baseURL,
+		internalURL: internalURL,
+		oidc:        oidcServer,
 	}
 }
 


### PR DESCRIPTION
After #701 moved probe endpoints to a dedicated internal server, `waitForReady` polled `/readiness` on the main server (always 404), and all parallel test instances raced for the hardcoded `:8081` internal port. Pass `WithInternalAddress(":0")` and direct `waitForReady` to the internal server's URL.