### PR TITLE
Fix `/me` roles when authz is unconfigured

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ pgpass.local
 
 # Kind cluster kubeconfig
 kconfig.yaml
+.worktrees/

--- a/internal/auth/authz_middleware.go
+++ b/internal/auth/authz_middleware.go
@@ -13,11 +13,23 @@ import (
 // them in the request context. This must run after the auth middleware (which
 // populates claims) and before any RequireRole or claim-checking code.
 //
-// If authzCfg is nil, a pass-through middleware is returned immediately.
+// If authzCfg is nil, authenticated users receive all roles (matching the
+// pass-through behaviour of RequireRole in the same mode). Anonymous requests
+// receive no roles.
 // If claims are nil (anonymous mode), roles are not resolved.
 func ResolveRolesMiddleware(authzCfg *config.AuthzConfig) func(http.Handler) http.Handler {
 	if authzCfg == nil {
-		return func(next http.Handler) http.Handler { return next }
+		// No authz config: any authenticated user implicitly holds all permissions
+		// (RequireRole is also a pass-through when authzCfg == nil). Store all roles
+		// in context so downstream code — including GET /v1/me — reflects reality.
+		return func(next http.Handler) http.Handler {
+			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if claims := ClaimsFromContext(r.Context()); claims != nil {
+					r = r.WithContext(ContextWithRoles(r.Context(), AllRoles()))
+				}
+				next.ServeHTTP(w, r)
+			})
+		}
 	}
 	var warnOnce sync.Once
 	return func(next http.Handler) http.Handler {

--- a/internal/auth/authz_middleware.go
+++ b/internal/auth/authz_middleware.go
@@ -13,10 +13,11 @@ import (
 // them in the request context. This must run after the auth middleware (which
 // populates claims) and before any RequireRole or claim-checking code.
 //
-// If authzCfg is nil, authenticated users receive all roles (matching the
-// pass-through behaviour of RequireRole in the same mode). Anonymous requests
-// receive no roles.
-// If claims are nil (anonymous mode), roles are not resolved.
+// If authzCfg is nil, authenticated requests receive all roles (so that
+// downstream role checks remain a no-op) and anonymous requests receive none.
+// If authzCfg is non-nil, roles are resolved from the JWT claims via ResolveRoles;
+// anonymous requests (nil claims) are passed through without roles and a
+// one-time warning is logged.
 func ResolveRolesMiddleware(authzCfg *config.AuthzConfig) func(http.Handler) http.Handler {
 	if authzCfg == nil {
 		// No authz config: any authenticated user implicitly holds all permissions

--- a/internal/auth/authz_middleware_test.go
+++ b/internal/auth/authz_middleware_test.go
@@ -13,13 +13,7 @@ import (
 )
 
 func TestResolveRolesMiddleware(t *testing.T) {
-	// NOTE: subtests run sequentially (not t.Parallel on subtests) because
-	// capturedRoles is shared and reset between runs.
-
-	var capturedRoles []Role
-	capture := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
-		capturedRoles = RolesFromContext(r.Context())
-	})
+	t.Parallel()
 
 	authzCfg := &config.AuthzConfig{
 		Roles: config.RolesConfig{
@@ -66,7 +60,12 @@ func TestResolveRolesMiddleware(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			capturedRoles = nil
+			t.Parallel()
+
+			var capturedRoles []Role
+			capture := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+				capturedRoles = RolesFromContext(r.Context())
+			})
 
 			handler := ResolveRolesMiddleware(tt.authzCfg)(capture)
 			req := httptest.NewRequest(http.MethodGet, "/test", nil)

--- a/internal/auth/authz_middleware_test.go
+++ b/internal/auth/authz_middleware_test.go
@@ -12,6 +12,81 @@ import (
 	"github.com/stacklok/toolhive-registry-server/internal/config"
 )
 
+func TestResolveRolesMiddleware(t *testing.T) {
+	// NOTE: subtests run sequentially (not t.Parallel on subtests) because
+	// capturedRoles is shared and reset between runs.
+
+	var capturedRoles []Role
+	capture := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		capturedRoles = RolesFromContext(r.Context())
+	})
+
+	authzCfg := &config.AuthzConfig{
+		Roles: config.RolesConfig{
+			ManageSources: []map[string]any{{"role": "editor"}},
+		},
+	}
+
+	tests := []struct {
+		name         string
+		authzCfg     *config.AuthzConfig
+		claims       jwt.MapClaims
+		setClaims    bool
+		wantAllRoles bool
+		wantRoles    []Role
+		wantNilRoles bool
+	}{
+		{
+			name:         "nil authz + authenticated stores all roles",
+			authzCfg:     nil,
+			claims:       jwt.MapClaims{"sub": "user-1"},
+			setClaims:    true,
+			wantAllRoles: true,
+		},
+		{
+			name:         "nil authz + anonymous stores no roles",
+			authzCfg:     nil,
+			setClaims:    false,
+			wantNilRoles: true,
+		},
+		{
+			name:      "authz configured + matching claims resolves roles",
+			authzCfg:  authzCfg,
+			claims:    jwt.MapClaims{"role": "editor"},
+			setClaims: true,
+			wantRoles: []Role{RoleManageSources},
+		},
+		{
+			name:         "authz configured + anonymous stores no roles",
+			authzCfg:     authzCfg,
+			setClaims:    false,
+			wantNilRoles: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			capturedRoles = nil
+
+			handler := ResolveRolesMiddleware(tt.authzCfg)(capture)
+			req := httptest.NewRequest(http.MethodGet, "/test", nil)
+			if tt.setClaims {
+				req = req.WithContext(ContextWithClaims(context.Background(), tt.claims))
+			}
+			handler.ServeHTTP(httptest.NewRecorder(), req)
+
+			switch {
+			case tt.wantAllRoles:
+				assert.Equal(t, AllRoles(), capturedRoles)
+			case tt.wantNilRoles:
+				assert.Nil(t, capturedRoles)
+			default:
+				assert.Equal(t, tt.wantRoles, capturedRoles)
+			}
+		})
+	}
+}
+
 func TestRequireRole(t *testing.T) {
 	t.Parallel()
 
@@ -77,6 +152,22 @@ func TestRequireRole(t *testing.T) {
 			authzCfg:       authzCfg,
 			requiredRole:   RoleManageSources,
 			claims:         jwt.MapClaims{"role": "admin"},
+			setClaims:      true,
+			expectedStatus: http.StatusOK,
+		},
+		{
+			name:           "nil authz config + authenticated user passes any role check",
+			authzCfg:       nil,
+			requiredRole:   RoleManageRegistries,
+			claims:         jwt.MapClaims{"sub": "user-1"},
+			setClaims:      true,
+			expectedStatus: http.StatusOK,
+		},
+		{
+			name:           "nil authz config + authenticated user passes superAdmin role check",
+			authzCfg:       nil,
+			requiredRole:   RoleSuperAdmin,
+			claims:         jwt.MapClaims{"sub": "user-1"},
 			setClaims:      true,
 			expectedStatus: http.StatusOK,
 		},

--- a/internal/auth/roles.go
+++ b/internal/auth/roles.go
@@ -45,6 +45,12 @@ func ResolveRoles(claims jwt.MapClaims, authzCfg *config.AuthzConfig) []Role {
 	return roles
 }
 
+// AllRoles returns every role defined in the system.
+// Used when no authz config is provided — authenticated users implicitly hold all permissions.
+func AllRoles() []Role {
+	return []Role{RoleSuperAdmin, RoleManageSources, RoleManageRegistries, RoleManageEntries}
+}
+
 // HasRole checks if the resolved roles contain the specified role.
 // superAdmin grants access to everything.
 func HasRole(roles []Role, required Role) bool {

--- a/internal/auth/roles.go
+++ b/internal/auth/roles.go
@@ -21,7 +21,8 @@ const (
 )
 
 // ResolveRoles returns all roles the user has based on JWT claims and authz config.
-// If authzCfg is nil, no roles are returned (only authenticated access is possible).
+// Returns nil when either argument is nil. The nil-authz semantic (authenticated
+// users receive all roles) is handled at the middleware layer by ResolveRolesMiddleware.
 func ResolveRoles(claims jwt.MapClaims, authzCfg *config.AuthzConfig) []Role {
 	if authzCfg == nil || claims == nil {
 		return nil

--- a/internal/auth/roles_test.go
+++ b/internal/auth/roles_test.go
@@ -243,6 +243,19 @@ func TestHasRole(t *testing.T) {
 	}
 }
 
+func TestAllRoles(t *testing.T) {
+	t.Parallel()
+
+	roles := AllRoles()
+
+	// Every named role constant must appear exactly once.
+	assert.Contains(t, roles, RoleSuperAdmin)
+	assert.Contains(t, roles, RoleManageSources)
+	assert.Contains(t, roles, RoleManageRegistries)
+	assert.Contains(t, roles, RoleManageEntries)
+	assert.Len(t, roles, 4, "AllRoles must stay in sync with the Role constants")
+}
+
 // TestMatchesClaimValue exercises the matchesClaimValue logic through
 // ResolveRoles, covering the various type combinations for JWT and required values.
 func TestMatchesClaimValue(t *testing.T) {


### PR DESCRIPTION
## Problem                                                

  When auth is configured (OAuth mode) but no authz config is provided,                                                                                                                                                                                                                                                                                                                                                                    
  `GET /v1/me` returned an empty roles list for every authenticated user.
  This was misleading: `RequireRole` is a pass-through when authz is                                                                                                                                                                                                                                                                                                                                                                       
  unconfigured, meaning authenticated users can actually call every                                                                                                                                                                                                                                                                                                                                                                        
  endpoint — but `/me` reported `"roles": []`, implying they had no                                                                                                                                                                                                                                                                                                                                                                        
  permissions at all.                                                                                                                                                                                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                                                                                                                                                           
  ## Root cause                                                                                                                                                                                                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                                                                                                                                                                           
  `ResolveRolesMiddleware` short-circuited to a pure pass-through when
  `authzCfg == nil`, so `ContextWithRoles` was never called and
  `RolesFromContext` always returned nil downstream.                                                                                                                                                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                                                                                                                                                           
  ## Fix                                                                                                                                                                                                                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                                                                                                                                                                           
  When `authzCfg == nil` and the request is authenticated (claims are                                                                                                                                                                                                                                                                                                                                                                      
  present in context), `ResolveRolesMiddleware` now stores `AllRoles()`
  in the request context. Anonymous requests (no claims) are unaffected.                                                                                                                                                                                                                                                                                                                                                                   
  This makes `/me` reflect the access level that role enforcement already                                                                                                                                                                                                                                                                                                                                                                  
  grants in practice.                                                                                                                                                                                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                                                                                                                                                           
  A new `AllRoles()` helper in the `auth` package returns the canonical                                                                                                                                                                                                                                                                                                                                                                    
  slice of all defined roles, keeping `ResolveRolesMiddleware` and any
  future callers in sync with the role constants.                                                                                                                                                                                                                                                                                                                                                                                          
                                                            
  ## Behaviour after fix                                                                                                                                                                                                                                                                                                                                                                                                                   
                                                            
  | Configuration | Authenticated? | `/me` roles |                                                                                                                                                                                                                                                                                                                                                                                         
  |---|---|---|                                             
  | Auth=OAuth, Authz=nil | yes | all roles |                                                                                                                                                                                                                                                                                                                                                                                              
  | Auth=OAuth, Authz=nil | no (anonymous) | 401 |
  | Auth=OAuth, Authz=configured | yes, matching | resolved subset |                                                                                                                                                                                                                                                                                                                                                                       
  | Auth=OAuth, Authz=configured | yes, no match | `[]` |   