### PR TITLE
Stop leaking internal error details to API clients

### DIFF
--- a/internal/api/registry/v01/routes.go
+++ b/internal/api/registry/v01/routes.go
@@ -337,9 +337,9 @@ func writeServiceError(w http.ResponseWriter, r *http.Request, err error) {
 	case errors.Is(err, service.ErrClaimsInsufficient):
 		common.WriteErrorResponse(w, "forbidden: insufficient claims for registry", http.StatusForbidden)
 	case errors.Is(err, service.ErrRegistryNotFound):
-		common.WriteErrorResponse(w, err.Error(), http.StatusNotFound)
+		common.WriteErrorResponse(w, "registry not found", http.StatusNotFound)
 	case errors.Is(err, service.ErrNotFound):
-		common.WriteErrorResponse(w, err.Error(), http.StatusNotFound)
+		common.WriteErrorResponse(w, "not found", http.StatusNotFound)
 	default:
 		slog.ErrorContext(r.Context(), "unexpected error", "error", err)
 		common.WriteErrorResponse(w, "internal server error", http.StatusInternalServerError)

--- a/internal/api/registry/v01/routes.go
+++ b/internal/api/registry/v01/routes.go
@@ -121,15 +121,7 @@ func (routes *Routes) handleListServers(w http.ResponseWriter, r *http.Request, 
 
 	listResult, err := routes.service.ListServers(r.Context(), opts...)
 	if err != nil {
-		if errors.Is(err, service.ErrClaimsInsufficient) {
-			common.WriteErrorResponse(w, "forbidden: insufficient claims for registry", http.StatusForbidden)
-			return
-		}
-		if errors.Is(err, service.ErrRegistryNotFound) {
-			common.WriteErrorResponse(w, err.Error(), http.StatusNotFound)
-			return
-		}
-		common.WriteErrorResponse(w, err.Error(), http.StatusInternalServerError)
+		writeServiceError(w, r, err)
 		return
 	}
 
@@ -212,15 +204,7 @@ func (routes *Routes) handleListVersions(w http.ResponseWriter, r *http.Request,
 
 	versions, err := routes.service.ListServerVersions(r.Context(), opts...)
 	if err != nil {
-		if errors.Is(err, service.ErrClaimsInsufficient) {
-			common.WriteErrorResponse(w, "forbidden: insufficient claims for registry", http.StatusForbidden)
-			return
-		}
-		if errors.Is(err, service.ErrRegistryNotFound) {
-			common.WriteErrorResponse(w, err.Error(), http.StatusNotFound)
-			return
-		}
-		common.WriteErrorResponse(w, err.Error(), http.StatusInternalServerError)
+		writeServiceError(w, r, err)
 		return
 	}
 
@@ -304,19 +288,12 @@ func (routes *Routes) handleGetVersion(w http.ResponseWriter, r *http.Request, r
 
 	server, err := routes.service.GetServerVersion(r.Context(), opts...)
 	if err != nil {
-		if errors.Is(err, service.ErrClaimsInsufficient) {
-			common.WriteErrorResponse(w, "forbidden: insufficient claims for registry", http.StatusForbidden)
-			return
-		}
-		if errors.Is(err, service.ErrRegistryNotFound) || errors.Is(err, service.ErrNotFound) {
-			common.WriteErrorResponse(w, err.Error(), http.StatusNotFound)
-			return
-		}
-		common.WriteErrorResponse(w, err.Error(), http.StatusInternalServerError)
+		writeServiceError(w, r, err)
 		return
 	}
 	if server == nil {
-		common.WriteErrorResponse(w, "Server not found", http.StatusNotFound)
+		slog.ErrorContext(r.Context(), "GetServerVersion returned nil without error")
+		common.WriteErrorResponse(w, "internal server error", http.StatusInternalServerError)
 		return
 	}
 
@@ -352,4 +329,19 @@ func (routes *Routes) getVersionWithRegistryName(w http.ResponseWriter, r *http.
 	}
 
 	routes.handleGetVersion(w, r, registryName)
+}
+
+// writeServiceError maps service-layer errors to HTTP responses for upstream API handlers.
+func writeServiceError(w http.ResponseWriter, r *http.Request, err error) {
+	switch {
+	case errors.Is(err, service.ErrClaimsInsufficient):
+		common.WriteErrorResponse(w, "forbidden: insufficient claims for registry", http.StatusForbidden)
+	case errors.Is(err, service.ErrRegistryNotFound):
+		common.WriteErrorResponse(w, err.Error(), http.StatusNotFound)
+	case errors.Is(err, service.ErrNotFound):
+		common.WriteErrorResponse(w, err.Error(), http.StatusNotFound)
+	default:
+		slog.ErrorContext(r.Context(), "unexpected error", "error", err)
+		common.WriteErrorResponse(w, "internal server error", http.StatusInternalServerError)
+	}
 }

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -141,10 +141,11 @@ func LoggingMiddleware(next http.Handler) http.Handler {
 func openAPIHandler(w http.ResponseWriter, _ *http.Request) {
 	doc, err := swag.ReadDoc("swagger")
 	if err != nil {
+		slog.Error("Failed to read OpenAPI specification", "error", err)
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusInternalServerError)
 		errorResp := map[string]string{
-			"error": "Failed to read OpenAPI specification: " + err.Error(),
+			"error": "failed to read OpenAPI specification",
 		}
 		if encodeErr := json.NewEncoder(w).Encode(errorResp); encodeErr != nil {
 			slog.Error("Failed to encode OpenAPI error response", "error", encodeErr)
@@ -186,13 +187,13 @@ func healthHandler(w http.ResponseWriter, _ *http.Request) {
 func readinessHandler(svc service.RegistryService) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if err := svc.CheckReadiness(r.Context()); err != nil {
-			slog.Warn("Readiness check failed",
+			slog.WarnContext(r.Context(), "Readiness check failed",
 				"error", err,
 				"remote_addr", r.RemoteAddr)
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusServiceUnavailable)
 			errorResp := map[string]string{
-				"error": "RegistryService not ready: " + err.Error(),
+				"error": "service not ready",
 			}
 			if encodeErr := json.NewEncoder(w).Encode(errorResp); encodeErr != nil {
 				slog.Error("Failed to encode readiness error response", "error", encodeErr)

--- a/internal/api/x/skills/routes.go
+++ b/internal/api/x/skills/routes.go
@@ -302,12 +302,12 @@ func writeServiceError(w http.ResponseWriter, r *http.Request, err error) {
 	case errors.Is(err, service.ErrClaimsInsufficient):
 		common.WriteErrorResponse(w, "forbidden: insufficient claims for registry", http.StatusForbidden)
 	case errors.Is(err, service.ErrNotFound):
-		common.WriteErrorResponse(w, err.Error(), http.StatusNotFound)
+		common.WriteErrorResponse(w, "not found", http.StatusNotFound)
 	case errors.Is(err, service.ErrRegistryNotFound):
-		common.WriteErrorResponse(w, err.Error(), http.StatusNotFound)
+		common.WriteErrorResponse(w, "registry not found", http.StatusNotFound)
 	default:
 		slog.ErrorContext(r.Context(), "unexpected error", "error", err)
-		common.WriteErrorResponse(w, "Internal server error", http.StatusInternalServerError)
+		common.WriteErrorResponse(w, "internal server error", http.StatusInternalServerError)
 	}
 }
 

--- a/internal/api/x/skills/routes.go
+++ b/internal/api/x/skills/routes.go
@@ -5,6 +5,7 @@ package skills
 import (
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"strconv"
 	"strings"
@@ -87,7 +88,7 @@ func (routes *Routes) listSkills(w http.ResponseWriter, r *http.Request) {
 
 	result, err := routes.service.ListSkills(r.Context(), opts...)
 	if err != nil {
-		writeServiceError(w, err)
+		writeServiceError(w, r, err)
 		return
 	}
 
@@ -147,7 +148,7 @@ func (routes *Routes) getLatestVersion(w http.ResponseWriter, r *http.Request) {
 
 	skill, err := routes.service.GetSkillVersion(r.Context(), skillOpts...)
 	if err != nil {
-		writeServiceError(w, err)
+		writeServiceError(w, r, err)
 		return
 	}
 
@@ -198,7 +199,7 @@ func (routes *Routes) listVersions(w http.ResponseWriter, r *http.Request) {
 
 	result, err := routes.service.ListSkills(r.Context(), listOpts...)
 	if err != nil {
-		writeServiceError(w, err)
+		writeServiceError(w, r, err)
 		return
 	}
 
@@ -264,7 +265,7 @@ func (routes *Routes) getVersion(w http.ResponseWriter, r *http.Request) {
 
 	skill, err := routes.service.GetSkillVersion(r.Context(), versionOpts...)
 	if err != nil {
-		writeServiceError(w, err)
+		writeServiceError(w, r, err)
 		return
 	}
 
@@ -296,7 +297,7 @@ func parseListSkillsQuery(r *http.Request) (*ListSkillsQuery, error) {
 }
 
 // writeServiceError maps service-layer errors to HTTP responses.
-func writeServiceError(w http.ResponseWriter, err error) {
+func writeServiceError(w http.ResponseWriter, r *http.Request, err error) {
 	switch {
 	case errors.Is(err, service.ErrClaimsInsufficient):
 		common.WriteErrorResponse(w, "forbidden: insufficient claims for registry", http.StatusForbidden)
@@ -305,6 +306,7 @@ func writeServiceError(w http.ResponseWriter, err error) {
 	case errors.Is(err, service.ErrRegistryNotFound):
 		common.WriteErrorResponse(w, err.Error(), http.StatusNotFound)
 	default:
+		slog.ErrorContext(r.Context(), "unexpected error", "error", err)
 		common.WriteErrorResponse(w, "Internal server error", http.StatusInternalServerError)
 	}
 }


### PR DESCRIPTION
## Summary

- Add centralized `writeServiceError` mapper to upstream v01 routes, replacing inline error handling that leaked raw `err.Error()` in 500 responses without server-side logging
- Fix `openAPIHandler` and `readinessHandler` in `server.go` to return generic error messages instead of exposing internal details
- Add missing error logging and request context propagation to skills `writeServiceError`

Fixes #181

## Test plan

- [x] `task lint-fix` passes with 0 issues
- [x] `task test` passes — all existing tests cover the refactored error paths
- [ ] Verify 500 responses no longer contain raw error strings (e.g., trigger an internal error via a misconfigured service and inspect the response body)

🤖 Generated with [Claude Code](https://claude.com/claude-code)