### PR TITLE
Implement PUT `/v1/entries/{type}/{name}/claims` endpoint

### DIFF
--- a/database/queries/registry_entries.sql
+++ b/database/queries/registry_entries.sql
@@ -107,3 +107,11 @@ SELECT e.entry_type,
   JOIN entry_version v ON v.entry_id = e.id
  WHERE rs.registry_id = sqlc.arg(registry_id)
  ORDER BY v.name ASC, v.version ASC, rs.position ASC;
+
+-- name: UpdateRegistryEntryClaims :execrows
+UPDATE registry_entry
+   SET claims = sqlc.narg(claims),
+       updated_at = NOW()
+ WHERE source_id = sqlc.arg(source_id)
+   AND entry_type = sqlc.arg(entry_type)
+   AND name = sqlc.arg(name);

--- a/docs/thv-registry-api/docs.go
+++ b/docs/thv-registry-api/docs.go
@@ -2002,6 +2002,19 @@ const docTemplate = `{
                             }
                         },
                         "description": "Internal server error"
+                    },
+                    "503": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "additionalProperties": {
+                                        "type": "string"
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "description": "No managed source available"
                     }
                 },
                 "summary": "Update entry claims",

--- a/docs/thv-registry-api/docs.go
+++ b/docs/thv-registry-api/docs.go
@@ -458,6 +458,15 @@ const docTemplate = `{
                 },
                 "type": "object"
             },
+            "internal_api_v1.updateEntryClaimsRequest": {
+                "properties": {
+                    "claims": {
+                        "additionalProperties": {},
+                        "type": "object"
+                    }
+                },
+                "type": "object"
+            },
             "internal_api_x_skills.SkillListMetadata": {
                 "properties": {
                     "count": {
@@ -1922,12 +1931,26 @@ const docTemplate = `{
                     "content": {
                         "application/json": {
                             "schema": {
-                                "type": "object"
+                                "oneOf": [
+                                    {
+                                        "type": "object"
+                                    },
+                                    {
+                                        "$ref": "#/components/schemas/internal_api_v1.updateEntryClaimsRequest",
+                                        "summary": "request",
+                                        "description": "Claims to set"
+                                    }
+                                ]
                             }
                         }
-                    }
+                    },
+                    "description": "Claims to set",
+                    "required": true
                 },
                 "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
                     "400": {
                         "content": {
                             "application/json": {
@@ -1941,7 +1964,7 @@ const docTemplate = `{
                         },
                         "description": "Bad request"
                     },
-                    "501": {
+                    "403": {
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -1952,7 +1975,33 @@ const docTemplate = `{
                                 }
                             }
                         },
-                        "description": "Not implemented"
+                        "description": "Forbidden"
+                    },
+                    "404": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "additionalProperties": {
+                                        "type": "string"
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "description": "Not found"
+                    },
+                    "500": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "additionalProperties": {
+                                        "type": "string"
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "description": "Internal server error"
                     }
                 },
                 "summary": "Update entry claims",

--- a/docs/thv-registry-api/swagger.json
+++ b/docs/thv-registry-api/swagger.json
@@ -1995,6 +1995,19 @@
                             }
                         },
                         "description": "Internal server error"
+                    },
+                    "503": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "additionalProperties": {
+                                        "type": "string"
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "description": "No managed source available"
                     }
                 },
                 "summary": "Update entry claims",

--- a/docs/thv-registry-api/swagger.json
+++ b/docs/thv-registry-api/swagger.json
@@ -451,6 +451,15 @@
                 },
                 "type": "object"
             },
+            "internal_api_v1.updateEntryClaimsRequest": {
+                "properties": {
+                    "claims": {
+                        "additionalProperties": {},
+                        "type": "object"
+                    }
+                },
+                "type": "object"
+            },
             "internal_api_x_skills.SkillListMetadata": {
                 "properties": {
                     "count": {
@@ -1915,12 +1924,26 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "type": "object"
+                                "oneOf": [
+                                    {
+                                        "type": "object"
+                                    },
+                                    {
+                                        "$ref": "#/components/schemas/internal_api_v1.updateEntryClaimsRequest",
+                                        "summary": "request",
+                                        "description": "Claims to set"
+                                    }
+                                ]
                             }
                         }
-                    }
+                    },
+                    "description": "Claims to set",
+                    "required": true
                 },
                 "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
                     "400": {
                         "content": {
                             "application/json": {
@@ -1934,7 +1957,7 @@
                         },
                         "description": "Bad request"
                     },
-                    "501": {
+                    "403": {
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -1945,7 +1968,33 @@
                                 }
                             }
                         },
-                        "description": "Not implemented"
+                        "description": "Forbidden"
+                    },
+                    "404": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "additionalProperties": {
+                                        "type": "string"
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "description": "Not found"
+                    },
+                    "500": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "additionalProperties": {
+                                        "type": "string"
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "description": "Internal server error"
                     }
                 },
                 "summary": "Update entry claims",

--- a/docs/thv-registry-api/swagger.yaml
+++ b/docs/thv-registry-api/swagger.yaml
@@ -1358,6 +1358,14 @@ paths:
                   type: string
                 type: object
           description: Internal server error
+        "503":
+          content:
+            application/json:
+              schema:
+                additionalProperties:
+                  type: string
+                type: object
+          description: No managed source available
       summary: Update entry claims
       tags:
       - v1

--- a/docs/thv-registry-api/swagger.yaml
+++ b/docs/thv-registry-api/swagger.yaml
@@ -308,6 +308,12 @@ components:
           type: array
           uniqueItems: false
       type: object
+    internal_api_v1.updateEntryClaimsRequest:
+      properties:
+        claims:
+          additionalProperties: {}
+          type: object
+      type: object
     internal_api_x_skills.SkillListMetadata:
       properties:
         count:
@@ -1310,8 +1316,16 @@ paths:
         content:
           application/json:
             schema:
-              type: object
+              oneOf:
+              - type: object
+              - $ref: '#/components/schemas/internal_api_v1.updateEntryClaimsRequest'
+                description: Claims to set
+                summary: request
+        description: Claims to set
+        required: true
       responses:
+        "204":
+          description: No Content
         "400":
           content:
             application/json:
@@ -1320,14 +1334,30 @@ paths:
                   type: string
                 type: object
           description: Bad request
-        "501":
+        "403":
           content:
             application/json:
               schema:
                 additionalProperties:
                   type: string
                 type: object
-          description: Not implemented
+          description: Forbidden
+        "404":
+          content:
+            application/json:
+              schema:
+                additionalProperties:
+                  type: string
+                type: object
+          description: Not found
+        "500":
+          content:
+            application/json:
+              schema:
+                additionalProperties:
+                  type: string
+                type: object
+          description: Internal server error
       summary: Update entry claims
       tags:
       - v1

--- a/internal/api/v1/entries.go
+++ b/internal/api/v1/entries.go
@@ -196,6 +196,7 @@ type updateEntryClaimsRequest struct {
 // @Failure		403	{object}	map[string]string	"Forbidden"
 // @Failure		404	{object}	map[string]string	"Not found"
 // @Failure		500	{object}	map[string]string	"Internal server error"
+// @Failure		503	{object}	map[string]string	"No managed source available"
 // @Router		/v1/entries/{type}/{name}/claims [put]
 func (routes *Routes) updateEntryClaims(w http.ResponseWriter, r *http.Request) {
 	entryType, err := common.GetAndValidateURLParam(r, "type")
@@ -210,11 +211,8 @@ func (routes *Routes) updateEntryClaims(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	switch entryType {
-	case "server", "skill":
-		// valid
-	default:
-		common.WriteErrorResponse(w, "unsupported entry type: must be 'server' or 'skill'", http.StatusBadRequest)
+	if err := service.ValidateEntryType(entryType); err != nil {
+		common.WriteErrorResponse(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 
@@ -245,7 +243,7 @@ func (routes *Routes) updateEntryClaims(w http.ResponseWriter, r *http.Request) 
 			return
 		}
 		if errors.Is(err, service.ErrNoManagedSource) {
-			common.WriteErrorResponse(w, "no managed source available", http.StatusInternalServerError)
+			common.WriteErrorResponse(w, "no managed source available for updating claims", http.StatusServiceUnavailable)
 			return
 		}
 		slog.ErrorContext(r.Context(), "failed to update entry claims", "error", err, "type", entryType)

--- a/internal/api/v1/entries.go
+++ b/internal/api/v1/entries.go
@@ -176,6 +176,11 @@ func (routes *Routes) deletePublishedEntry(w http.ResponseWriter, r *http.Reques
 	w.WriteHeader(http.StatusNoContent)
 }
 
+// updateEntryClaimsRequest is the request body for updating entry claims.
+type updateEntryClaimsRequest struct {
+	Claims map[string]any `json:"claims"`
+}
+
 // updateEntryClaims handles PUT /v1/entries/{type}/{name}/claims
 //
 // @Summary		Update entry claims
@@ -185,19 +190,68 @@ func (routes *Routes) deletePublishedEntry(w http.ResponseWriter, r *http.Reques
 // @Produce		json
 // @Param		type	path	string	true	"Entry Type (server or skill)"
 // @Param		name	path	string	true	"Entry Name"
+// @Param		request	body	updateEntryClaimsRequest	true	"Claims to set"
+// @Success		204	"No Content"
 // @Failure		400	{object}	map[string]string	"Bad request"
-// @Failure		501	{object}	map[string]string	"Not implemented"
+// @Failure		403	{object}	map[string]string	"Forbidden"
+// @Failure		404	{object}	map[string]string	"Not found"
+// @Failure		500	{object}	map[string]string	"Internal server error"
 // @Router		/v1/entries/{type}/{name}/claims [put]
-func (*Routes) updateEntryClaims(w http.ResponseWriter, r *http.Request) {
-	if _, err := common.GetAndValidateURLParam(r, "type"); err != nil {
+func (routes *Routes) updateEntryClaims(w http.ResponseWriter, r *http.Request) {
+	entryType, err := common.GetAndValidateURLParam(r, "type")
+	if err != nil {
 		common.WriteErrorResponse(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 
-	if _, err := common.GetAndValidateURLParam(r, "name"); err != nil {
+	name, err := common.GetAndValidateURLParam(r, "name")
+	if err != nil {
 		common.WriteErrorResponse(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 
-	common.WriteErrorResponse(w, "Updating entry claims is not yet implemented", http.StatusNotImplemented)
+	switch entryType {
+	case "server", "skill":
+		// valid
+	default:
+		common.WriteErrorResponse(w, "unsupported entry type: must be 'server' or 'skill'", http.StatusBadRequest)
+		return
+	}
+
+	var req updateEntryClaimsRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		common.WriteErrorResponse(w, "invalid request body: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	opts := []service.Option{
+		service.WithEntryType(entryType),
+		service.WithName(name),
+	}
+	if req.Claims != nil {
+		opts = append(opts, service.WithClaims(req.Claims))
+	}
+	if jwtClaims := auth.ClaimsFromContext(r.Context()); jwtClaims != nil {
+		opts = append(opts, service.WithJWTClaims(map[string]any(jwtClaims)))
+	}
+
+	if err := routes.service.UpdateEntryClaims(r.Context(), opts...); err != nil {
+		if errors.Is(err, service.ErrClaimsInsufficient) {
+			common.WriteErrorResponse(w, err.Error(), http.StatusForbidden)
+			return
+		}
+		if errors.Is(err, service.ErrNotFound) {
+			common.WriteErrorResponse(w, err.Error(), http.StatusNotFound)
+			return
+		}
+		if errors.Is(err, service.ErrNoManagedSource) {
+			common.WriteErrorResponse(w, "no managed source available", http.StatusInternalServerError)
+			return
+		}
+		slog.ErrorContext(r.Context(), "failed to update entry claims", "error", err, "type", entryType)
+		common.WriteErrorResponse(w, "failed to update entry claims", http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
 }

--- a/internal/api/v1/entries_test.go
+++ b/internal/api/v1/entries_test.go
@@ -306,8 +306,8 @@ func TestUpdateEntryClaims(t *testing.T) {
 				m.EXPECT().UpdateEntryClaims(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(service.ErrNoManagedSource)
 			},
-			wantStatus: http.StatusInternalServerError,
-			wantError:  "no managed source available",
+			wantStatus: http.StatusServiceUnavailable,
+			wantError:  "no managed source available for updating claims",
 		},
 		{
 			name: "generic service error",

--- a/internal/api/v1/entries_test.go
+++ b/internal/api/v1/entries_test.go
@@ -224,6 +224,136 @@ func TestDeletePublishedEntry(t *testing.T) {
 	}
 }
 
+func TestUpdateEntryClaims(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		path       string
+		body       []byte
+		setupMock  func(*mocks.MockRegistryService)
+		wantStatus int
+		wantError  string
+	}{
+		{
+			name: "success - server type",
+			path: "/entries/server/test%2Fserver/claims",
+			body: mustMarshal(map[string]any{"claims": map[string]any{"org": "acme"}}),
+			setupMock: func(m *mocks.MockRegistryService) {
+				m.EXPECT().UpdateEntryClaims(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+			},
+			wantStatus: http.StatusNoContent,
+		},
+		{
+			name: "success - skill type",
+			path: "/entries/skill/test%2Fskill/claims",
+			body: mustMarshal(map[string]any{"claims": map[string]any{"org": "acme"}}),
+			setupMock: func(m *mocks.MockRegistryService) {
+				m.EXPECT().UpdateEntryClaims(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+			},
+			wantStatus: http.StatusNoContent,
+		},
+		{
+			name: "success - clear claims",
+			path: "/entries/server/test%2Fserver/claims",
+			body: mustMarshal(map[string]any{"claims": map[string]any{}}),
+			setupMock: func(m *mocks.MockRegistryService) {
+				m.EXPECT().UpdateEntryClaims(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+			},
+			wantStatus: http.StatusNoContent,
+		},
+		{
+			name:       "unsupported entry type",
+			path:       "/entries/unknown/test%2Fentry/claims",
+			body:       mustMarshal(map[string]any{"claims": map[string]any{}}),
+			setupMock:  func(_ *mocks.MockRegistryService) {},
+			wantStatus: http.StatusBadRequest,
+			wantError:  "unsupported entry type",
+		},
+		{
+			name:       "invalid JSON body",
+			path:       "/entries/server/test%2Fserver/claims",
+			body:       []byte("not-json"),
+			setupMock:  func(_ *mocks.MockRegistryService) {},
+			wantStatus: http.StatusBadRequest,
+			wantError:  "invalid request body",
+		},
+		{
+			name: "entry not found",
+			path: "/entries/server/test%2Fserver/claims",
+			body: mustMarshal(map[string]any{"claims": map[string]any{"org": "acme"}}),
+			setupMock: func(m *mocks.MockRegistryService) {
+				m.EXPECT().UpdateEntryClaims(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(service.ErrNotFound)
+			},
+			wantStatus: http.StatusNotFound,
+		},
+		{
+			name: "claims insufficient",
+			path: "/entries/server/test%2Fserver/claims",
+			body: mustMarshal(map[string]any{"claims": map[string]any{"org": "acme"}}),
+			setupMock: func(m *mocks.MockRegistryService) {
+				m.EXPECT().UpdateEntryClaims(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(service.ErrClaimsInsufficient)
+			},
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			name: "no managed source",
+			path: "/entries/server/test%2Fserver/claims",
+			body: mustMarshal(map[string]any{"claims": map[string]any{"org": "acme"}}),
+			setupMock: func(m *mocks.MockRegistryService) {
+				m.EXPECT().UpdateEntryClaims(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(service.ErrNoManagedSource)
+			},
+			wantStatus: http.StatusInternalServerError,
+			wantError:  "no managed source available",
+		},
+		{
+			name: "generic service error",
+			path: "/entries/server/test%2Fserver/claims",
+			body: mustMarshal(map[string]any{"claims": map[string]any{"org": "acme"}}),
+			setupMock: func(m *mocks.MockRegistryService) {
+				m.EXPECT().UpdateEntryClaims(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(fmt.Errorf("unexpected error"))
+			},
+			wantStatus: http.StatusInternalServerError,
+			wantError:  "failed to update entry claims",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctrl := gomock.NewController(t)
+			t.Cleanup(ctrl.Finish)
+
+			mockSvc := mocks.NewMockRegistryService(ctrl)
+			tt.setupMock(mockSvc)
+
+			router := Router(mockSvc, nil)
+			req, err := http.NewRequest(http.MethodPut, tt.path, bytes.NewReader(tt.body))
+			require.NoError(t, err)
+
+			rr := httptest.NewRecorder()
+			router.ServeHTTP(rr, req)
+
+			assert.Equal(t, tt.wantStatus, rr.Code)
+
+			if tt.wantError != "" {
+				var response map[string]string
+				err = json.Unmarshal(rr.Body.Bytes(), &response)
+				require.NoError(t, err)
+				assert.Contains(t, response["error"], tt.wantError)
+			}
+
+			if tt.wantStatus == http.StatusNoContent {
+				assert.Empty(t, rr.Body.Bytes())
+			}
+		})
+	}
+}
+
 // mustMarshal is a test helper that marshals v to JSON or panics.
 func mustMarshal(v any) []byte {
 	b, err := json.Marshal(v)

--- a/internal/api/v1/routes_test.go
+++ b/internal/api/v1/routes_test.go
@@ -17,48 +17,6 @@ import (
 	"github.com/stacklok/toolhive-registry-server/internal/service/mocks"
 )
 
-func TestV1StubEndpoints(t *testing.T) {
-	t.Parallel()
-	ctrl := gomock.NewController(t)
-	t.Cleanup(ctrl.Finish)
-
-	mockSvc := mocks.NewMockRegistryService(ctrl)
-	router := Router(mockSvc, nil)
-
-	tests := []struct {
-		name      string
-		method    string
-		path      string
-		wantError string
-	}{
-		// Endpoints still returning 501
-		{
-			name:      "update entry claims",
-			method:    "PUT",
-			path:      "/entries/server/my-entry/claims",
-			wantError: "Updating entry claims is not yet implemented",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			req, err := http.NewRequest(tt.method, tt.path, nil)
-			require.NoError(t, err)
-
-			rr := httptest.NewRecorder()
-			router.ServeHTTP(rr, req)
-
-			assert.Equal(t, http.StatusNotImplemented, rr.Code)
-
-			var response map[string]string
-			err = json.Unmarshal(rr.Body.Bytes(), &response)
-			require.NoError(t, err)
-			assert.Equal(t, tt.wantError, response["error"])
-		})
-	}
-}
-
 func TestListSources(t *testing.T) {
 	t.Parallel()
 	ctrl := gomock.NewController(t)

--- a/internal/authz/authz_sources_test.go
+++ b/internal/authz/authz_sources_test.go
@@ -37,7 +37,7 @@ func TestAuthzIntegration_SourceCRUD(t *testing.T) {
 	// Use file-data sources (not managed) since the base config already has a
 	// managed source and at most one is allowed globally.
 	fileDataSource := map[string]any{
-		"file":   map[string]any{"data": `{"version":"1.0.0","last_updated":"2025-01-15T10:30:00Z","servers":{}}`},
+		"file":   map[string]any{"data": `{"version":"1.0.0","meta":{"last_updated":"2025-01-15T10:30:00Z"},"data":{"servers":[{"name":"io.test/placeholder","version":"1.0.0","description":"placeholder","packages":[{"registryType":"oci","identifier":"ghcr.io/test/placeholder:latest","transport":{"type":"stdio"}}]}]}}`},
 		"claims": map[string]any{"org": "acme", "team": "platform"},
 	}
 
@@ -48,7 +48,7 @@ func TestAuthzIntegration_SourceCRUD(t *testing.T) {
 
 	t.Run("create source with non-subset claims", func(t *testing.T) {
 		resp := doRequest(t, "PUT", env.baseURL+"/v1/sources/bad-src", platformAdmin, map[string]any{
-			"file":   map[string]any{"data": `{"version":"1.0.0","last_updated":"2025-01-15T10:30:00Z","servers":{}}`},
+			"file":   map[string]any{"data": `{"version":"1.0.0","meta":{"last_updated":"2025-01-15T10:30:00Z"},"data":{"servers":[{"name":"io.test/placeholder","version":"1.0.0","description":"placeholder","packages":[{"registryType":"oci","identifier":"ghcr.io/test/placeholder:latest","transport":{"type":"stdio"}}]}]}}`},
 			"claims": map[string]any{"org": "acme", "team": "finance"},
 		})
 		assertStatus(t, resp, 403)

--- a/internal/db/sqlc/querier.go
+++ b/internal/db/sqlc/querier.go
@@ -135,6 +135,7 @@ type Querier interface {
 	PropagateSourceClaimsToEntries(ctx context.Context, arg PropagateSourceClaimsToEntriesParams) error
 	UnlinkAllRegistrySources(ctx context.Context, registryID uuid.UUID) error
 	UnlinkRegistrySource(ctx context.Context, arg UnlinkRegistrySourceParams) error
+	UpdateRegistryEntryClaims(ctx context.Context, arg UpdateRegistryEntryClaimsParams) (int64, error)
 	// Update an existing source. Go callers guard against modifying wrong creation_type.
 	UpdateSource(ctx context.Context, arg UpdateSourceParams) (Source, error)
 	UpdateSourceSync(ctx context.Context, arg UpdateSourceSyncParams) error

--- a/internal/db/sqlc/registry_entries.sql.go
+++ b/internal/db/sqlc/registry_entries.sql.go
@@ -362,3 +362,32 @@ func (q *Queries) PropagateSourceClaimsToEntries(ctx context.Context, arg Propag
 	_, err := q.db.Exec(ctx, propagateSourceClaimsToEntries, arg.Claims, arg.SourceID)
 	return err
 }
+
+const updateRegistryEntryClaims = `-- name: UpdateRegistryEntryClaims :execrows
+UPDATE registry_entry
+   SET claims = $1,
+       updated_at = NOW()
+ WHERE source_id = $2
+   AND entry_type = $3
+   AND name = $4
+`
+
+type UpdateRegistryEntryClaimsParams struct {
+	Claims    []byte    `json:"claims"`
+	SourceID  uuid.UUID `json:"source_id"`
+	EntryType EntryType `json:"entry_type"`
+	Name      string    `json:"name"`
+}
+
+func (q *Queries) UpdateRegistryEntryClaims(ctx context.Context, arg UpdateRegistryEntryClaimsParams) (int64, error) {
+	result, err := q.db.Exec(ctx, updateRegistryEntryClaims,
+		arg.Claims,
+		arg.SourceID,
+		arg.EntryType,
+		arg.Name,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}

--- a/internal/service/db/admin_claims_test.go
+++ b/internal/service/db/admin_claims_test.go
@@ -88,7 +88,7 @@ func managedSourceReq(claims map[string]any) *service.SourceCreateRequest {
 func fileDataSourceReq(claims map[string]any) *service.SourceCreateRequest {
 	return &service.SourceCreateRequest{
 		File: &config.FileConfig{
-			Data: `{"version":"1.0.0","last_updated":"2025-01-15T10:30:00Z","servers":{}}`,
+			Data: `{"version":"1.0.0","meta":{"last_updated":"2025-01-15T10:30:00Z"},"data":{"servers":[{"name":"io.test/placeholder","version":"1.0.0","description":"placeholder","packages":[{"registryType":"oci","identifier":"ghcr.io/test/placeholder:latest","transport":{"type":"stdio"}}]}]}}`,
 		},
 		Claims: claims,
 	}

--- a/internal/service/db/impl_entries.go
+++ b/internal/service/db/impl_entries.go
@@ -1,0 +1,146 @@
+package database
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/go-chi/chi/v5/middleware"
+	"github.com/jackc/pgx/v5"
+	"go.opentelemetry.io/otel/attribute"
+
+	"github.com/stacklok/toolhive-registry-server/internal/db"
+	"github.com/stacklok/toolhive-registry-server/internal/db/sqlc"
+	"github.com/stacklok/toolhive-registry-server/internal/otel"
+	"github.com/stacklok/toolhive-registry-server/internal/service"
+)
+
+// UpdateEntryClaims updates the claims on a published registry entry within the managed source.
+func (s *dbService) UpdateEntryClaims(ctx context.Context, opts ...service.Option) error {
+	ctx, span := s.startSpan(ctx, "dbService.UpdateEntryClaims")
+	defer span.End()
+	start := time.Now()
+
+	options := &service.UpdateEntryClaimsOptions{}
+	for _, opt := range opts {
+		if err := opt(options); err != nil {
+			otel.RecordError(span, err)
+			return fmt.Errorf("invalid option: %w", err)
+		}
+	}
+
+	span.SetAttributes(
+		attribute.String("entry.type", options.EntryType),
+		attribute.String("entry.name", options.Name),
+	)
+
+	entryType, err := mapEntryType(options.EntryType)
+	if err != nil {
+		otel.RecordError(span, err)
+		return err
+	}
+
+	if options.Claims != nil {
+		if err := db.ValidateClaimValues(options.Claims); err != nil {
+			otel.RecordError(span, err)
+			return fmt.Errorf("invalid claim values: %w", err)
+		}
+	}
+
+	if err := validateClaimsSubset(ctx, options.JWTClaims, options.Claims); err != nil {
+		otel.RecordError(span, err)
+		return err
+	}
+
+	if err := s.executeUpdateClaimsTransaction(ctx, options, entryType); err != nil {
+		otel.RecordError(span, err)
+		return err
+	}
+
+	slog.InfoContext(ctx, "Entry claims updated",
+		"duration_ms", time.Since(start).Milliseconds(),
+		"entry_type", options.EntryType,
+		"name", options.Name,
+		"request_id", middleware.GetReqID(ctx))
+
+	return nil
+}
+
+// executeUpdateClaimsTransaction runs the claims update within a serializable transaction.
+func (s *dbService) executeUpdateClaimsTransaction(
+	ctx context.Context,
+	options *service.UpdateEntryClaimsOptions,
+	entryType sqlc.EntryType,
+) error {
+	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{
+		IsoLevel:   pgx.Serializable,
+		AccessMode: pgx.ReadWrite,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer func() {
+		err := tx.Rollback(ctx)
+		if err != nil && !errors.Is(err, pgx.ErrTxClosed) {
+			slog.WarnContext(ctx, "Failed to rollback transaction", "error", err)
+		}
+	}()
+
+	querier := sqlc.New(tx)
+
+	source, err := getManagedSource(ctx, querier)
+	if err != nil {
+		return err
+	}
+
+	existing, err := querier.GetRegistryEntryByName(ctx, sqlc.GetRegistryEntryByNameParams{
+		SourceID:  source.ID,
+		EntryType: entryType,
+		Name:      options.Name,
+	})
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return fmt.Errorf("%w: %s", service.ErrNotFound, options.Name)
+		}
+		return fmt.Errorf("failed to look up registry entry: %w", err)
+	}
+
+	if err := validateClaimsSubsetBytes(ctx, options.JWTClaims, existing.Claims); err != nil {
+		return err
+	}
+
+	claimsJSON := db.SerializeClaims(options.Claims)
+
+	rowsAffected, err := querier.UpdateRegistryEntryClaims(ctx, sqlc.UpdateRegistryEntryClaimsParams{
+		Claims:    claimsJSON,
+		SourceID:  source.ID,
+		EntryType: entryType,
+		Name:      options.Name,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to update entry claims: %w", err)
+	}
+	if rowsAffected == 0 {
+		return fmt.Errorf("%w: %s", service.ErrNotFound, options.Name)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("failed to commit transaction: %w", err)
+	}
+
+	return nil
+}
+
+// mapEntryType converts a raw entry type string to the corresponding sqlc.EntryType.
+func mapEntryType(entryType string) (sqlc.EntryType, error) {
+	switch entryType {
+	case "server":
+		return sqlc.EntryTypeMCP, nil
+	case "skill":
+		return sqlc.EntryTypeSKILL, nil
+	default:
+		return "", fmt.Errorf("unsupported entry type: %s", entryType)
+	}
+}

--- a/internal/service/db/impl_entries.go
+++ b/internal/service/db/impl_entries.go
@@ -133,14 +133,19 @@ func (s *dbService) executeUpdateClaimsTransaction(
 	return nil
 }
 
-// mapEntryType converts a raw entry type string to the corresponding sqlc.EntryType.
+// mapEntryType converts a validated entry type string to the corresponding sqlc.EntryType.
+// Relies on service.ValidateEntryType as the single source of truth for valid inputs.
 func mapEntryType(entryType string) (sqlc.EntryType, error) {
+	if err := service.ValidateEntryType(entryType); err != nil {
+		return "", err
+	}
 	switch entryType {
-	case "server":
+	case service.EntryTypeServer:
 		return sqlc.EntryTypeMCP, nil
-	case "skill":
+	case service.EntryTypeSkill:
 		return sqlc.EntryTypeSKILL, nil
 	default:
+		// Unreachable: ValidateEntryType guards the set of accepted values.
 		return "", fmt.Errorf("unsupported entry type: %s", entryType)
 	}
 }

--- a/internal/service/db/update_entry_claims_test.go
+++ b/internal/service/db/update_entry_claims_test.go
@@ -1,0 +1,273 @@
+package database
+
+import (
+	"context"
+	"testing"
+
+	upstreamv0 "github.com/modelcontextprotocol/registry/pkg/api/v0"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stacklok/toolhive-registry-server/internal/auth"
+	"github.com/stacklok/toolhive-registry-server/internal/service"
+)
+
+func TestUpdateEntryClaims_Success(t *testing.T) {
+	t.Parallel()
+
+	svc, cleanup := setupTestService(t)
+	defer cleanup()
+
+	sourceName := "uec-success"
+	createManagedSource(t, svc, sourceName)
+
+	ctx := context.Background()
+
+	// Publish a server with claims {"org": "acme"}
+	_, err := svc.PublishServerVersion(ctx,
+		service.WithServerData(&upstreamv0.ServerJSON{
+			Name:    "com.test/uec-success",
+			Version: "1.0.0",
+		}),
+		service.WithClaims(map[string]any{"org": "acme"}),
+		service.WithJWTClaims(map[string]any{"org": "acme", "team": []string{"eng", "ops"}}),
+	)
+	require.NoError(t, err)
+
+	// Update claims to {"org": "acme", "team": "eng"} with a JWT that covers both
+	err = svc.UpdateEntryClaims(ctx,
+		service.WithEntryType("server"),
+		service.WithName("com.test/uec-success"),
+		service.WithClaims(map[string]any{"org": "acme", "team": "eng"}),
+		service.WithJWTClaims(map[string]any{"org": "acme", "team": []string{"eng", "ops"}}),
+	)
+	require.NoError(t, err)
+}
+
+func TestUpdateEntryClaims_CallerMustCoverExistingClaims(t *testing.T) {
+	t.Parallel()
+
+	svc, cleanup := setupTestService(t)
+	defer cleanup()
+
+	sourceName := "uec-cover-existing"
+	createManagedSource(t, svc, sourceName)
+
+	ctx := context.Background()
+
+	// Publish a server with claims {"org": "acme"}
+	_, err := svc.PublishServerVersion(ctx,
+		service.WithServerData(&upstreamv0.ServerJSON{
+			Name:    "com.test/uec-cover-existing",
+			Version: "1.0.0",
+		}),
+		service.WithClaims(map[string]any{"org": "acme"}),
+		service.WithJWTClaims(map[string]any{"org": "acme"}),
+	)
+	require.NoError(t, err)
+
+	// Attempt to update with a JWT that does NOT cover existing claims
+	err = svc.UpdateEntryClaims(ctx,
+		service.WithEntryType("server"),
+		service.WithName("com.test/uec-cover-existing"),
+		service.WithClaims(map[string]any{"org": "contoso"}),
+		service.WithJWTClaims(map[string]any{"org": "contoso"}),
+	)
+	assert.ErrorIs(t, err, service.ErrClaimsInsufficient)
+}
+
+func TestUpdateEntryClaims_CallerMustCoverNewClaims(t *testing.T) {
+	t.Parallel()
+
+	svc, cleanup := setupTestService(t)
+	defer cleanup()
+
+	sourceName := "uec-cover-new"
+	createManagedSource(t, svc, sourceName)
+
+	ctx := context.Background()
+
+	// Publish a server with claims {"org": "acme"}
+	_, err := svc.PublishServerVersion(ctx,
+		service.WithServerData(&upstreamv0.ServerJSON{
+			Name:    "com.test/uec-cover-new",
+			Version: "1.0.0",
+		}),
+		service.WithClaims(map[string]any{"org": "acme"}),
+		service.WithJWTClaims(map[string]any{"org": "acme"}),
+	)
+	require.NoError(t, err)
+
+	// Attempt to update with new claims that the JWT doesn't cover
+	err = svc.UpdateEntryClaims(ctx,
+		service.WithEntryType("server"),
+		service.WithName("com.test/uec-cover-new"),
+		service.WithClaims(map[string]any{"org": "acme", "team": "eng"}),
+		service.WithJWTClaims(map[string]any{"org": "acme"}),
+	)
+	assert.ErrorIs(t, err, service.ErrClaimsInsufficient)
+}
+
+func TestUpdateEntryClaims_NilJWTSkipsValidation(t *testing.T) {
+	t.Parallel()
+
+	svc, cleanup := setupTestService(t)
+	defer cleanup()
+
+	sourceName := "uec-nil-jwt"
+	createManagedSource(t, svc, sourceName)
+
+	ctx := context.Background()
+
+	// Publish a server with claims {"org": "acme"}
+	_, err := svc.PublishServerVersion(ctx,
+		service.WithServerData(&upstreamv0.ServerJSON{
+			Name:    "com.test/uec-nil-jwt",
+			Version: "1.0.0",
+		}),
+		service.WithClaims(map[string]any{"org": "acme"}),
+	)
+	require.NoError(t, err)
+
+	// Update without passing WithJWTClaims (nil JWT means anonymous mode)
+	err = svc.UpdateEntryClaims(ctx,
+		service.WithEntryType("server"),
+		service.WithName("com.test/uec-nil-jwt"),
+		service.WithClaims(map[string]any{"org": "acme", "team": "eng"}),
+	)
+	require.NoError(t, err)
+}
+
+func TestUpdateEntryClaims_EntryNotFound(t *testing.T) {
+	t.Parallel()
+
+	svc, cleanup := setupTestService(t)
+	defer cleanup()
+
+	sourceName := "uec-not-found"
+	createManagedSource(t, svc, sourceName)
+
+	ctx := context.Background()
+
+	// Attempt to update claims on an entry that doesn't exist
+	err := svc.UpdateEntryClaims(ctx,
+		service.WithEntryType("server"),
+		service.WithName("com.test/nonexistent-server"),
+		service.WithClaims(map[string]any{"org": "acme"}),
+		service.WithJWTClaims(map[string]any{"org": "acme"}),
+	)
+	assert.ErrorIs(t, err, service.ErrNotFound)
+}
+
+func TestUpdateEntryClaims_ClearClaims(t *testing.T) {
+	t.Parallel()
+
+	svc, cleanup := setupTestService(t)
+	defer cleanup()
+
+	sourceName := "uec-clear"
+	createManagedSource(t, svc, sourceName)
+
+	ctx := context.Background()
+
+	// Publish a server with claims {"org": "acme"}
+	_, err := svc.PublishServerVersion(ctx,
+		service.WithServerData(&upstreamv0.ServerJSON{
+			Name:    "com.test/uec-clear",
+			Version: "1.0.0",
+		}),
+		service.WithClaims(map[string]any{"org": "acme"}),
+	)
+	require.NoError(t, err)
+
+	// Update without passing WithClaims (should clear claims)
+	err = svc.UpdateEntryClaims(ctx,
+		service.WithEntryType("server"),
+		service.WithName("com.test/uec-clear"),
+	)
+	require.NoError(t, err)
+}
+
+func TestUpdateEntryClaims_NoManagedSource(t *testing.T) {
+	t.Parallel()
+
+	svc, cleanup := setupTestService(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	// Do NOT call createManagedSource - attempt to update claims
+	err := svc.UpdateEntryClaims(ctx,
+		service.WithEntryType("server"),
+		service.WithName("com.test/no-managed-source"),
+		service.WithClaims(map[string]any{"org": "acme"}),
+	)
+	assert.ErrorIs(t, err, service.ErrNoManagedSource)
+}
+
+func TestUpdateEntryClaims_SuperAdminBypass(t *testing.T) {
+	t.Parallel()
+
+	svc, cleanup := setupTestService(t)
+	defer cleanup()
+
+	sourceName := "uec-superadmin"
+	createManagedSource(t, svc, sourceName)
+
+	ctx := context.Background()
+
+	// Publish a server with claims {"org": "acme"}
+	_, err := svc.PublishServerVersion(ctx,
+		service.WithServerData(&upstreamv0.ServerJSON{
+			Name:    "com.test/uec-superadmin",
+			Version: "1.0.0",
+		}),
+		service.WithClaims(map[string]any{"org": "acme"}),
+	)
+	require.NoError(t, err)
+
+	// Update with non-matching JWT but with super-admin context
+	saCtx := auth.ContextWithRoles(ctx, []auth.Role{auth.RoleSuperAdmin})
+
+	err = svc.UpdateEntryClaims(saCtx,
+		service.WithEntryType("server"),
+		service.WithName("com.test/uec-superadmin"),
+		service.WithClaims(map[string]any{"org": "other"}),
+		service.WithJWTClaims(map[string]any{"org": "other"}),
+	)
+	require.NoError(t, err)
+}
+
+func TestUpdateEntryClaims_SkillType(t *testing.T) {
+	t.Parallel()
+
+	svc, cleanup := setupTestService(t)
+	defer cleanup()
+
+	registryName := "uec-skill"
+	createManagedSourceWithRegistry(t, svc, registryName)
+
+	ctx := context.Background()
+
+	// Publish a skill with claims {"org": "acme"}
+	skill := &service.Skill{
+		Namespace: "com.test",
+		Name:      "uec-skill",
+		Version:   "1.0.0",
+		Title:     "Test Skill",
+	}
+	_, err := svc.PublishSkill(ctx, skill,
+		service.WithClaims(map[string]any{"org": "acme"}),
+		service.WithJWTClaims(map[string]any{"org": "acme", "team": []string{"eng", "ops"}}),
+	)
+	require.NoError(t, err)
+
+	// Update the skill's claims
+	err = svc.UpdateEntryClaims(ctx,
+		service.WithEntryType("skill"),
+		service.WithName("uec-skill"),
+		service.WithClaims(map[string]any{"org": "acme", "team": "eng"}),
+		service.WithJWTClaims(map[string]any{"org": "acme", "team": []string{"eng", "ops"}}),
+	)
+	require.NoError(t, err)
+}

--- a/internal/service/entry_types.go
+++ b/internal/service/entry_types.go
@@ -1,0 +1,21 @@
+package service
+
+import "fmt"
+
+// Supported entry types for registry operations.
+const (
+	EntryTypeServer = "server"
+	EntryTypeSkill  = "skill"
+)
+
+// ValidateEntryType returns nil if entryType is a supported entry type,
+// or an error otherwise. It is the single source of truth for the set of
+// valid entry type strings used across the API, options, and service layers.
+func ValidateEntryType(entryType string) error {
+	switch entryType {
+	case EntryTypeServer, EntryTypeSkill:
+		return nil
+	default:
+		return fmt.Errorf("unsupported entry type: must be %q or %q", EntryTypeServer, EntryTypeSkill)
+	}
+}

--- a/internal/service/mocks/mock_service.go
+++ b/internal/service/mocks/mock_service.go
@@ -396,6 +396,25 @@ func (mr *MockRegistryServiceMockRecorder) PublishSkill(ctx, skill any, opts ...
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PublishSkill", reflect.TypeOf((*MockRegistryService)(nil).PublishSkill), varargs...)
 }
 
+// UpdateEntryClaims mocks base method.
+func (m *MockRegistryService) UpdateEntryClaims(ctx context.Context, opts ...service.Option) error {
+	m.ctrl.T.Helper()
+	varargs := []any{ctx}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "UpdateEntryClaims", varargs...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateEntryClaims indicates an expected call of UpdateEntryClaims.
+func (mr *MockRegistryServiceMockRecorder) UpdateEntryClaims(ctx any, opts ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{ctx}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateEntryClaims", reflect.TypeOf((*MockRegistryService)(nil).UpdateEntryClaims), varargs...)
+}
+
 // UpdateRegistry mocks base method.
 func (m *MockRegistryService) UpdateRegistry(ctx context.Context, name string, req *service.RegistryCreateRequest) (*service.RegistryInfo, error) {
 	m.ctrl.T.Helper()

--- a/internal/service/options.go
+++ b/internal/service/options.go
@@ -194,6 +194,10 @@ func WithClaims(claims map[string]any) Option {
 	}
 }
 
+type entryTypeOption interface {
+	setEntryType(entryType string) error
+}
+
 type jwtClaimsOption interface {
 	setJWTClaims(claims map[string]any) error
 }
@@ -205,6 +209,23 @@ func WithJWTClaims(claims map[string]any) Option {
 		switch o := o.(type) {
 		case jwtClaimsOption:
 			return o.setJWTClaims(claims)
+		default:
+			return fmt.Errorf("invalid option type: %T", o)
+		}
+	}
+}
+
+// WithEntryType sets the entry type for the UpdateEntryClaims operation.
+// Valid values are "server" and "skill".
+func WithEntryType(entryType string) Option {
+	return func(o any) error {
+		if entryType == "" {
+			return fmt.Errorf("invalid entry type: %s", entryType)
+		}
+
+		switch o := o.(type) {
+		case entryTypeOption:
+			return o.setEntryType(entryType)
 		default:
 			return fmt.Errorf("invalid option type: %T", o)
 		}

--- a/internal/service/options.go
+++ b/internal/service/options.go
@@ -216,13 +216,10 @@ func WithJWTClaims(claims map[string]any) Option {
 }
 
 // WithEntryType sets the entry type for the UpdateEntryClaims operation.
-// Valid values are "server" and "skill".
+// Valid values are defined in entry_types.go (EntryTypeServer, EntryTypeSkill).
+// The setter fully validates the value via ValidateEntryType.
 func WithEntryType(entryType string) Option {
 	return func(o any) error {
-		if entryType == "" {
-			return fmt.Errorf("invalid entry type: %s", entryType)
-		}
-
 		switch o := o.(type) {
 		case entryTypeOption:
 			return o.setEntryType(entryType)

--- a/internal/service/options_entries.go
+++ b/internal/service/options_entries.go
@@ -1,0 +1,40 @@
+package service
+
+import "fmt"
+
+// UpdateEntryClaimsOptions is the options for the UpdateEntryClaims operation.
+type UpdateEntryClaimsOptions struct {
+	EntryType string // "server" or "skill"
+	Name      string
+	Claims    map[string]any
+	JWTClaims map[string]any
+}
+
+//nolint:unparam
+func (o *UpdateEntryClaimsOptions) setEntryType(entryType string) error {
+	switch entryType {
+	case "server", "skill":
+		o.EntryType = entryType
+	default:
+		return fmt.Errorf("unsupported entry type: %s", entryType)
+	}
+	return nil
+}
+
+//nolint:unparam
+func (o *UpdateEntryClaimsOptions) setName(name string) error {
+	o.Name = name
+	return nil
+}
+
+//nolint:unparam
+func (o *UpdateEntryClaimsOptions) setClaims(claims map[string]any) error {
+	o.Claims = claims
+	return nil
+}
+
+//nolint:unparam
+func (o *UpdateEntryClaimsOptions) setJWTClaims(claims map[string]any) error {
+	o.JWTClaims = claims
+	return nil
+}

--- a/internal/service/options_entries.go
+++ b/internal/service/options_entries.go
@@ -1,23 +1,18 @@
 package service
 
-import "fmt"
-
 // UpdateEntryClaimsOptions is the options for the UpdateEntryClaims operation.
 type UpdateEntryClaimsOptions struct {
-	EntryType string // "server" or "skill"
+	EntryType string // EntryTypeServer or EntryTypeSkill
 	Name      string
 	Claims    map[string]any
 	JWTClaims map[string]any
 }
 
-//nolint:unparam
 func (o *UpdateEntryClaimsOptions) setEntryType(entryType string) error {
-	switch entryType {
-	case "server", "skill":
-		o.EntryType = entryType
-	default:
-		return fmt.Errorf("unsupported entry type: %s", entryType)
+	if err := ValidateEntryType(entryType); err != nil {
+		return err
 	}
+	o.EntryType = entryType
 	return nil
 }
 

--- a/internal/service/options_entries_test.go
+++ b/internal/service/options_entries_test.go
@@ -1,0 +1,125 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWithEntryType(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		entryType string
+		wantErr   bool
+		wantValue string
+	}{
+		{name: "server is valid", entryType: EntryTypeServer, wantErr: false, wantValue: EntryTypeServer},
+		{name: "skill is valid", entryType: EntryTypeSkill, wantErr: false, wantValue: EntryTypeSkill},
+		{name: "empty rejected", entryType: "", wantErr: true},
+		{name: "unknown rejected", entryType: "widget", wantErr: true},
+		{name: "wrong case rejected", entryType: "Server", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			opts := &UpdateEntryClaimsOptions{}
+			err := WithEntryType(tt.entryType)(opts)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Empty(t, opts.EntryType, "EntryType must remain unset on error")
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantValue, opts.EntryType)
+		})
+	}
+}
+
+func TestWithEntryType_WrongOptionType(t *testing.T) {
+	t.Parallel()
+
+	// An option type that doesn't implement entryTypeOption.
+	type incompatibleOpts struct{}
+	err := WithEntryType(EntryTypeServer)(&incompatibleOpts{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid option type")
+}
+
+func TestUpdateEntryClaimsOptions_Setters(t *testing.T) {
+	t.Parallel()
+
+	t.Run("setName stores the name", func(t *testing.T) {
+		t.Parallel()
+		opts := &UpdateEntryClaimsOptions{}
+		err := WithName("com.example/widget")(opts)
+		require.NoError(t, err)
+		assert.Equal(t, "com.example/widget", opts.Name)
+	})
+
+	t.Run("setClaims stores the claims map", func(t *testing.T) {
+		t.Parallel()
+		opts := &UpdateEntryClaimsOptions{}
+		claims := map[string]any{"org": "acme", "team": "platform"}
+		err := WithClaims(claims)(opts)
+		require.NoError(t, err)
+		assert.Equal(t, claims, opts.Claims)
+	})
+
+	t.Run("setJWTClaims stores the JWT claims map", func(t *testing.T) {
+		t.Parallel()
+		opts := &UpdateEntryClaimsOptions{}
+		jwtClaims := map[string]any{"sub": "user-1", "org": "acme"}
+		err := WithJWTClaims(jwtClaims)(opts)
+		require.NoError(t, err)
+		assert.Equal(t, jwtClaims, opts.JWTClaims)
+	})
+
+	t.Run("multiple setters compose", func(t *testing.T) {
+		t.Parallel()
+		opts := &UpdateEntryClaimsOptions{}
+		require.NoError(t, WithEntryType(EntryTypeSkill)(opts))
+		require.NoError(t, WithName("skill-1")(opts))
+		require.NoError(t, WithClaims(map[string]any{"org": "acme"})(opts))
+		require.NoError(t, WithJWTClaims(map[string]any{"sub": "u1"})(opts))
+
+		assert.Equal(t, EntryTypeSkill, opts.EntryType)
+		assert.Equal(t, "skill-1", opts.Name)
+		assert.Equal(t, map[string]any{"org": "acme"}, opts.Claims)
+		assert.Equal(t, map[string]any{"sub": "u1"}, opts.JWTClaims)
+	})
+}
+
+func TestValidateEntryType(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{name: "server", input: EntryTypeServer, wantErr: false},
+		{name: "skill", input: EntryTypeSkill, wantErr: false},
+		{name: "empty", input: "", wantErr: true},
+		{name: "unknown", input: "widget", wantErr: true},
+		{name: "uppercase server", input: "SERVER", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := ValidateEntryType(tt.input)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "unsupported entry type")
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -147,6 +147,9 @@ type RegistryService interface {
 
 	// DeleteSkillVersion deletes a skill version
 	DeleteSkillVersion(ctx context.Context, opts ...Option) error
+
+	// UpdateEntryClaims updates the claims on a published entry within the managed source.
+	UpdateEntryClaims(ctx context.Context, opts ...Option) error
 }
 
 // SourceInfo represents detailed information about a source


### PR DESCRIPTION
## Summary

- Implements the PUT `/v1/entries/{type}/{name}/claims` endpoint that was previously returning 501
- Allows updating claims on a published entry (MCP server or skill) within the managed source
- Enforces JWT-based authorization: caller's claims must cover both existing and new claims; super-admins bypass
- Returns 204 on success, 400 for validation errors, 403 for insufficient claims, 404 if entry not found

## Changes

- **SQL**: Added `UpdateRegistryEntryClaims` query with nullable claims and `:execrows` for not-found detection
- **Service interface**: Added `UpdateEntryClaims` method and `WithEntryType` option
- **Service implementation**: New `impl_entries.go` with serializable transaction, managed source lookup, and dual claims validation
- **API handler**: Replaced 501 stub with full implementation including entry type validation and error mapping
- **Tests**: 9 handler unit tests + 9 service-layer integration tests covering authorization, not-found, clear-claims, super-admin bypass, and skill-type scenarios
- Removed obsolete `TestV1StubEndpoints` (only tested the 501 stub)

## Test plan

- [x] `task build` — compiles cleanly
- [x] `task lint-fix` — 0 issues
- [x] `task test` — all unit and integration tests pass (including 18 new tests)
- [x] End-to-end: docker compose (anonymous mode) — set/update/clear claims, not-found, bad type, skill type
- [x] End-to-end: native server + mock OIDC (OAuth mode) — authorized update, cross-org rejection (403), JWT scope enforcement (403), no-auth (401), super-admin bypass (204)

Fixes #638

🤖 Generated with [Claude Code](https://claude.com/claude-code)