### PR TITLE
Single-row lock for `GetNextSyncJob`

### DIFF
--- a/database/queries/sync.sql
+++ b/database/queries/sync.sql
@@ -143,8 +143,11 @@ SELECT s.name,
 FROM registry_sync rs
 INNER JOIN source s ON rs.source_id = s.id
 WHERE s.syncable = true
+  AND (rs.ended_at IS NULL
+       OR rs.ended_at + s.sync_schedule::interval <= now())
 ORDER BY rs.ended_at ASC NULLS FIRST, s.name ASC
-FOR UPDATE OF rs SKIP LOCKED;
+FOR UPDATE OF rs SKIP LOCKED
+LIMIT 1;
 
 -- name: UpdateSourceSyncStatusByName :exec
 UPDATE registry_sync

--- a/internal/db/sqlc/sync.sql.go
+++ b/internal/db/sqlc/sync.sql.go
@@ -251,8 +251,11 @@ SELECT s.name,
 FROM registry_sync rs
 INNER JOIN source s ON rs.source_id = s.id
 WHERE s.syncable = true
+  AND (rs.ended_at IS NULL
+       OR rs.ended_at + s.sync_schedule::interval <= now())
 ORDER BY rs.ended_at ASC NULLS FIRST, s.name ASC
 FOR UPDATE OF rs SKIP LOCKED
+LIMIT 1
 `
 
 type ListSourceSyncsByLastUpdateRow struct {


### PR DESCRIPTION
The query previously locked every unlocked `registry_sync` row via `FOR UPDATE SKIP LOCKED`, even though the Go caller only uses the first match. Add a schedule-eligibility WHERE clause (`ended_at IS NULL` or interval elapsed) and `LIMIT 1` so the database returns — and locks — at most one row, reducing contention from O(N) to O(1).