### PR TITLE
Return 400 for invalid server name on publish

### DIFF
--- a/internal/api/v1/entries.go
+++ b/internal/api/v1/entries.go
@@ -90,6 +90,10 @@ func (routes *Routes) publishEntry(w http.ResponseWriter, r *http.Request) {
 
 // writePublishError maps service-layer publish errors to HTTP responses.
 func writePublishError(w http.ResponseWriter, r *http.Request, err error) {
+	if errors.Is(err, service.ErrInvalidServerName) {
+		common.WriteErrorResponse(w, err.Error(), http.StatusBadRequest)
+		return
+	}
 	if errors.Is(err, service.ErrClaimsInsufficient) {
 		common.WriteErrorResponse(w, err.Error(), http.StatusForbidden)
 		return

--- a/internal/api/v1/entries_test.go
+++ b/internal/api/v1/entries_test.go
@@ -82,6 +82,18 @@ func TestPublishEntry(t *testing.T) {
 			wantError:  "no managed source available for publishing",
 		},
 		{
+			name: "invalid server name returns 400",
+			body: mustMarshal(publishEntryRequest{
+				Server: &upstreamv0.ServerJSON{Name: "bad/name-", Version: "1.0.0"},
+			}),
+			setupMock: func(m *mocks.MockRegistryService) {
+				m.EXPECT().PublishServerVersion(gomock.Any(), gomock.Any()).
+					Return(nil, fmt.Errorf("%w: bad/name-", service.ErrInvalidServerName))
+			},
+			wantStatus: http.StatusBadRequest,
+			wantError:  "invalid server name",
+		},
+		{
 			name: "generic service error",
 			body: mustMarshal(publishEntryRequest{
 				Server: &upstreamv0.ServerJSON{Name: "test/server", Version: "1.0.0"},

--- a/internal/service/db/impl_mcp.go
+++ b/internal/service/db/impl_mcp.go
@@ -620,7 +620,7 @@ func (s *dbService) PublishServerVersion(
 
 	// Defensive check: validate server name format (should never fail if API layer is correct)
 	if !validators.IsValidServerName(serverData.Name) {
-		err := fmt.Errorf("invalid server name format: %s", serverData.Name)
+		err := fmt.Errorf("%w: %s", service.ErrInvalidServerName, serverData.Name)
 		otel.RecordError(span, err)
 		return nil, err
 	}

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -63,6 +63,8 @@ var (
 	ErrClaimsInsufficient = errors.New("insufficient claims")
 	// ErrInvalidEntryType is returned when an unsupported entry type string is supplied to an option
 	ErrInvalidEntryType = errors.New("invalid entry type")
+	// ErrInvalidServerName is returned when a server name fails format validation
+	ErrInvalidServerName = errors.New("invalid server name")
 )
 
 //go:generate mockgen -destination=mocks/mock_service.go -package=mocks -source=service.go Service


### PR DESCRIPTION
The publish entry flow returned HTTP 500 when the service layer rejected an invalid server name because the error was a plain `fmt.Errorf` with no sentinel. Add `ErrInvalidServerName` as a sentinel in the service package, wrap it in the database layer's validation check, and match it in `writePublishError` to return 400 Bad Request. A corresponding test case covers the new mapping.