### PR TITLE
Gate claims check on `authzEnabled`

### DIFF
--- a/internal/api/v1/entries.go
+++ b/internal/api/v1/entries.go
@@ -48,8 +48,8 @@ func (routes *Routes) publishEntry(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if routes.authEnabled && len(req.Claims) == 0 {
-		common.WriteErrorResponse(w, "claims are required when authentication is enabled", http.StatusBadRequest)
+	if routes.authzEnabled && len(req.Claims) == 0 {
+		common.WriteErrorResponse(w, "claims are required when authorization is enabled", http.StatusBadRequest)
 		return
 	}
 

--- a/internal/api/v1/entries_test.go
+++ b/internal/api/v1/entries_test.go
@@ -134,6 +134,7 @@ func TestPublishEntry(t *testing.T) {
 func TestPublishEntryClaimsRequired(t *testing.T) {
 	t.Parallel()
 
+	authzCfg := &config.AuthConfig{Mode: config.AuthModeOAuth, Authz: &config.AuthzConfig{}}
 	oauthCfg := &config.AuthConfig{Mode: config.AuthModeOAuth}
 	anonCfg := &config.AuthConfig{Mode: config.AuthModeAnonymous}
 
@@ -147,8 +148,8 @@ func TestPublishEntryClaimsRequired(t *testing.T) {
 		wantError  string
 	}{
 		{
-			name:    "auth enabled without claims returns 400",
-			authCfg: oauthCfg,
+			name:    "authz enabled without claims returns 400",
+			authCfg: authzCfg,
 			body: mustMarshal(publishEntryRequest{
 				Server: &upstreamv0.ServerJSON{Name: "test/server", Version: "1.0.0"},
 			}),
@@ -158,8 +159,8 @@ func TestPublishEntryClaimsRequired(t *testing.T) {
 			wantError:  "claims are required",
 		},
 		{
-			name:    "auth enabled with empty claims returns 400",
-			authCfg: oauthCfg,
+			name:    "authz enabled with empty claims returns 400",
+			authCfg: authzCfg,
 			body: mustMarshal(publishEntryRequest{
 				Server: &upstreamv0.ServerJSON{Name: "test/server", Version: "1.0.0"},
 				Claims: map[string]any{},
@@ -170,11 +171,24 @@ func TestPublishEntryClaimsRequired(t *testing.T) {
 			wantError:  "claims are required",
 		},
 		{
-			name:    "auth enabled with claims succeeds",
-			authCfg: oauthCfg,
+			name:    "authz enabled with claims succeeds",
+			authCfg: authzCfg,
 			body: mustMarshal(publishEntryRequest{
 				Server: &upstreamv0.ServerJSON{Name: "test/server", Version: "1.0.0"},
 				Claims: map[string]any{"sub": "user1"},
+			}),
+			jwtClaims: jwt.MapClaims{"sub": "user1"},
+			setupMock: func(m *mocks.MockRegistryService) {
+				m.EXPECT().PublishServerVersion(gomock.Any(), gomock.Any()).
+					Return(&upstreamv0.ServerJSON{Name: "test/server", Version: "1.0.0"}, nil)
+			},
+			wantStatus: http.StatusCreated,
+		},
+		{
+			name:    "auth enabled without authz config without claims succeeds",
+			authCfg: oauthCfg,
+			body: mustMarshal(publishEntryRequest{
+				Server: &upstreamv0.ServerJSON{Name: "test/server", Version: "1.0.0"},
 			}),
 			jwtClaims: jwt.MapClaims{"sub": "user1"},
 			setupMock: func(m *mocks.MockRegistryService) {
@@ -224,6 +238,10 @@ func TestPublishEntryClaimsRequired(t *testing.T) {
 
 			if tt.jwtClaims != nil {
 				ctx := auth.ContextWithClaims(req.Context(), tt.jwtClaims)
+				// Grant all roles so RequireRole middleware does not block
+				// the request. This test focuses on the claims-required
+				// check, not role enforcement.
+				ctx = auth.ContextWithRoles(ctx, auth.AllRoles())
 				req = req.WithContext(ctx)
 			}
 

--- a/internal/api/v1/routes.go
+++ b/internal/api/v1/routes.go
@@ -14,33 +14,32 @@ import (
 
 // Routes handles HTTP requests for API v1 endpoints.
 type Routes struct {
-	service     service.RegistryService
-	authEnabled bool
+	service      service.RegistryService
+	authzEnabled bool
 }
 
 // NewRoutes creates a new Routes instance with the given service.
-// authEnabled reflects whether the server is configured to require
-// authentication (i.e. Auth.Mode != anonymous); handlers use it to gate
-// policies that only make sense when publishers are authenticated users.
-func NewRoutes(svc service.RegistryService, authEnabled bool) *Routes {
+// authzEnabled reflects whether the server has authorization configured
+// (i.e. AuthConfig.Authz != nil); handlers use it to gate policies that
+// only make sense when publishers are subject to authorization checks.
+func NewRoutes(svc service.RegistryService, authzEnabled bool) *Routes {
 	return &Routes{
-		service:     svc,
-		authEnabled: authEnabled,
+		service:      svc,
+		authzEnabled: authzEnabled,
 	}
 }
 
 // Router creates and configures the HTTP router for API v1 endpoints.
 // authCfg is the full authentication configuration; its Authz subtree drives
-// role checks and its Mode determines whether publish-time claim requirements
-// are enforced. A nil authCfg means no auth is configured (development).
+// role checks and publish-time claim requirements. A nil authCfg means no
+// auth is configured (development).
 func Router(svc service.RegistryService, authCfg *config.AuthConfig) http.Handler {
 	var authzCfg *config.AuthzConfig
-	authEnabled := false
 	if authCfg != nil {
 		authzCfg = authCfg.Authz
-		authEnabled = authCfg.Mode != config.AuthModeAnonymous
 	}
-	routes := NewRoutes(svc, authEnabled)
+	authzEnabled := authzCfg != nil
+	routes := NewRoutes(svc, authzEnabled)
 
 	r := chi.NewRouter()
 


### PR DESCRIPTION
The publishEntry handler was checking `authEnabled` (authentication mode != anonymous) to decide whether claims are required. This is incorrect because claims are an authorization concept: they should only be required when the Authz configuration is present, not merely when authentication is turned on. Replace the `authEnabled` field on `Routes` with `authzEnabled`, derived from `authCfg.Authz != nil`, and update the handler, error message, and tests accordingly.