### PR TITLE
Remove obsolete Vercel deploy hook for docs-website

### DIFF
--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -183,16 +183,6 @@ jobs:
       id-token: write
     uses: ./.github/workflows/image-build-and-publish.yml
 
-  update-docs-website:
-    name: Trigger Docs Website Rebuild
-    needs: [ release-binaries ]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Trigger Vercel Deploy Hook
-        run: |
-          echo "Triggering docs website rebuild to refresh the API spec..."
-          curl -f -X POST "${{ secrets.DOCS_VERCEL_DEPLOY_HOOK }}" || exit 1
-
   publish-helm:
     name: Publish Helm Chart
     needs: [image-build-and-push]


### PR DESCRIPTION
## Context

The \`update-docs-website\` job in \`releaser.yml\` was a legacy of the pre-Renovate docs pipeline. Back then docs-website pulled the Registry Server Swagger via jsdelivr (a remote reference), so every release needed Vercel to rebuild docs-website to pick up the new spec. This job triggered that rebuild:

\`\`\`yaml
update-docs-website:
  name: Trigger Docs Website Rebuild
  needs: [release-binaries]
  runs-on: ubuntu-latest
  steps:
    - name: Trigger Vercel Deploy Hook
      run: |
        echo \"Triggering docs website rebuild to refresh the API spec...\"
        curl -f -X POST \"\${{ secrets.DOCS_VERCEL_DEPLOY_HOOK }}\" || exit 1
\`\`\`

## Why it's dead weight now

docs-website now pins the Swagger as a **static file** synced by \`sync-assets.mjs\` inside a Renovate-opened version-bump PR. Vercel auto-redeploys on push to docs-website's \`main\` branch when that PR merges.

The hook currently fires after every release against docs-website \`main\` at a state where nothing has changed — pure no-op that consumes runner minutes and creates a redundant deploy in Vercel.

Noticed on the v1.3.0 release run:
https://github.com/stacklok/toolhive-registry-server/actions/runs/24778037006/job/72503570856

## Scope

Cross-checked the other three upstreams that docs-website tracks — \`toolhive\`, \`toolhive-studio\`, \`toolhive-cloud-ui\` — none have an equivalent job. \`toolhive\` was cleaned up via stacklok/toolhive#4982 when the unified docs pipeline shipped; this is the last leftover.

## Follow-up (not in this PR)

The \`DOCS_VERCEL_DEPLOY_HOOK\` repo secret can be deleted once this merges — the only consumer is this job.