### PR TITLE
Enrich `ListRegistryEntries` response with version metadata

### DIFF
--- a/database/queries/registry_entries.sql
+++ b/database/queries/registry_entries.sql
@@ -99,6 +99,10 @@ SELECT e.entry_type,
 SELECT e.entry_type,
        e.name,
        v.version,
+       v.title,
+       v.description,
+       v.created_at,
+       v.updated_at,
        src.name AS source_name,
        rs.position
   FROM registry_source rs

--- a/docs/thv-registry-api/docs.go
+++ b/docs/thv-registry-api/docs.go
@@ -122,13 +122,28 @@ const docTemplate = `{
             },
             "github_com_stacklok_toolhive-registry-server_internal_service.RegistryEntryInfo": {
                 "properties": {
+                    "createdAt": {
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
                     "entryType": {
                         "type": "string"
                     },
                     "name": {
                         "type": "string"
                     },
+                    "position": {
+                        "type": "integer"
+                    },
                     "sourceName": {
+                        "type": "string"
+                    },
+                    "title": {
+                        "type": "string"
+                    },
+                    "updatedAt": {
                         "type": "string"
                     },
                     "version": {

--- a/docs/thv-registry-api/swagger.json
+++ b/docs/thv-registry-api/swagger.json
@@ -115,13 +115,28 @@
             },
             "github_com_stacklok_toolhive-registry-server_internal_service.RegistryEntryInfo": {
                 "properties": {
+                    "createdAt": {
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
                     "entryType": {
                         "type": "string"
                     },
                     "name": {
                         "type": "string"
                     },
+                    "position": {
+                        "type": "integer"
+                    },
                     "sourceName": {
+                        "type": "string"
+                    },
+                    "title": {
+                        "type": "string"
+                    },
+                    "updatedAt": {
                         "type": "string"
                     },
                     "version": {

--- a/docs/thv-registry-api/swagger.yaml
+++ b/docs/thv-registry-api/swagger.yaml
@@ -81,11 +81,21 @@ components:
       type: object
     github_com_stacklok_toolhive-registry-server_internal_service.RegistryEntryInfo:
       properties:
+        createdAt:
+          type: string
+        description:
+          type: string
         entryType:
           type: string
         name:
           type: string
+        position:
+          type: integer
         sourceName:
+          type: string
+        title:
+          type: string
+        updatedAt:
           type: string
         version:
           type: string

--- a/internal/api/v1/routes_test.go
+++ b/internal/api/v1/routes_test.go
@@ -677,10 +677,12 @@ func TestListRegistryEntries(t *testing.T) {
 			registryName: "my-registry",
 			mockReturn: []service.RegistryEntryInfo{
 				{
-					EntryType:  "MCP",
-					Name:       "my-server",
-					Version:    "1.0.0",
-					SourceName: "src1",
+					EntryType:   "MCP",
+					Name:        "my-server",
+					Version:     "1.0.0",
+					Title:       "My Server",
+					Description: "A test server",
+					SourceName:  "src1",
 				},
 			},
 			wantStatus: http.StatusOK,
@@ -730,6 +732,10 @@ func TestListRegistryEntries(t *testing.T) {
 				err = json.Unmarshal(rr.Body.Bytes(), &resp)
 				require.NoError(t, err)
 				assert.Len(t, resp.Entries, tt.wantLen)
+				if tt.wantLen > 0 {
+					assert.Equal(t, tt.mockReturn[0].Title, resp.Entries[0].Title)
+					assert.Equal(t, tt.mockReturn[0].Description, resp.Entries[0].Description)
+				}
 			}
 		})
 	}

--- a/internal/db/sqlc/registry_entries.sql.go
+++ b/internal/db/sqlc/registry_entries.sql.go
@@ -212,6 +212,10 @@ const listEntriesByRegistry = `-- name: ListEntriesByRegistry :many
 SELECT e.entry_type,
        e.name,
        v.version,
+       v.title,
+       v.description,
+       v.created_at,
+       v.updated_at,
        src.name AS source_name,
        rs.position
   FROM registry_source rs
@@ -223,11 +227,15 @@ SELECT e.entry_type,
 `
 
 type ListEntriesByRegistryRow struct {
-	EntryType  EntryType `json:"entry_type"`
-	Name       string    `json:"name"`
-	Version    string    `json:"version"`
-	SourceName string    `json:"source_name"`
-	Position   int32     `json:"position"`
+	EntryType   EntryType  `json:"entry_type"`
+	Name        string     `json:"name"`
+	Version     string     `json:"version"`
+	Title       *string    `json:"title"`
+	Description *string    `json:"description"`
+	CreatedAt   *time.Time `json:"created_at"`
+	UpdatedAt   *time.Time `json:"updated_at"`
+	SourceName  string     `json:"source_name"`
+	Position    int32      `json:"position"`
 }
 
 func (q *Queries) ListEntriesByRegistry(ctx context.Context, registryID uuid.UUID) ([]ListEntriesByRegistryRow, error) {
@@ -243,6 +251,10 @@ func (q *Queries) ListEntriesByRegistry(ctx context.Context, registryID uuid.UUI
 			&i.EntryType,
 			&i.Name,
 			&i.Version,
+			&i.Title,
+			&i.Description,
+			&i.CreatedAt,
+			&i.UpdatedAt,
 			&i.SourceName,
 			&i.Position,
 		); err != nil {

--- a/internal/service/db/impl_registry.go
+++ b/internal/service/db/impl_registry.go
@@ -426,12 +426,26 @@ func (s *dbService) ListRegistryEntries(ctx context.Context, registryName string
 	// Map each row directly to RegistryEntryInfo (flat, no grouping)
 	result := make([]service.RegistryEntryInfo, 0, len(rows))
 	for _, row := range rows {
-		result = append(result, service.RegistryEntryInfo{
+		info := service.RegistryEntryInfo{
 			EntryType:  string(row.EntryType),
 			Name:       row.Name,
 			Version:    row.Version,
 			SourceName: row.SourceName,
-		})
+			Position:   row.Position,
+		}
+		if row.Title != nil {
+			info.Title = *row.Title
+		}
+		if row.Description != nil {
+			info.Description = *row.Description
+		}
+		if row.CreatedAt != nil {
+			info.CreatedAt = *row.CreatedAt
+		}
+		if row.UpdatedAt != nil {
+			info.UpdatedAt = *row.UpdatedAt
+		}
+		result = append(result, info)
 	}
 
 	span.SetAttributes(otel.AttrResultCount.Int(len(result)))

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -231,10 +231,15 @@ type SourceEntriesResponse struct {
 
 // RegistryEntryInfo represents a lightweight entry in a registry listing.
 type RegistryEntryInfo struct {
-	EntryType  string `json:"entryType"`
-	Name       string `json:"name"`
-	Version    string `json:"version"`
-	SourceName string `json:"sourceName"`
+	EntryType   string    `json:"entryType"`
+	Name        string    `json:"name"`
+	Version     string    `json:"version"`
+	Title       string    `json:"title,omitempty"`
+	Description string    `json:"description,omitempty"`
+	CreatedAt   time.Time `json:"createdAt"`
+	UpdatedAt   time.Time `json:"updatedAt"`
+	SourceName  string    `json:"sourceName"`
+	Position    int32     `json:"position"`
 }
 
 // RegistryEntriesResponse is the JSON envelope for listing registry entries.


### PR DESCRIPTION
## Summary

- `GET /v1/registries/{name}/entries` now returns `title`, `description`, `createdAt`, `updatedAt`, and `position` alongside the existing `entryType`, `name`, `version`, and `sourceName`.
- Brings this admin endpoint to parity (in terms of available per-version metadata) with `GET /v1/sources/{name}/entries`, which the admin UI already relies on for the corresponding sources view.
- Response shape stays flat (one row per version). The endpoint is intentionally unshadowed — per `.claude/rules/api.md` §5 — so grouping stays a UI concern.

## Why

The admin UI lists all entries of a registry and needs to render title + description per entry. Those fields live on `entry_version` and were already selected by `ListEntriesBySource`; `ListEntriesByRegistry` was the only path that dropped them. `createdAt`/`updatedAt`/`position` close remaining metadata gaps between the two admin endpoints.

The upstream v0.1 consumer endpoints (`/registry/{name}/v0.1/servers`, `/x/dev.toolhive/skills`) already return description via their spec-shaped payloads — they are unchanged.

## Scope

- `database/queries/registry_entries.sql` — extend `ListEntriesByRegistry` SELECT.
- `internal/db/sqlc/registry_entries.sql.go` — regenerated.
- `internal/service/service.go` — new fields on `RegistryEntryInfo`.
- `internal/service/db/impl_registry.go` — map nullable columns, same pattern as `impl_source.go`.
- `internal/api/v1/routes_test.go` — happy-path fixture + assertions cover the new fields.
- `docs/thv-registry-api/*` — swagger regenerated.

`/v1/sources/{name}/entries` and `SourceEntryInfo` are untouched. `position` is only added to the registry endpoint — it's the source's priority within a given registry (`registry_source.position`) and has no meaning in the source-centric view.

## Test plan

- [x] `task lint-fix` — clean
- [x] `task test` for `internal/api/v1/...` and `internal/service/...` — green (the only failure in the full `task test` run was an unrelated testcontainers/docker timeout in `internal/sync/writer`)
- [x] `task docker-up-detached` and hit the endpoint end-to-end:
  ```
  curl -s http://localhost:8080/v1/registries/default/entries
  ```
  Confirmed `title`, `description`, `createdAt`, `updatedAt`, `position` all populate from the seeded file source; `/v1/sources/{name}/entries` response shape unchanged.
- [ ] Reviewer: sanity-check swagger diff (`docs/thv-registry-api/swagger.yaml`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)