### PR TITLE
ci(release): mint GitHub App installation token instead of RELEASE_TOKEN PAT

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -30,6 +30,13 @@ jobs:
     name: Create Release PR
     runs-on: ubuntu-latest
     steps:
+      - name: Generate release app token
+        id: app-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -46,7 +53,7 @@ jobs:
         with:
           releaseo_version: v0.0.4
           bump_type: ${{ inputs.bump_type }}
-          token: ${{ secrets.RELEASE_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           version_files: |
             - file: deploy/charts/toolhive-registry-server/Chart.yaml
               path: version

--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -20,6 +20,13 @@ jobs:
   create-tag:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate release app token
+        id: app-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -119,13 +126,14 @@ jobs:
           echo "Created and pushed tag: $TAG"
 
           # Create GitHub Release (triggers releaser.yml via release event)
-          # Note: Must use PAT (GH_TOKEN) because GITHUB_TOKEN cannot trigger other workflows
+          # Note: Uses a GitHub App installation token rather than GITHUB_TOKEN,
+          # because events from GITHUB_TOKEN cannot trigger downstream workflows.
           gh release create "$TAG" \
             --title "Release $TAG" \
             --generate-notes
           echo "Created GitHub Release: $TAG"
         env:
-          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
 
       - name: Summary
         run: |

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -14,22 +14,24 @@ The release process is fully automated using the [releaseo](https://github.com/s
 
 ## Prerequisites
 
-### Required Secrets
+### Required GitHub App
 
-The following repository secrets must be configured:
+A GitHub App must be installed on this repository to mint short-lived
+installation tokens for the release workflows. An installation token (rather
+than `GITHUB_TOKEN`) is required because events authored by `GITHUB_TOKEN`
+cannot trigger downstream workflows.
 
-| Secret | Description |
-|--------|-------------|
-| `RELEASE_TOKEN` | Personal Access Token with `contents: write` and `pull-requests: write` scope. Required because `GITHUB_TOKEN` cannot trigger other workflows. |
+| Setting | Value |
+|---------|-------|
+| Repository **variable** `RELEASE_APP_CLIENT_ID` | The GitHub App's Client ID |
+| Repository **secret** `RELEASE_APP_PRIVATE_KEY` | The GitHub App's private key (PEM) |
+| App repository permissions | `contents: write`, `pull-requests: write` |
+| App installation | Must be installed on this repository |
 
-> **Warning: Token Expiry**
->
-> The `RELEASE_TOKEN` PAT has a **90-day expiry**. Set a calendar reminder to rotate it before expiration. When the token expires, releases will fail at the tag creation step.
->
-> To rotate:
-> 1. Create a new PAT at https://github.com/settings/tokens with `contents: write` and `pull-requests: write` scope
-> 2. Update the `RELEASE_TOKEN` repository secret
-> 3. Delete the old PAT
+The release workflows use [`actions/create-github-app-token`](https://github.com/actions/create-github-app-token)
+to mint a token at the start of each job. The token is automatically scoped
+to this repository and expires after one hour, so there is nothing to
+rotate manually.
 
 ## Creating a Release
 
@@ -161,7 +163,8 @@ The release process includes multiple security checks:
 **Workflow fails to create PR**
 
 Check the workflow logs in GitHub Actions for specific error messages. Common issues:
-- `RELEASE_TOKEN` secret is not configured or has expired
+- Release GitHub App is not installed on the repo, or `RELEASE_APP_CLIENT_ID` variable / `RELEASE_APP_PRIVATE_KEY` secret is missing
+- App lacks `contents: write` and/or `pull-requests: write` permission
 - Branch `release/v{version}` already exists
 
 **"Branch release/v{version} already exists"**
@@ -194,11 +197,11 @@ Solution: Delete the tag and release, fix the VERSION file, and create a new rel
 
 ### Release Not Triggered After Merge
 
-The `create-release-tag.yml` workflow uses a Personal Access Token (`RELEASE_TOKEN`) to create the tag and release. If releases aren't triggering:
+The `create-release-tag.yml` workflow uses a GitHub App installation token (minted via `actions/create-github-app-token`) to create the tag and release. Installation tokens are required because tags pushed under `GITHUB_TOKEN` do not trigger downstream workflows. If releases aren't triggering:
 
-1. Verify `RELEASE_TOKEN` secret is configured
-2. Verify the PAT has `contents: write` scope
-3. Verify the PAT hasn't expired
+1. Verify the release GitHub App is installed on the repo
+2. Verify `RELEASE_APP_CLIENT_ID` repository variable and `RELEASE_APP_PRIVATE_KEY` repository secret are configured
+3. Verify the app has `contents: write` permission
 
 ## Manual Release (Emergency Only)
 


### PR DESCRIPTION
## Summary

- Replace the long-lived `RELEASE_TOKEN` PAT with a GitHub App installation token minted via [`actions/create-github-app-token@v3.1.1`](https://github.com/actions/create-github-app-token) in `create-release-pr.yml` and `create-release-tag.yml`.
- Update `docs/releasing.md`: replace the "Required Secrets" / PAT-rotation section with a "Required GitHub App" section and refresh the troubleshooting steps.
- Installation tokens are short-lived (1h) and repo-scoped, while still satisfying the constraint that `GITHUB_TOKEN` cannot trigger downstream workflows (e.g. `releaser.yml`).

## Pre-merge configuration (required)

The release workflows will fail until the following are configured on this repo:

1. Install the release GitHub App on `stacklok/toolhive-registry-server` with repository permissions:
   - `contents: write` (for the tag workflow)
   - `pull-requests: write` (for the release PR workflow)
2. Set repository **variable** `RELEASE_APP_CLIENT_ID` to the app's Client ID.
3. Set repository **secret** `RELEASE_APP_PRIVATE_KEY` to the app's private key (PEM).

## Post-merge cleanup

- Delete the now-unused `RELEASE_TOKEN` repository secret from repo settings.

## Test plan

- [ ] Verify GitHub App is installed on `stacklok/toolhive-registry-server` with required permissions.
- [ ] Verify `vars.RELEASE_APP_CLIENT_ID` and `secrets.RELEASE_APP_PRIVATE_KEY` are set on the repo.
- [ ] Trigger `Create Release PR` (patch bump) once via `workflow_dispatch` and confirm the PR is opened by the App actor.
- [ ] Merge that release PR and confirm `create-release-tag.yml` succeeds, the tag is pushed, the GitHub Release is published, and `releaser.yml` fires.
- [ ] After successful release, delete the `RELEASE_TOKEN` repo secret.

Refs: stacklok/toolhive#4835

🤖 Generated with [Claude Code](https://claude.com/claude-code)