### PR TITLE
Self-heal stale `IN_PROGRESS` syncs in `ShouldSync`

### DIFF
--- a/internal/sync/manager.go
+++ b/internal/sync/manager.go
@@ -87,6 +87,13 @@ const (
 	ManualSyncReasonRequested        = "manual-sync-requested"
 )
 
+// orphanedSyncGracePeriod is the maximum time a source may legitimately stay
+// at IN_PROGRESS before ShouldSync treats the row as orphaned (left over from
+// a process killed mid-sync) and re-runs the sync. Comfortably longer than
+// any realistic sync run, but well under the multi-day wedge windows we have
+// observed when this guardrail was missing.
+const orphanedSyncGracePeriod = time.Hour
+
 // Condition reasons for status conditions
 const (
 	// Failure reasons
@@ -192,8 +199,16 @@ func (s *defaultSyncManager) ShouldSync(
 	syncStatus *status.SyncStatus,
 	manualSyncRequested bool,
 ) (Reason, *sources.FetchResult) {
-	// If registry is currently syncing, don't start another sync
-	if syncStatus.Phase == status.SyncPhaseSyncing {
+	// If registry is currently syncing, don't start another sync — unless the
+	// row is orphaned (see isOrphanedInProgressSync), in which case the
+	// previous sync was killed mid-flight and we fall through so the regular
+	// sync flow can land a fresh terminal status.
+	if syncStatus.Phase == status.SyncPhaseSyncing && !isOrphanedInProgressSync(regCfg.Name, syncStatus) {
+		slog.Info("ShouldSync returning",
+			"reason", ReasonAlreadyInProgress.String(),
+			"shouldSync", false,
+			"registry", regCfg.Name,
+			"started_at", syncStatus.LastAttempt)
 		return ReasonAlreadyInProgress, nil
 	}
 
@@ -252,6 +267,26 @@ func (s *defaultSyncManager) ShouldSync(
 	slog.Info("ShouldSync returning", "reason", reason.String(), "shouldSync", reason.ShouldSync())
 
 	return reason, prefetched
+}
+
+// isOrphanedInProgressSync returns true when an IN_PROGRESS row was almost
+// certainly left over from a sync process killed mid-flight. The deferred
+// status update in coordinator.performRegistrySync is the only path that
+// clears IN_PROGRESS; if the process dies (SIGKILL, OOM, eviction) the defer
+// never runs and the row stays IN_PROGRESS forever, wedging the source on
+// every subsequent coordinator tick. The grace window is comfortably longer
+// than any realistic sync run, so a real in-flight sync is never misclassified
+// as orphaned. A nil started_at is treated as orphaned because we have no
+// timestamp to bound it against.
+func isOrphanedInProgressSync(registryName string, syncStatus *status.SyncStatus) bool {
+	if syncStatus.LastAttempt != nil && time.Since(*syncStatus.LastAttempt) <= orphanedSyncGracePeriod {
+		return false
+	}
+	slog.Warn("Detected stale IN_PROGRESS sync, treating as failed",
+		"registry", registryName,
+		"started_at", syncStatus.LastAttempt,
+		"grace_period", orphanedSyncGracePeriod.String())
+	return true
 }
 
 // isSyncNeededForState checks if sync is needed based on the registry's current state

--- a/internal/sync/manager_test.go
+++ b/internal/sync/manager_test.go
@@ -21,6 +21,8 @@ import (
 	writermocks "github.com/stacklok/toolhive-registry-server/internal/sync/writer/mocks"
 )
 
+func ptrTime(t time.Time) *time.Time { return &t }
+
 func TestNewDefaultSyncManager(t *testing.T) {
 	t.Parallel()
 
@@ -73,7 +75,46 @@ func TestDefaultSyncManager_ShouldSync(t *testing.T) {
 			expectedReason: ReasonRegistryNotReady,
 		},
 		{
-			name:                "sync not needed when already syncing",
+			name:                "sync not needed when already syncing within grace window",
+			manualSyncRequested: false,
+			config: &config.SourceConfig{
+				Name: "test-registry",
+				File: &config.FileConfig{
+					Path: testFilePath,
+				},
+			},
+			syncStatus: &status.SyncStatus{
+				Phase:       status.SyncPhaseSyncing,
+				LastAttempt: ptrTime(time.Now().Add(-5 * time.Minute)), // recent — real in-flight sync
+			},
+			expectedReason: ReasonAlreadyInProgress,
+		},
+		{
+			// Regression coverage for the "wedged IN_PROGRESS" bug: when a sync
+			// process is killed mid-flight, its deferred status update never
+			// lands and the row stays IN_PROGRESS forever. Once started_at is
+			// older than orphanedSyncGracePeriod, ShouldSync must treat the row
+			// as orphaned and fall through to the normal sync path, which lets
+			// the coordinator's defer write a fresh terminal status.
+			name:                "stale IN_PROGRESS past grace window is treated as orphaned",
+			manualSyncRequested: false,
+			config: &config.SourceConfig{
+				Name: "test-registry",
+				File: &config.FileConfig{
+					Path: testFilePath,
+				},
+			},
+			syncStatus: &status.SyncStatus{
+				Phase:       status.SyncPhaseSyncing,
+				LastAttempt: ptrTime(time.Now().Add(-2 * time.Hour)), // well past 1h grace
+			},
+			expectedReason: ReasonRegistryNotReady,
+		},
+		{
+			// IN_PROGRESS without a started_at can only come from legacy data
+			// or a code path that forgot to set it; either way we can't tell
+			// when the sync started, so default to treating it as orphaned.
+			name:                "IN_PROGRESS with no started_at is treated as orphaned",
 			manualSyncRequested: false,
 			config: &config.SourceConfig{
 				Name: "test-registry",
@@ -84,7 +125,7 @@ func TestDefaultSyncManager_ShouldSync(t *testing.T) {
 			syncStatus: &status.SyncStatus{
 				Phase: status.SyncPhaseSyncing,
 			},
-			expectedReason: ReasonAlreadyInProgress,
+			expectedReason: ReasonRegistryNotReady,
 		},
 		{
 			name:                "sync needed when registry is in failed state",


### PR DESCRIPTION
## Bug

A `git` sync hit a clone error and the pod was killed before `performRegistrySync`'s defer could write a terminal `sync_status`, leaving the `registry_sync` row at `IN_PROGRESS`. `BulkInitializeSourceSyncs` is `ON CONFLICT DO NOTHING`, so restarts never repaired it. Every coordinator tick then short-circuited in `ShouldSync` on `SyncPhaseSyncing` before reaching its trailing log line — wedged for ~2.5 months on staging, completely silent.

## Fix

In `ShouldSync`, detect `IN_PROGRESS` rows whose `started_at` is `nil` or older than a 1-hour grace window. Log a `WARN` and fall through to the normal sync flow so the coordinator's deferred `UpdateSyncStatus` writes a fresh terminal status on the next sync attempt that actually runs. The grace window is comfortably longer than any realistic sync run.

Lives in `ShouldSync` rather than a startup reaper so it heals lazily on every tick (not only on restart) and avoids a SQL surface change. As a side effect, every `IN_PROGRESS` skip now emits a structured log line, closing the silent-wedge gap that hid the original incident.

## Smoke test (docker compose)

- **Before**: wedge `registry_sync` to `IN_PROGRESS` with `started_at = now() - 2h`, restart → coordinator silently skips (`Registry does not need sync, reason: sync-already-in-progress`, `DEBUG` only — invisible at `INFO`).
- **After**: same setup → `WARN: Detected stale IN_PROGRESS sync, treating as failed`. `ShouldSync` falls through; once the regular flow runs the sync (data change, filter change, manual trigger), the deferred status update flips the row to a terminal status.

## Tests

Added to `TestDefaultSyncManager_ShouldSync`:
- `stale IN_PROGRESS past grace window is treated as orphaned` — fails without the fix.
- `IN_PROGRESS with no started_at is treated as orphaned` — covers nil timestamps.

Tightened the existing `sync not needed when already syncing` case to `LastAttempt = now - 5min` to exercise the inside-grace-window path.

## Relationship to #769

#769 closes the graceful-failure starvation hole; this PR closes the SIGKILL-mid-sync wedge hole.