### PR TITLE
Grant `id-token: write` to Claude PR Assistant

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -35,6 +35,7 @@ jobs:
       pull-requests: read
       issues: read
       actions: read # Required for Claude to read CI results on PRs
+      id-token: write # Required for the action to mint its OIDC token
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6


### PR DESCRIPTION
## Summary

- The Claude Code Action authenticates by minting an OIDC token, which requires the workflow to have `id-token: write` permission. Today the `claude.yml` workflow only requests read permissions, so every `@claude` invocation fails at the token-mint step.
- Adds the single missing permission line.

Failing run for reference: https://github.com/stacklok/toolhive-registry-server/actions/runs/25463244266/job/74710400241

```
Could not fetch an OIDC token. Did you remember to add `id-token: write` to your workflow permissions?
```

## Test plan

- [ ] Once merged, comment `@claude` on a PR and confirm the action successfully obtains an OIDC token and runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)