### PR TITLE
Remove `scopes_supported` from protected resource metadata

### DIFF
--- a/deploy/charts/toolhive-registry-server/values.yaml
+++ b/deploy/charts/toolhive-registry-server/values.yaml
@@ -237,9 +237,6 @@ config:
 #     oauth:
 #       resourceUrl: https://registry.example.com
 #       realm: "mcp-registry"
-#       scopesSupported:
-#         - "mcp-registry:read"
-#         - "mcp-registry:write"
 #       providers:
 #         - name: keycloak
 #           issuerUrl: https://auth.example.com/realms/myrealm

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -120,13 +120,6 @@ auth:
     # Defaults to "mcp-registry"
     realm: mcp-registry
 
-    # OAuth scopes supported by this resource (optional)
-    # Defaults to ["mcp-registry:read", "mcp-registry:write"]
-    scopesSupported:
-      - mcp-registry:read
-      - mcp-registry:write
-      - mcp-registry:admin
-
     # OAuth/OIDC providers (at least one required)
     providers:
       - name: primary-idp
@@ -223,11 +216,7 @@ GET /.well-known/oauth-protected-resource
     "https://idp.example.com",
     "https://kubernetes.default.svc"
   ],
-  "bearer_methods_supported": ["header"],
-  "scopes_supported": [
-    "mcp-registry:read",
-    "mcp-registry:write"
-  ]
+  "bearer_methods_supported": ["header"]
 }
 ```
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -336,9 +336,6 @@ auth:
   oauth:
     resourceUrl: https://registry.example.com
     realm: mcp-registry          # Optional
-    scopesSupported:             # Optional
-      - mcp-registry:read
-      - mcp-registry:write
     providers:
       - name: my-idp
         issuerUrl: https://idp.example.com

--- a/examples/config-oauth.yaml
+++ b/examples/config-oauth.yaml
@@ -57,12 +57,6 @@ auth:
     # Defaults to "mcp-registry"
     realm: mcp-registry
 
-    # OAuth scopes supported by this resource (optional)
-    # Defaults to ["mcp-registry:read", "mcp-registry:write"]
-    scopesSupported:
-      - mcp-registry:read
-      - mcp-registry:write
-
     # OAuth/OIDC providers (at least one required)
     # Multiple providers can be configured (e.g., external IDP + Kubernetes)
     providers:

--- a/internal/auth/factory.go
+++ b/internal/auth/factory.go
@@ -95,7 +95,7 @@ func createOAuthMiddleware(
 	}
 
 	// Create RFC 9728 compliant protected resource handler
-	handler, err := newProtectedResourceHandler(oauth.ResourceURL, issuerURLs, oauth.ScopesSupported)
+	handler, err := newProtectedResourceHandler(oauth.ResourceURL, issuerURLs)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create protected resource handler: %w", err)
 	}

--- a/internal/auth/well_known.go
+++ b/internal/auth/well_known.go
@@ -5,8 +5,6 @@ import (
 	"errors"
 	"log/slog"
 	"net/http"
-
-	"github.com/stacklok/toolhive-registry-server/internal/config"
 )
 
 // protectedResourceMetadata represents RFC 9728 OAuth 2.0 Protected Resource Metadata
@@ -14,7 +12,6 @@ type protectedResourceMetadata struct {
 	Resource               string   `json:"resource"`
 	AuthorizationServers   []string `json:"authorization_servers"`
 	BearerMethodsSupported []string `json:"bearer_methods_supported,omitempty"`
-	ScopesSupported        []string `json:"scopes_supported,omitempty"`
 }
 
 // newProtectedResourceHandler creates an RFC 9728 compliant handler.
@@ -24,15 +21,9 @@ type protectedResourceMetadata struct {
 func newProtectedResourceHandler(
 	resourceURL string,
 	authorizationServers []string,
-	scopes []string,
 ) (http.Handler, error) {
 	if len(authorizationServers) == 0 {
 		return nil, errors.New("at least one authorization server is required")
-	}
-
-	// Apply default scopes if not specified (defensive copy to avoid aliasing)
-	if len(scopes) == 0 {
-		scopes = append([]string{}, config.DefaultScopes...)
 	}
 
 	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -40,7 +31,6 @@ func newProtectedResourceHandler(
 			Resource:               resourceURL,
 			AuthorizationServers:   authorizationServers,
 			BearerMethodsSupported: []string{"header"},
-			ScopesSupported:        scopes,
 		}
 
 		data, err := json.Marshal(metadata)

--- a/internal/auth/well_known_test.go
+++ b/internal/auth/well_known_test.go
@@ -8,8 +8,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/stacklok/toolhive-registry-server/internal/config"
 )
 
 func TestNewProtectedResourceHandler(t *testing.T) {
@@ -19,46 +17,22 @@ func TestNewProtectedResourceHandler(t *testing.T) {
 		name            string
 		resourceURL     string
 		authServers     []string
-		scopes          []string
 		wantResource    string
 		wantAuthServers []string
-		wantScopes      []string
 	}{
 		{
 			name:            "full configuration",
 			resourceURL:     "https://api.example.com",
 			authServers:     []string{"https://auth.example.com"},
-			scopes:          []string{"read", "write"},
 			wantResource:    "https://api.example.com",
 			wantAuthServers: []string{"https://auth.example.com"},
-			wantScopes:      []string{"read", "write"},
-		},
-		{
-			name:            "default scopes applied when nil",
-			resourceURL:     "https://api.example.com",
-			authServers:     []string{"https://auth.example.com"},
-			scopes:          nil,
-			wantResource:    "https://api.example.com",
-			wantAuthServers: []string{"https://auth.example.com"},
-			wantScopes:      config.DefaultScopes,
-		},
-		{
-			name:            "default scopes applied when empty",
-			resourceURL:     "https://api.example.com",
-			authServers:     []string{"https://auth.example.com"},
-			scopes:          []string{},
-			wantResource:    "https://api.example.com",
-			wantAuthServers: []string{"https://auth.example.com"},
-			wantScopes:      config.DefaultScopes,
 		},
 		{
 			name:            "multiple auth servers",
 			resourceURL:     "https://api.example.com",
 			authServers:     []string{"https://auth1.example.com", "https://auth2.example.com"},
-			scopes:          []string{"admin"},
 			wantResource:    "https://api.example.com",
 			wantAuthServers: []string{"https://auth1.example.com", "https://auth2.example.com"},
-			wantScopes:      []string{"admin"},
 		},
 	}
 
@@ -66,7 +40,7 @@ func TestNewProtectedResourceHandler(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			handler, err := newProtectedResourceHandler(tt.resourceURL, tt.authServers, tt.scopes)
+			handler, err := newProtectedResourceHandler(tt.resourceURL, tt.authServers)
 			require.NoError(t, err)
 			require.NotNil(t, handler)
 
@@ -83,8 +57,13 @@ func TestNewProtectedResourceHandler(t *testing.T) {
 
 			assert.Equal(t, tt.wantResource, metadata.Resource)
 			assert.Equal(t, tt.wantAuthServers, metadata.AuthorizationServers)
-			assert.Equal(t, tt.wantScopes, metadata.ScopesSupported)
 			assert.Contains(t, metadata.BearerMethodsSupported, "header")
+
+			// Verify scopes_supported is not emitted.
+			var raw map[string]any
+			require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &raw))
+			_, hasScopes := raw["scopes_supported"]
+			assert.False(t, hasScopes, "scopes_supported should not be present in metadata")
 		})
 	}
 }
@@ -96,21 +75,18 @@ func TestNewProtectedResourceHandler_ValidationErrors(t *testing.T) {
 		name        string
 		resourceURL string
 		authServers []string
-		scopes      []string
 		wantErr     string
 	}{
 		{
 			name:        "nil auth servers",
 			resourceURL: "https://api.example.com",
 			authServers: nil,
-			scopes:      []string{"read"},
 			wantErr:     "at least one authorization server is required",
 		},
 		{
 			name:        "empty auth servers",
 			resourceURL: "https://api.example.com",
 			authServers: []string{},
-			scopes:      []string{"read"},
 			wantErr:     "at least one authorization server is required",
 		},
 	}
@@ -119,7 +95,7 @@ func TestNewProtectedResourceHandler_ValidationErrors(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			handler, err := newProtectedResourceHandler(tt.resourceURL, tt.authServers, tt.scopes)
+			handler, err := newProtectedResourceHandler(tt.resourceURL, tt.authServers)
 			require.Error(t, err)
 			assert.Nil(t, handler)
 			assert.Contains(t, err.Error(), tt.wantErr)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -415,24 +415,9 @@ type OAuthConfig struct {
 	// Multiple providers can be configured (e.g., Kubernetes + external IDP)
 	Providers []OAuthProviderConfig `yaml:"providers,omitempty"`
 
-	// ScopesSupported defines the OAuth scopes supported by this resource (RFC 9728)
-	// Defaults to ["mcp-registry:read", "mcp-registry:write"] if not specified
-	ScopesSupported []string `yaml:"scopesSupported,omitempty"`
-
 	// Realm is the protection space identifier for WWW-Authenticate header (RFC 7235)
 	// Defaults to "mcp-registry" if not specified
 	Realm string `yaml:"realm,omitempty"`
-}
-
-// DefaultScopes are the default OAuth scopes for the registry when not configured
-var DefaultScopes = []string{"mcp-registry:read", "mcp-registry:write"}
-
-// GetScopes returns the configured OAuth scopes or defaults if not specified
-func (o *OAuthConfig) GetScopes() []string {
-	if len(o.ScopesSupported) == 0 {
-		return DefaultScopes
-	}
-	return o.ScopesSupported
 }
 
 // OAuthProviderConfig defines configuration for an OAuth/OIDC provider


### PR DESCRIPTION
## Summary

- `scopes_supported` in `/.well-known/oauth-protected-resource` has no effect on authorization — the registry server gates access via role-resolved JWT claim matching, not OAuth scopes.
- Removes the field from the emitted metadata, the `OAuthConfig.ScopesSupported` config key, `DefaultScopes`, docs, sample configs, and the Helm values comment.
- YAML config loading is non-strict, so existing configs that still set `scopesSupported:` continue to load (the value is silently ignored).

## Test plan

- [x] `go build ./...`
- [x] `go test ./...`
- [ ] `task lint-fix` (run locally before merge)
- [ ] Hit `/.well-known/oauth-protected-resource` against a deployed instance and confirm `scopes_supported` is absent

Fixes #792

🤖 Generated with [Claude Code](https://claude.com/claude-code)