### PR TITLE
Migrate K8s controller to `v1beta1` MCP CRDs

### DIFF
--- a/internal/kubernetes/builder.go
+++ b/internal/kubernetes/builder.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"time"
 
-	mcpv1alpha1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1alpha1"
+	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
@@ -211,8 +211,8 @@ func NewMCPServerReconciler(
 	}
 
 	scheme := runtime.NewScheme()
-	if err := mcpv1alpha1.AddToScheme(scheme); err != nil {
-		return nil, fmt.Errorf("failed to add MCPv1alpha1 scheme: %w", err)
+	if err := mcpv1beta1.AddToScheme(scheme); err != nil {
+		return nil, fmt.Errorf("failed to add MCPv1beta1 scheme: %w", err)
 	}
 
 	options := ctrl.Options{

--- a/internal/kubernetes/controller.go
+++ b/internal/kubernetes/controller.go
@@ -9,7 +9,7 @@ import (
 
 	upstreamv0 "github.com/modelcontextprotocol/registry/pkg/api/v0"
 	toolhivetypes "github.com/stacklok/toolhive-core/registry/types"
-	mcpv1alpha1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1alpha1"
+	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -166,9 +166,9 @@ func (r *MCPServerReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(r.registryName).
-		For(&mcpv1alpha1.MCPServer{}, builder.WithPredicates(annotationPredicate)).
-		Watches(&mcpv1alpha1.VirtualMCPServer{}, enqueueMCPServerRequests(), builder.WithPredicates(annotationPredicate)).
-		Watches(&mcpv1alpha1.MCPRemoteProxy{}, enqueueMCPServerRequests(), builder.WithPredicates(annotationPredicate)).
+		For(&mcpv1beta1.MCPServer{}, builder.WithPredicates(annotationPredicate)).
+		Watches(&mcpv1beta1.VirtualMCPServer{}, enqueueMCPServerRequests(), builder.WithPredicates(annotationPredicate)).
+		Watches(&mcpv1beta1.MCPRemoteProxy{}, enqueueMCPServerRequests(), builder.WithPredicates(annotationPredicate)).
 		Complete(r)
 }
 
@@ -229,15 +229,15 @@ func getMCPServerList(
 		client.InNamespace(namespace),
 	}
 
-	var mcpServerList mcpv1alpha1.MCPServerList
+	var mcpServerList mcpv1beta1.MCPServerList
 	if err := c.List(ctx, &mcpServerList, listOptions...); err != nil {
 		return nil, fmt.Errorf("failed to list MCPServers: %w", err)
 	}
-	var vmcpServerList mcpv1alpha1.VirtualMCPServerList
+	var vmcpServerList mcpv1beta1.VirtualMCPServerList
 	if err := c.List(ctx, &vmcpServerList, listOptions...); err != nil {
 		return nil, fmt.Errorf("failed to list VirtualMCPServers: %w", err)
 	}
-	var mcpRemoteProxyList mcpv1alpha1.MCPRemoteProxyList
+	var mcpRemoteProxyList mcpv1beta1.MCPRemoteProxyList
 	if err := c.List(ctx, &mcpRemoteProxyList, listOptions...); err != nil {
 		return nil, fmt.Errorf("failed to list MCPRemoteProxies: %w", err)
 	}
@@ -251,7 +251,7 @@ func getMCPServerList(
 		mcpObjects[i] = &mcpServerList.Items[i]
 	}
 	serverJSONs = processResources(mcpObjects, "MCPServer", func(obj client.Object) (*upstreamv0.ServerJSON, error) {
-		inner, ok := obj.(*mcpv1alpha1.MCPServer)
+		inner, ok := obj.(*mcpv1beta1.MCPServer)
 		if !ok {
 			return nil, fmt.Errorf("unexpected type %T", obj)
 		}
@@ -263,7 +263,7 @@ func getMCPServerList(
 		vmcpObjects[i] = &vmcpServerList.Items[i]
 	}
 	serverJSONs = processResources(vmcpObjects, "VirtualMCPServer", func(obj client.Object) (*upstreamv0.ServerJSON, error) {
-		inner, ok := obj.(*mcpv1alpha1.VirtualMCPServer)
+		inner, ok := obj.(*mcpv1beta1.VirtualMCPServer)
 		if !ok {
 			return nil, fmt.Errorf("unexpected type %T", obj)
 		}
@@ -275,7 +275,7 @@ func getMCPServerList(
 		mcpProxyObjects[i] = &mcpRemoteProxyList.Items[i]
 	}
 	serverJSONs = processResources(mcpProxyObjects, "MCPRemoteProxy", func(obj client.Object) (*upstreamv0.ServerJSON, error) {
-		inner, ok := obj.(*mcpv1alpha1.MCPRemoteProxy)
+		inner, ok := obj.(*mcpv1beta1.MCPRemoteProxy)
 		if !ok {
 			return nil, fmt.Errorf("unexpected type %T", obj)
 		}

--- a/internal/kubernetes/controller_claims_test.go
+++ b/internal/kubernetes/controller_claims_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	upstreamv0 "github.com/modelcontextprotocol/registry/pkg/api/v0"
-	mcpv1alpha1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1alpha1"
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -207,7 +206,7 @@ func TestValidateClaimValues(t *testing.T) {
 
 // createMCPServerObject creates a test MCPServer as a client.Object with the given name and annotations.
 func createMCPServerObject(name string, annotations map[string]string) client.Object {
-	return &mcpv1alpha1.MCPServer{
+	return &mcpv1beta1.MCPServer{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        name,
 			Namespace:   "default",

--- a/internal/kubernetes/controller_test.go
+++ b/internal/kubernetes/controller_test.go
@@ -3,7 +3,6 @@ package kubernetes
 import (
 	"testing"
 
-	mcpv1alpha1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1alpha1"
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -11,8 +10,8 @@ import (
 )
 
 // createTestMCPServerForPredicate creates a test MCPServer object with the given annotations for predicate tests
-func createTestMCPServerForPredicate(annotations map[string]string) *mcpv1alpha1.MCPServer {
-	return &mcpv1alpha1.MCPServer{
+func createTestMCPServerForPredicate(annotations map[string]string) *mcpv1beta1.MCPServer {
+	return &mcpv1beta1.MCPServer{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        "test-server",
 			Namespace:   "default",
@@ -88,9 +87,9 @@ func TestMakeNewObjectPredicate(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			predicate := makeNewObjectPredicate[*mcpv1alpha1.MCPServer](annotation)
+			predicate := makeNewObjectPredicate[*mcpv1beta1.MCPServer](annotation)
 			obj := createTestMCPServerForPredicate(tt.annotations)
-			createEvent := event.TypedCreateEvent[*mcpv1alpha1.MCPServer]{
+			createEvent := event.TypedCreateEvent[*mcpv1beta1.MCPServer]{
 				Object: obj,
 			}
 
@@ -202,10 +201,10 @@ func TestMakeUpdateObjectPredicate(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			predicate := makeUpdateObjectPredicate[*mcpv1alpha1.MCPServer](annotation)
+			predicate := makeUpdateObjectPredicate[*mcpv1beta1.MCPServer](annotation)
 			oldObj := createTestMCPServerForPredicate(tt.oldAnnots)
 			newObj := createTestMCPServerForPredicate(tt.newAnnots)
-			updateEvent := event.TypedUpdateEvent[*mcpv1alpha1.MCPServer]{
+			updateEvent := event.TypedUpdateEvent[*mcpv1beta1.MCPServer]{
 				ObjectOld: oldObj,
 				ObjectNew: newObj,
 			}
@@ -278,9 +277,9 @@ func TestMakeDeleteObjectPredicate(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			predicate := makeDeleteObjectPredicate[*mcpv1alpha1.MCPServer](annotation)
+			predicate := makeDeleteObjectPredicate[*mcpv1beta1.MCPServer](annotation)
 			obj := createTestMCPServerForPredicate(tt.annotations)
-			deleteEvent := event.TypedDeleteEvent[*mcpv1alpha1.MCPServer]{
+			deleteEvent := event.TypedDeleteEvent[*mcpv1beta1.MCPServer]{
 				Object: obj,
 			}
 

--- a/internal/kubernetes/types.go
+++ b/internal/kubernetes/types.go
@@ -10,7 +10,7 @@ import (
 	upstreamv0 "github.com/modelcontextprotocol/registry/pkg/api/v0"
 	model "github.com/modelcontextprotocol/registry/pkg/model"
 	registry "github.com/stacklok/toolhive-core/registry/types"
-	mcpv1alpha1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1alpha1"
+	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
 )
 
 const (
@@ -28,7 +28,7 @@ const (
 // extractServer converts an MCPServer to a ServerJSON object
 //
 //nolint:unparam
-func extractServer(mcpServer *mcpv1alpha1.MCPServer) (*upstreamv0.ServerJSON, error) {
+func extractServer(mcpServer *mcpv1beta1.MCPServer) (*upstreamv0.ServerJSON, error) {
 	// Generate reverse-DNS formatted server name
 	serverName, err := GenerateServerName(mcpServer.Namespace, mcpServer.Name)
 	if err != nil {
@@ -120,7 +120,7 @@ func extractServer(mcpServer *mcpv1alpha1.MCPServer) (*upstreamv0.ServerJSON, er
 // extractVirtualMCPServer converts a VirtualMCPServer to a ServerJSON object
 //
 //nolint:unparam
-func extractVirtualMCPServer(virtualMCPServer *mcpv1alpha1.VirtualMCPServer) (*upstreamv0.ServerJSON, error) {
+func extractVirtualMCPServer(virtualMCPServer *mcpv1beta1.VirtualMCPServer) (*upstreamv0.ServerJSON, error) {
 	// Generate reverse-DNS formatted server name
 	serverName, err := GenerateServerName(virtualMCPServer.Namespace, virtualMCPServer.Name)
 	if err != nil {
@@ -206,7 +206,7 @@ func extractVirtualMCPServer(virtualMCPServer *mcpv1alpha1.VirtualMCPServer) (*u
 // extractMCPRemoteProxy converts a MCPRemoteProxy to a ServerJSON object
 //
 //nolint:unparam
-func extractMCPRemoteProxy(mcpRemoteProxy *mcpv1alpha1.MCPRemoteProxy) (*upstreamv0.ServerJSON, error) {
+func extractMCPRemoteProxy(mcpRemoteProxy *mcpv1beta1.MCPRemoteProxy) (*upstreamv0.ServerJSON, error) {
 	// Generate reverse-DNS formatted server name
 	serverName, err := GenerateServerName(mcpRemoteProxy.Namespace, mcpRemoteProxy.Name)
 	if err != nil {
@@ -333,7 +333,7 @@ func extractTools(annotations map[string]string, name, namespace string) []strin
 
 // extractPackages extracts packages from MCPServer spec
 // MCPServer uses container images, so we create an OCI package from the image
-func extractPackages(mcpServer *mcpv1alpha1.MCPServer) []model.Package {
+func extractPackages(mcpServer *mcpv1beta1.MCPServer) []model.Package {
 	var packages []model.Package
 
 	transportType := mcpServer.Spec.Transport

--- a/internal/kubernetes/types_test.go
+++ b/internal/kubernetes/types_test.go
@@ -8,7 +8,6 @@ import (
 	upstreamv0 "github.com/modelcontextprotocol/registry/pkg/api/v0"
 	model "github.com/modelcontextprotocol/registry/pkg/model"
 	"github.com/stacklok/toolhive-core/registry/types"
-	mcpv1alpha1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1alpha1"
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -17,8 +16,8 @@ import (
 )
 
 // createTestMCPServer creates a test MCPServer with the given configuration
-func createTestMCPServer(name, namespace string, annotations map[string]string, spec mcpv1beta1.MCPServerSpec) *mcpv1alpha1.MCPServer {
-	return &mcpv1alpha1.MCPServer{
+func createTestMCPServer(name, namespace string, annotations map[string]string, spec mcpv1beta1.MCPServerSpec) *mcpv1beta1.MCPServer {
+	return &mcpv1beta1.MCPServer{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        name,
 			Namespace:   namespace,
@@ -34,7 +33,7 @@ func TestExtractServer(t *testing.T) {
 
 	tests := []struct {
 		name        string
-		mcpServer   *mcpv1alpha1.MCPServer
+		mcpServer   *mcpv1beta1.MCPServer
 		wantSchema  string
 		wantName    string
 		wantVersion string
@@ -531,7 +530,7 @@ func TestExtractPackages(t *testing.T) {
 
 	tests := []struct {
 		name             string
-		mcpServer        *mcpv1alpha1.MCPServer
+		mcpServer        *mcpv1beta1.MCPServer
 		wantCount        int
 		wantRegistryType string
 		wantIdentifier   string
@@ -679,8 +678,8 @@ func TestExtractPackages(t *testing.T) {
 }
 
 // createTestVirtualMCPServer creates a test VirtualMCPServer with the given configuration
-func createTestVirtualMCPServer(name, namespace string, annotations map[string]string) *mcpv1alpha1.VirtualMCPServer {
-	return &mcpv1alpha1.VirtualMCPServer{
+func createTestVirtualMCPServer(name, namespace string, annotations map[string]string) *mcpv1beta1.VirtualMCPServer {
+	return &mcpv1beta1.VirtualMCPServer{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        name,
 			Namespace:   namespace,
@@ -695,7 +694,7 @@ func TestExtractVirtualMCPServer(t *testing.T) {
 
 	tests := []struct {
 		name        string
-		vmcpServer  *mcpv1alpha1.VirtualMCPServer
+		vmcpServer  *mcpv1beta1.VirtualMCPServer
 		wantSchema  string
 		wantName    string
 		wantVersion string
@@ -993,8 +992,8 @@ func TestExtractVirtualMCPServer(t *testing.T) {
 }
 
 // createTestMCPRemoteProxy creates a test MCPRemoteProxy with the given configuration
-func createTestMCPRemoteProxy(name, namespace string, annotations map[string]string) *mcpv1alpha1.MCPRemoteProxy {
-	return &mcpv1alpha1.MCPRemoteProxy{
+func createTestMCPRemoteProxy(name, namespace string, annotations map[string]string) *mcpv1beta1.MCPRemoteProxy {
+	return &mcpv1beta1.MCPRemoteProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        name,
 			Namespace:   namespace,
@@ -1009,7 +1008,7 @@ func TestExtractMCPRemoteProxy(t *testing.T) {
 
 	tests := []struct {
 		name           string
-		mcpRemoteProxy *mcpv1alpha1.MCPRemoteProxy
+		mcpRemoteProxy *mcpv1beta1.MCPRemoteProxy
 		wantSchema     string
 		wantName       string
 		wantVersion    string


### PR DESCRIPTION
## Summary

- Swap the `mcpv1alpha1` import alias for `mcpv1beta1` across `internal/kubernetes/` so scheme registration, `For(...)`/`Watches(...)` GVKs, the `List` calls in `getMCPServerList`, and the `extractServer`/`extractVirtualMCPServer`/`extractMCPRemoteProxy` parameter types all move off the deprecated v1alpha1 API.
- Spec field access is unchanged (`Image`, `Transport`, `ProxyMode` have identical names in v1beta1), and tests already imported v1beta1 for spec construction — only the outer object types swap.
- Silences the controller-runtime cache warning `toolhive.stacklok.dev/v1alpha1 is deprecated; use v1beta1` that fired on startup, every resync, and every watch reconnect.

## Test plan

- [x] `task gen` regenerates mocks cleanly
- [x] `task build` succeeds
- [x] `task lint-fix` reports `0 issues`
- [x] `go test ./internal/kubernetes/... ./internal/app/... ./internal/sync/... ./cmd/...` all pass
- [x] Verified in a Kind cluster with toolhive CRDs from `toolhive@v0.27.2` (which serves both `v1alpha1` deprecated and `v1beta1` storage):
  - **PR branch**: `Starting EventSource ... source: *v1beta1.MCPServer/MCPRemoteProxy/VirtualMCPServer` and **zero** `v1alpha1 is deprecated` warnings across 40+ log lines.
  - **Control run on `main`**: same pod, same cluster, same CRDs — emitted exactly three `Warning: toolhive.stacklok.dev/v1alpha1 is deprecated; use v1beta1` log lines right after EventSource startup, matching the issue's reported behavior.

Fixes #790

🤖 Generated with [Claude Code](https://claude.com/claude-code)