### PR TITLE
Drop all `pgx` and `docker/docker` vuln suppressions

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -59,25 +59,21 @@ jobs:
           # Ignored vulnerabilities with justification:
           # GO-2026-4883: Off-by-one error in Moby plugin privilege validation (CVE-2026-33997)
           #   Affects the Docker daemon's plugin privilege handling code. This project only
-          #   uses the Docker client SDK (via testcontainers) for integration tests, not the
-          #   daemon plugin subsystem. No fixed version exists for github.com/docker/docker;
-          #   fix is only in github.com/moby/moby/v2 v2.0.0-beta.8+ which is not yet
-          #   available as a docker/docker release.
+          #   consumes the Docker API client/types transitively (toolhive CRD types +
+          #   testcontainers), runs no daemon, and never touches the plugin subsystem, so the
+          #   vulnerable path is unreachable. github.com/docker/docker is deprecated as of
+          #   Docker v29 (Nov 2025) and gets no further releases — there is no docker/docker
+          #   version to bump to. Remediation is the upstream migration of docker/docker
+          #   imports to github.com/moby/moby/client + github.com/moby/moby/api.
           # GO-2026-4887: AuthZ plugin bypass with oversized request bodies (CVE-2026-34040)
-          #   Affects the Docker daemon's AuthZ plugin mechanism. This project only uses the
-          #   Docker client SDK (via testcontainers) and does not run or configure AuthZ
-          #   plugins. No fixed version exists for github.com/docker/docker; fix is only in
-          #   github.com/moby/moby/v2 v2.0.0-beta.8+ which is not yet available as a
-          #   docker/docker release.
-          # GO-2026-4771: Memory-safety vulnerability in pgx pgproto3 Bind.Decode (CVE-2026-33815)
-          #   Affects the PostgreSQL wire protocol server-side message decoding. This project
-          #   is a PostgreSQL client connecting to trusted database servers, not a PostgreSQL
-          #   server. No fixed version of github.com/jackc/pgx/v5 exists yet.
-          # GO-2026-4772: Memory-safety vulnerability in pgx pgproto3 FunctionCall.Decode (CVE-2026-33816)
-          #   Same as above — affects server-side protocol decoding. This project is a
-          #   PostgreSQL client connecting to trusted database servers. No fixed version of
-          #   github.com/jackc/pgx/v5 exists yet.
-          IGNORED_VULNS="GO-2026-4883 GO-2026-4887 GO-2026-4771 GO-2026-4772"
+          #   Affects the Docker daemon's AuthZ plugin mechanism. This project only consumes the
+          #   Docker API client/types transitively (toolhive CRD types + testcontainers), runs
+          #   no daemon, and configures no AuthZ plugins, so the vulnerable path is unreachable.
+          #   github.com/docker/docker is deprecated as of Docker v29 (Nov 2025) and gets no
+          #   further releases — there is no docker/docker version to bump to. Remediation is
+          #   the upstream migration of docker/docker imports to github.com/moby/moby/client +
+          #   github.com/moby/moby/api.
+          IGNORED_VULNS="GO-2026-4883 GO-2026-4887"
 
           # Show the raw output for debugging
           echo "::group::govulncheck raw output"

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -56,24 +56,11 @@ jobs:
 
       - name: Check for vulnerabilities (with exclusions)
         run: |
-          # Ignored vulnerabilities with justification:
-          # GO-2026-4883: Off-by-one error in Moby plugin privilege validation (CVE-2026-33997)
-          #   Affects the Docker daemon's plugin privilege handling code. This project only
-          #   consumes the Docker API client/types transitively (toolhive CRD types +
-          #   testcontainers), runs no daemon, and never touches the plugin subsystem, so the
-          #   vulnerable path is unreachable. github.com/docker/docker is deprecated as of
-          #   Docker v29 (Nov 2025) and gets no further releases — there is no docker/docker
-          #   version to bump to. Remediation is the upstream migration of docker/docker
-          #   imports to github.com/moby/moby/client + github.com/moby/moby/api.
-          # GO-2026-4887: AuthZ plugin bypass with oversized request bodies (CVE-2026-34040)
-          #   Affects the Docker daemon's AuthZ plugin mechanism. This project only consumes the
-          #   Docker API client/types transitively (toolhive CRD types + testcontainers), runs
-          #   no daemon, and configures no AuthZ plugins, so the vulnerable path is unreachable.
-          #   github.com/docker/docker is deprecated as of Docker v29 (Nov 2025) and gets no
-          #   further releases — there is no docker/docker version to bump to. Remediation is
-          #   the upstream migration of docker/docker imports to github.com/moby/moby/client +
-          #   github.com/moby/moby/api.
-          IGNORED_VULNS="GO-2026-4883 GO-2026-4887"
+          # No suppressions. The previous GO-2026-4883 / GO-2026-4887 (docker/docker
+          # daemon advisories) ignores were removed; they are resolved by the upstream
+          # docker/docker -> github.com/moby/moby/{client,api} migration (toolhive#5420).
+          # Until that bump lands, this job is expected to fail on those two advisories.
+          IGNORED_VULNS=""
 
           # Show the raw output for debugging
           echo "::group::govulncheck raw output"

--- a/.grype.yaml
+++ b/.grype.yaml
@@ -1,27 +1,12 @@
 # Grype configuration for the registry server.
 #
-# Ignore rules below mirror the justifications in
-# .github/workflows/security-scan.yml for govulncheck. Each entry should cite
-# the equivalent GO-* advisory so the two scanners stay aligned.
-
-ignore:
-  # GHSA-x744-4wpc-v9h2 / CVE-2026-34040 / GO-2026-4887
-  # AuthZ plugin bypass with oversized request bodies in the Docker daemon.
-  # This project only consumes the Docker API client/types transitively (via
-  # toolhive's CRD types and testcontainers); it runs no daemon and never
-  # configures AuthZ plugins, so the vulnerable path is unreachable.
-  # github.com/docker/docker is deprecated as of Docker v29 (Nov 2025) and
-  # receives no further releases — there is no docker/docker version to bump
-  # to. The advisory's "29.3.1" is the engine product release; the library
-  # remediation is migrating docker/docker imports to the maintained
-  # github.com/moby/moby/client and github.com/moby/moby/api modules (both
-  # already in our graph), which is an upstream task in our dependencies
-  # (toolhive, golang-migrate, ory/x).
-  - vulnerability: GHSA-x744-4wpc-v9h2
-    package:
-      name: github.com/docker/docker
-      type: go-module
-  - vulnerability: CVE-2026-34040
-    package:
-      name: github.com/docker/docker
-      type: go-module
+# No active ignore rules. The previous GHSA-x744-4wpc-v9h2 / CVE-2026-34040
+# (GO-2026-4887, docker/docker daemon AuthZ advisory) suppression was removed;
+# it is resolved by the upstream docker/docker -> github.com/moby/moby/{client,api}
+# migration (toolhive#5420). Until that bump lands, the Grype Repository Scan is
+# expected to fail on this advisory.
+#
+# Keep this aligned with the govulncheck ignore list in
+# .github/workflows/security-scan.yml — each entry should cite the equivalent
+# GO-* advisory so the two scanners stay in sync.
+ignore: []

--- a/.grype.yaml
+++ b/.grype.yaml
@@ -7,11 +7,16 @@
 ignore:
   # GHSA-x744-4wpc-v9h2 / CVE-2026-34040 / GO-2026-4887
   # AuthZ plugin bypass with oversized request bodies in the Docker daemon.
-  # This project only uses the Docker client SDK (via testcontainers) for
-  # integration tests; it does not run or configure AuthZ plugins. The fix
-  # lives in github.com/moby/moby v29.3.1 / github.com/moby/moby/v2
-  # v2.0.0-beta.8 — neither is available as a github.com/docker/docker
-  # release on the Go module proxy yet.
+  # This project only consumes the Docker API client/types transitively (via
+  # toolhive's CRD types and testcontainers); it runs no daemon and never
+  # configures AuthZ plugins, so the vulnerable path is unreachable.
+  # github.com/docker/docker is deprecated as of Docker v29 (Nov 2025) and
+  # receives no further releases — there is no docker/docker version to bump
+  # to. The advisory's "29.3.1" is the engine product release; the library
+  # remediation is migrating docker/docker imports to the maintained
+  # github.com/moby/moby/client and github.com/moby/moby/api modules (both
+  # already in our graph), which is an upstream task in our dependencies
+  # (toolhive, golang-migrate, ory/x).
   - vulnerability: GHSA-x744-4wpc-v9h2
     package:
       name: github.com/docker/docker


### PR DESCRIPTION
## Summary

Removes **all** govulncheck and grype vuln suppressions from the repo. After this PR there are no active ignore entries in `.github/workflows/security-scan.yml` (`IGNORED_VULNS=""`) or `.grype.yaml` (`ignore: []`).

### Dropped (stale): `GO-2026-4771` / `GO-2026-4772` (pgx pgproto3 decode)
These were added when no fix for `github.com/jackc/pgx/v5` existed. The fix shipped in **`pgx/v5 v5.9.0`**, and this project is already on **`v5.9.2`** — so the advisories no longer apply, the version isn't in the affected range, and govulncheck doesn't report them. Removing them does not change which vulnerabilities are reported (they were never in the found/called set).

### Dropped (intentionally surfaced): `GO-2026-4883` / `GO-2026-4887` (docker daemon)
Also removes the `GHSA-x744-4wpc-v9h2` / `CVE-2026-34040` block from `.grype.yaml`.

These are Docker daemon advisories (plugin privilege off-by-one and AuthZ bypass). This client-only consumer reaches `github.com/docker/docker` solely through toolhive's transitive import — the daemon-side vulnerable paths are unreachable here. `github.com/docker/docker` is frozen at `v28.5.2` with no fixed release, so there is **nothing to bump to**; the real remediation is the upstream `docker/docker` → `github.com/moby/moby/{client,api}` migration (stacklok/toolhive#5420).

Rather than keep these masked, we remove the suppressions now so the advisories surface. Once the moby-migrated toolhive is bumped here, `docker/docker` leaves the dependency graph and both scanners go green again — at which point no follow-up cleanup is needed because the ignore entries are already gone.

## ⚠️ Expected CI state

Both `Security Scan / Go Vulnerability Check` and `Security Scan / Grype Repository Scan` are **required status checks** and will be **red** on this PR until the toolhive/moby bump lands:

- **Grype** fails on `GHSA-x744-4wpc-v9h2` (`docker/docker@v28.5.2`, High, fix `29.3.1`).
- **govulncheck** fails on `GO-2026-4883` / `GO-2026-4887` (docker), plus transiently on `GO-2026-5037/5038/5039` (stdlib, until CI's `stable` toolchain reaches `go1.26.4`).

Merging therefore requires an admin bypass, and downstream PRs cut from `main` will inherit the same red required checks until the bump merges.

## Notes
- No code changes — security-scan workflow + grype config only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
