### PR TITLE
Add Docker Hub login to testcontainer CI jobs

### DIFF
--- a/.github/workflows/run-on-main.yml
+++ b/.github/workflows/run-on-main.yml
@@ -24,6 +24,8 @@ jobs:
     uses: ./.github/workflows/test.yml
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
   codegen:
     name: Verify Generated Files
     uses: ./.github/workflows/verify-gen.yml

--- a/.github/workflows/run-on-pr.yml
+++ b/.github/workflows/run-on-pr.yml
@@ -28,6 +28,8 @@ jobs:
     uses: ./.github/workflows/test.yml
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 
   codegen:
     name: Verify Generated Files

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,10 @@ on:
     secrets:
       CODECOV_TOKEN:
         required: false
+      DOCKERHUB_USERNAME:
+        required: false
+      DOCKERHUB_TOKEN:
+        required: false
 
 permissions:
   contents: read
@@ -32,6 +36,13 @@ jobs:
               ./internal/app/storage
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        if: ${{ secrets.DOCKERHUB_USERNAME != '' }}
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
@@ -159,6 +170,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        if: ${{ secrets.DOCKERHUB_USERNAME != '' }}
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6


### PR DESCRIPTION
## Summary

- `integration-tests` and `db-tests` (4 matrix shards) all pull `postgres:16-alpine` concurrently on fresh runners — five anonymous Docker Hub pulls from the same GitHub Actions IP range, which hits the rate limit and produces the `unknown:` error seen in #823
- Adds a `docker/login-action` step (guarded by `if: secrets.DOCKERHUB_USERNAME != ''`) to both `db-tests` and `integration-tests` so authenticated pulls are used when credentials are configured, degrading gracefully to anonymous otherwise
- Threads `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` as optional secrets through `run-on-pr.yml` and `run-on-main.yml`

## Test plan

- [ ] Confirm CI passes on this PR (triggers `run-on-pr.yml` → both `db-tests` and `integration-tests`)
- [ ] After merging, re-run or re-trigger #823 to confirm the release PR's integration tests pass
- [ ] Verify the `Log in to Docker Hub` step is skipped gracefully when `DOCKERHUB_USERNAME` secret is not set

Fixes #823 (unblocks the release PR by making CI resilient against Docker Hub rate limits)

🤖 Generated with [Claude Code](https://claude.com/claude-code)