### PR TITLE
Extract icon and category from MCPServer annotations

### DIFF
--- a/internal/kubernetes/builder.go
+++ b/internal/kubernetes/builder.go
@@ -26,6 +26,8 @@ const (
 	defaultRegistryURLAnnotation             = "toolhive.stacklok.dev/registry-url"
 	defaultRegistryDescriptionAnnotation     = "toolhive.stacklok.dev/registry-description"
 	defaultRegistryTitleAnnotation           = "toolhive.stacklok.dev/registry-title"
+	defaultRegistryIconAnnotation            = "toolhive.stacklok.dev/registry-icon"
+	defaultRegistryCategoryAnnotation        = "toolhive.stacklok.dev/registry-category"
 	defaultRegistryToolDefinitionsAnnotation = "toolhive.stacklok.dev/tool-definitions"
 	defaultRegistryToolsAnnotation           = "toolhive.stacklok.dev/tools"
 	defaultAuthzClaimsAnnotation             = "toolhive.stacklok.dev/authz-claims"

--- a/internal/kubernetes/types.go
+++ b/internal/kubernetes/types.go
@@ -63,6 +63,8 @@ func extractServer(mcpServer *mcpv1beta1.MCPServer) (*upstreamv0.ServerJSON, err
 		serverJSON.Title = title
 	}
 
+	applyRegistryIcon(serverJSON, annotations)
+
 	transportURL, ok := annotations[defaultRegistryURLAnnotation]
 	if !ok {
 		return nil, fmt.Errorf("URL not found in annotations")
@@ -103,6 +105,8 @@ func extractServer(mcpServer *mcpv1beta1.MCPServer) (*upstreamv0.ServerJSON, err
 	if tools := extractTools(annotations, mcpServer.Name, mcpServer.Namespace); tools != nil {
 		extensions.Tools = tools
 	}
+
+	applyRegistryCategory(extensions, annotations)
 
 	// Convert extensions struct to map[string]any for JSON serialization
 	extensionsMap, err := structToMap(extensions)
@@ -151,6 +155,8 @@ func extractVirtualMCPServer(virtualMCPServer *mcpv1beta1.VirtualMCPServer) (*up
 		serverJSON.Title = title
 	}
 
+	applyRegistryIcon(serverJSON, annotations)
+
 	transportURL, ok := annotations[defaultRegistryURLAnnotation]
 	if !ok {
 		return nil, fmt.Errorf("URL not found in annotations")
@@ -189,6 +195,8 @@ func extractVirtualMCPServer(virtualMCPServer *mcpv1beta1.VirtualMCPServer) (*up
 	if tools := extractTools(annotations, virtualMCPServer.Name, virtualMCPServer.Namespace); tools != nil {
 		extensions.Tools = tools
 	}
+
+	applyRegistryCategory(extensions, annotations)
 
 	// Convert extensions struct to map[string]any for JSON serialization
 	extensionsMap, err := structToMap(extensions)
@@ -237,6 +245,8 @@ func extractMCPRemoteProxy(mcpRemoteProxy *mcpv1beta1.MCPRemoteProxy) (*upstream
 		serverJSON.Title = title
 	}
 
+	applyRegistryIcon(serverJSON, annotations)
+
 	transportURL, ok := annotations[defaultRegistryURLAnnotation]
 	if !ok {
 		return nil, fmt.Errorf("URL not found in annotations")
@@ -275,6 +285,8 @@ func extractMCPRemoteProxy(mcpRemoteProxy *mcpv1beta1.MCPRemoteProxy) (*upstream
 	if tools := extractTools(annotations, mcpRemoteProxy.Name, mcpRemoteProxy.Namespace); tools != nil {
 		extensions.Tools = tools
 	}
+
+	applyRegistryCategory(extensions, annotations)
 
 	// Convert extensions struct to map[string]any for JSON serialization
 	extensionsMap, err := structToMap(extensions)
@@ -329,6 +341,25 @@ func extractTools(annotations map[string]string, name, namespace string) []strin
 	}
 
 	return tools
+}
+
+// applyRegistryIcon sets the server's icon from the registry-icon annotation
+// when present. Icons are a first-class field of the upstream server.json, so
+// the annotation value (a single icon source URL) is placed there directly.
+func applyRegistryIcon(serverJSON *upstreamv0.ServerJSON, annotations map[string]string) {
+	if icon, ok := annotations[defaultRegistryIconAnnotation]; ok && icon != "" {
+		serverJSON.Icons = []model.Icon{{Src: icon}}
+	}
+}
+
+// applyRegistryCategory records the registry-category annotation as a ToolHive
+// tag when present. Category is not an upstream server.json field; ToolHive's
+// Tags extension is the categorization and filtering mechanism, so the category
+// is carried there.
+func applyRegistryCategory(extensions *registry.ServerExtensions, annotations map[string]string) {
+	if category, ok := annotations[defaultRegistryCategoryAnnotation]; ok && category != "" {
+		extensions.Tags = append(extensions.Tags, category)
+	}
 }
 
 // extractPackages extracts packages from MCPServer spec

--- a/internal/kubernetes/types_test.go
+++ b/internal/kubernetes/types_test.go
@@ -88,6 +88,74 @@ func TestExtractServer(t *testing.T) {
 			},
 		},
 		{
+			name: "MCPServer with icon and category annotations",
+			mcpServer: createTestMCPServer(
+				"test-server",
+				"default",
+				map[string]string{
+					defaultRegistryDescriptionAnnotation: "A test MCP server",
+					defaultRegistryURLAnnotation:         "https://example.com/mcp",
+					defaultRegistryTitleAnnotation:       "Test Server",
+					defaultRegistryIconAnnotation:        "https://example.com/icon.png",
+					defaultRegistryCategoryAnnotation:    "developer-tools",
+				},
+				mcpv1beta1.MCPServerSpec{
+					Image:     "test/image:latest",
+					Transport: "streamable-http",
+				},
+			),
+			wantSchema:  "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+			wantName:    "com.toolhive.k8s.default/test-server",
+			wantVersion: "1.0.0",
+			wantErr:     false,
+			//nolint:thelper // We want to see these lines in the test output
+			checkMeta: func(t *testing.T, sj *upstreamv0.ServerJSON) {
+				assert.Equal(t, "Test Server", sj.Title)
+				// Icon rides on the upstream server.json as a first-class field.
+				require.Len(t, sj.Icons, 1)
+				assert.Equal(t, "https://example.com/icon.png", sj.Icons[0].Src)
+
+				// Category rides on the ToolHive Tags extension.
+				ioStacklok := sj.Meta.PublisherProvided["io.github.stacklok"].(map[string]any)
+				mcpMetadata := ioStacklok["https://example.com/mcp"].(map[string]any)
+				data, err := json.Marshal(mcpMetadata)
+				require.NoError(t, err)
+				var ext registry.ServerExtensions
+				require.NoError(t, json.Unmarshal(data, &ext))
+				assert.Contains(t, ext.Tags, "developer-tools")
+			},
+		},
+		{
+			name: "MCPServer without icon or category annotations leaves them unset",
+			mcpServer: createTestMCPServer(
+				"test-server",
+				"default",
+				map[string]string{
+					defaultRegistryDescriptionAnnotation: "A test MCP server",
+					defaultRegistryURLAnnotation:         "https://example.com/mcp",
+				},
+				mcpv1beta1.MCPServerSpec{
+					Image:     "test/image:latest",
+					Transport: "streamable-http",
+				},
+			),
+			wantSchema:  "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+			wantName:    "com.toolhive.k8s.default/test-server",
+			wantVersion: "1.0.0",
+			wantErr:     false,
+			//nolint:thelper // We want to see these lines in the test output
+			checkMeta: func(t *testing.T, sj *upstreamv0.ServerJSON) {
+				assert.Empty(t, sj.Icons, "Icons should be empty when the icon annotation is not set")
+				ioStacklok := sj.Meta.PublisherProvided["io.github.stacklok"].(map[string]any)
+				mcpMetadata := ioStacklok["https://example.com/mcp"].(map[string]any)
+				data, err := json.Marshal(mcpMetadata)
+				require.NoError(t, err)
+				var ext registry.ServerExtensions
+				require.NoError(t, json.Unmarshal(data, &ext))
+				assert.Empty(t, ext.Tags, "Tags should be empty when the category annotation is not set")
+			},
+		},
+		{
 			name: "MCPServer with nil annotations",
 			mcpServer: createTestMCPServer(
 				"test-server",


### PR DESCRIPTION
## What

The `kubernetes` source already maps `registry-title` / `registry-description` / `registry-url` annotations into the exported `server.json`. This adds two more optional annotations, mirroring `registry-title`:

| Annotation | Mapped to |
|---|---|
| `toolhive.stacklok.dev/registry-icon` | `serverJSON.Icons` — a **first-class** upstream `server.json` field (`model.Icon.Src`) |
| `toolhive.stacklok.dev/registry-category` | the **ToolHive `Tags` extension** (`_meta…publisher-provided…tags`) |

Applied consistently across `extractServer` (MCPServer), `extractVirtualMCPServer`, and `extractMCPRemoteProxy` via two small helpers (`applyRegistryIcon`, `applyRegistryCategory`). Both are optional and no-op when the annotation is absent.

## Why

Consumers render exported servers as cards. Today the k8s source emits `name` + `description` + `remotes` only, so cards have no icon and no category. `title` already had annotation support; this extends the same pattern to icon and category so operators can control presentation from the MCPServer CR.

## Design notes

- **Icon → main property.** The MCP `server.json` schema (2025-12-11) has a first-class `icons` array, so icon belongs there rather than in an extension. A single icon source URL is set as `Icons[0].Src`.
- **Category → `Tags`.** `ServerExtensions` (from `toolhive-core`) has no dedicated `Category` field. `Tags` is the documented categorization + filtering mechanism (see `internal/registry/doc.go`, `internal/filtering/tag_filter.go`), so the category is carried as a tag. Adding a distinct `Category` field would require a `toolhive-core` change; `Tags` keeps this self-contained.

## Tests

`TestExtractServer` gains two cases: one asserting `Icons[0].Src` and `Tags` are populated from the annotations, and one asserting both stay empty when the annotations are absent. `go test ./internal/kubernetes/` and `golangci-lint run ./internal/kubernetes/...` both pass.