### PR TITLE
Add configurable timeout for `api` sources

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -179,6 +179,7 @@ Sync from upstream MCP Registry APIs. Ideal for federation scenarios.
 ```yaml
 api:
   endpoint: https://registry.example.com
+  timeout: 30s
 ```
 
 **Fields:**
@@ -186,6 +187,7 @@ api:
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `endpoint` | string | Yes | Base API URL (without path); the server appends MCP Registry API v0.1 paths automatically |
+| `timeout` | string | No | Per-request HTTP timeout as a Go duration (e.g. `30s`, `1m`). Defaults to `10s`; must be greater than `0` and at most `5m`. Raise this for public or occasionally-slow upstreams where individual requests can take longer. |
 
 **Supports:**
 - Automatic background synchronization

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -286,6 +286,12 @@ type APIConfig struct {
 	//   - /v0.1/servers/{name}/versions/{version} - Get specific version
 	// Example: "http://my-registry-api.default.svc.cluster.local/registry"
 	Endpoint string `yaml:"endpoint" json:"endpoint"`
+
+	// Timeout is the per-request timeout for HTTP requests to the API endpoint
+	// Accepts a Go duration string (e.g., "30s", "1m"); must be > 0 and <= 5m
+	// Defaults to 10s if not specified
+	// Useful for public or occasionally-slow upstreams where the default is too aggressive
+	Timeout string `yaml:"timeout,omitempty" json:"timeout,omitempty"`
 }
 
 // FileConfig defines file source configuration
@@ -1079,11 +1085,31 @@ func validateGitConfig(git *GitConfig, prefix string) error {
 	return nil
 }
 
+// maxAPITimeout is the upper bound for a per-source api.timeout override. The
+// timeout applies per HTTP request and pagination can loop up to maxPaginationPages,
+// so an unbounded value could make a single sync cycle run for hours.
+const maxAPITimeout = 5 * time.Minute
+
 // validateAPIConfig validates API-specific configuration
 func validateAPIConfig(api *APIConfig, prefix string) error {
 	if api.Endpoint == "" {
 		return fmt.Errorf("%s: api.endpoint is required", prefix)
 	}
+
+	// Validate timeout if specified
+	if api.Timeout != "" {
+		timeout, err := time.ParseDuration(api.Timeout)
+		if err != nil {
+			return fmt.Errorf("%s: api.timeout must be a valid duration (e.g., '30s', '1m'): %w", prefix, err)
+		}
+		if timeout <= 0 {
+			return fmt.Errorf("%s: api.timeout must be greater than zero", prefix)
+		}
+		if timeout > maxAPITimeout {
+			return fmt.Errorf("%s: api.timeout must not exceed %s", prefix, maxAPITimeout)
+		}
+	}
+
 	return nil
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -563,6 +563,102 @@ func TestConfigValidate(t *testing.T) {
 			errMsg:  "file.timeout must be a valid duration",
 		},
 		{
+			name: "valid_api_with_timeout",
+			config: &Config{
+				Sources: []SourceConfig{
+					{
+						Name: "test-registry",
+						API: &APIConfig{
+							Endpoint: "https://registry.modelcontextprotocol.io",
+							Timeout:  "1m",
+						},
+						SyncPolicy: &SyncPolicyConfig{
+							Interval: "1h",
+						},
+					},
+				},
+				Registries: []RegistryConfig{
+					{Name: "default", Sources: []string{"test-registry"}},
+				},
+				Database: &DatabaseConfig{
+					Host:     "localhost",
+					Port:     5432,
+					User:     "testuser",
+					Database: "testdb",
+				},
+				Auth: &AuthConfig{
+					Mode: AuthModeAnonymous,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid_api_timeout",
+			config: &Config{
+				Sources: []SourceConfig{
+					{
+						Name: "test-registry",
+						API: &APIConfig{
+							Endpoint: "https://registry.modelcontextprotocol.io",
+							Timeout:  "invalid",
+						},
+						SyncPolicy: &SyncPolicyConfig{
+							Interval: "1h",
+						},
+					},
+				},
+				Auth: &AuthConfig{
+					Mode: AuthModeAnonymous,
+				},
+			},
+			wantErr: true,
+			errMsg:  "api.timeout must be a valid duration",
+		},
+		{
+			name: "invalid_api_timeout_zero",
+			config: &Config{
+				Sources: []SourceConfig{
+					{
+						Name: "test-registry",
+						API: &APIConfig{
+							Endpoint: "https://registry.modelcontextprotocol.io",
+							Timeout:  "0s",
+						},
+						SyncPolicy: &SyncPolicyConfig{
+							Interval: "1h",
+						},
+					},
+				},
+				Auth: &AuthConfig{
+					Mode: AuthModeAnonymous,
+				},
+			},
+			wantErr: true,
+			errMsg:  "api.timeout must be greater than zero",
+		},
+		{
+			name: "invalid_api_timeout_too_large",
+			config: &Config{
+				Sources: []SourceConfig{
+					{
+						Name: "test-registry",
+						API: &APIConfig{
+							Endpoint: "https://registry.modelcontextprotocol.io",
+							Timeout:  "10m",
+						},
+						SyncPolicy: &SyncPolicyConfig{
+							Interval: "1h",
+						},
+					},
+				},
+				Auth: &AuthConfig{
+					Mode: AuthModeAnonymous,
+				},
+			},
+			wantErr: true,
+			errMsg:  "api.timeout must not exceed",
+		},
+		{
 			name: "invalid_file_url_scheme",
 			config: &Config{
 				Sources: []SourceConfig{

--- a/internal/sources/api.go
+++ b/internal/sources/api.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"time"
 
 	"github.com/stacklok/toolhive-registry-server/internal/config"
 	"github.com/stacklok/toolhive-registry-server/internal/httpclient"
@@ -12,19 +13,13 @@ import (
 // apiRegistryHandler handles registry data from API endpoints
 // It validates the Upstream format and delegates to the appropriate handler
 type apiRegistryHandler struct {
-	httpClient      httpclient.Client
-	validator       RegistryDataValidator
-	upstreamHandler *upstreamAPIHandler
+	validator RegistryDataValidator
 }
 
 // NewAPIRegistryHandler creates a new API registry handler
 func NewAPIRegistryHandler() RegistryHandler {
-	httpClient := httpclient.NewDefaultClient(0) // Use default timeout
-
 	return &apiRegistryHandler{
-		httpClient:      httpClient,
-		validator:       NewRegistryDataValidator(),
-		upstreamHandler: NewUpstreamAPIHandler(httpClient),
+		validator: NewRegistryDataValidator(),
 	}
 }
 
@@ -53,9 +48,15 @@ func (h *apiRegistryHandler) FetchRegistry(ctx context.Context, regCfg *config.S
 		return nil, fmt.Errorf("registry validation failed: %w", err)
 	}
 
-	// Validate Upstream format and get appropriate handler
-	handler, err := h.validateUstreamFormat(ctx, regCfg)
+	// Build the upstream handler with an HTTP client whose timeout honors the
+	// optional per-source override, falling back to DefaultAPITimeout.
+	handler, err := h.newUpstreamHandler(regCfg)
 	if err != nil {
+		return nil, err
+	}
+
+	// Validate Upstream format before delegating
+	if err := h.validateUpstreamFormat(ctx, handler, regCfg); err != nil {
 		return nil, fmt.Errorf("upstream format validation failed: %w", err)
 	}
 
@@ -65,22 +66,38 @@ func (h *apiRegistryHandler) FetchRegistry(ctx context.Context, regCfg *config.S
 	return handler.FetchRegistry(ctx, regCfg)
 }
 
-// validateUstreamFormat validates the Upstream format and returns the appropriate handler
-func (h *apiRegistryHandler) validateUstreamFormat(
+// newUpstreamHandler builds an upstream API handler backed by an HTTP client whose
+// timeout honors the optional per-source override, defaulting to httpclient.DefaultTimeout.
+// Bounds on the override are enforced at config load (see config.validateAPIConfig).
+func (*apiRegistryHandler) newUpstreamHandler(regCfg *config.SourceConfig) (*upstreamAPIHandler, error) {
+	timeout := httpclient.DefaultTimeout
+	if regCfg.API.Timeout != "" {
+		parsed, err := time.ParseDuration(regCfg.API.Timeout)
+		if err != nil {
+			return nil, fmt.Errorf("invalid api timeout %q: %w", regCfg.API.Timeout, err)
+		}
+		timeout = parsed
+	}
+
+	return NewUpstreamAPIHandler(httpclient.NewDefaultClient(timeout)), nil
+}
+
+// validateUpstreamFormat validates the endpoint speaks the upstream MCP Registry format
+// (by checking /openapi.yaml via the given handler)
+func (h *apiRegistryHandler) validateUpstreamFormat(
 	ctx context.Context,
+	handler *upstreamAPIHandler,
 	regCfg *config.SourceConfig,
-) (*upstreamAPIHandler, error) {
+) error {
 	endpoint := h.getBaseURL(regCfg)
 
-	// Try upstream format (/openapi.yaml)
-	upstreamErr := h.upstreamHandler.Validate(ctx, endpoint)
-	if upstreamErr == nil {
-		slog.Info("Validated as upstream MCP Registry format")
-		return h.upstreamHandler, nil
+	if err := handler.Validate(ctx, endpoint); err != nil {
+		slog.Debug("Upstream format validation failed", "error", err.Error())
+		return fmt.Errorf("unable to validate Upstream format")
 	}
-	slog.Debug("Upstream format validation failed", "error", upstreamErr.Error())
 
-	return nil, fmt.Errorf("unable to validate Upstream format")
+	slog.Info("Validated as upstream MCP Registry format")
+	return nil
 }
 
 // getBaseURL extracts and normalizes the base URL

--- a/internal/sources/api_test.go
+++ b/internal/sources/api_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -246,6 +247,117 @@ func TestAPIRegistryHandler_NilAPIConfig(t *testing.T) {
 	registryConfig := &config.SourceConfig{
 		Name: "test-registry",
 		API:  nil,
+	}
+
+	_, err := handler.FetchRegistry(ctx, registryConfig)
+
+	require.Error(t, err)
+}
+
+// newUpstreamMockServer returns an httptest.Server that speaks the upstream MCP
+// Registry format with a single server, optionally delaying every response by
+// delay to exercise client timeout behavior.
+func newUpstreamMockServer(delay time.Duration) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if delay > 0 {
+			time.Sleep(delay)
+		}
+		switch r.URL.Path {
+		case openapiPath:
+			w.Header().Set("Content-Type", "application/x-yaml")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`
+info:
+  title: Official MCP Registry
+  description: |
+    A community driven registry service for Model Context Protocol (MCP) servers.
+
+    [GitHub repository](https://github.com/modelcontextprotocol/registry)
+  version: 1.0.0
+openapi: 3.1.0
+`))
+		case "/v0.1/servers":
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{
+				"servers": [
+					{
+						"server": {
+							"name": "test-server",
+							"description": "A test MCP server"
+						},
+						"_meta": {}
+					}
+				],
+				"metadata": {"nextCursor": "", "count": 1}
+			}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+}
+
+func TestAPIRegistryHandler_FetchRegistry_WithConfiguredTimeout(t *testing.T) {
+	t.Parallel()
+
+	mockServer := newUpstreamMockServer(0)
+	defer mockServer.Close()
+
+	handler := sources.NewAPIRegistryHandler()
+	ctx := context.Background()
+
+	registryConfig := &config.SourceConfig{
+		Name: "test-registry",
+		API: &config.APIConfig{
+			Endpoint: mockServer.URL,
+			Timeout:  "1m",
+		},
+	}
+
+	result, err := handler.FetchRegistry(ctx, registryConfig)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, 1, result.ServerCount)
+}
+
+func TestAPIRegistryHandler_FetchRegistry_InvalidTimeout(t *testing.T) {
+	t.Parallel()
+
+	handler := sources.NewAPIRegistryHandler()
+	ctx := context.Background()
+
+	registryConfig := &config.SourceConfig{
+		Name: "test-registry",
+		API: &config.APIConfig{
+			Endpoint: "https://example.com",
+			Timeout:  "not-a-duration",
+		},
+	}
+
+	_, err := handler.FetchRegistry(ctx, registryConfig)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid api timeout")
+}
+
+func TestAPIRegistryHandler_FetchRegistry_TimeoutEnforced(t *testing.T) {
+	t.Parallel()
+
+	// Server delays longer than the configured per-request timeout, so the
+	// request should fail rather than hang until the default timeout.
+	mockServer := newUpstreamMockServer(200 * time.Millisecond)
+	defer mockServer.Close()
+
+	handler := sources.NewAPIRegistryHandler()
+	ctx := context.Background()
+
+	registryConfig := &config.SourceConfig{
+		Name: "test-registry",
+		API: &config.APIConfig{
+			Endpoint: mockServer.URL,
+			Timeout:  "50ms",
+		},
 	}
 
 	_, err := handler.FetchRegistry(ctx, registryConfig)


### PR DESCRIPTION
## Summary

`api`-format sources built their HTTP client with a fixed timeout (`httpclient.DefaultTimeout`, 10s) and there was no way to override it per source. A public or occasionally-slow upstream (e.g. `https://registry.modelcontextprotocol.io`) whose time-to-first-byte exceeds 10s fails the entire sync, even though the endpoint is up and a retry moments later would succeed.

This surfaces the timeout as a configurable field on the `api` source definition, mirroring the existing `file.timeout`.

## Changes

- Add an optional `timeout` field to `APIConfig` (`sources[].api.timeout`).
- When set, the API handler builds its HTTP client with that per-request timeout for both the `/openapi.yaml` format probe and the paginated fetch. When unset, it keeps the existing 10s default (default unchanged).
- Validate the value at config load: must parse as a Go duration, be greater than `0`, and not exceed `5m`.
- Document the field in `docs/configuration.md`.

## Why the 5m upper bound

The timeout applies **per request**, and `fetchAllServers` paginates up to `maxPaginationPages` (1000). An unbounded override could make a single sync cycle run for hours, so the value is capped. Rejecting `<= 0` also avoids the confusing case where `0s` silently falls back to the 10s default and a negative duration fails every request.

## Example

```yaml
- name: official-registry
  format: upstream
  api:
    endpoint: https://registry.modelcontextprotocol.io
    timeout: 30s
  syncPolicy:
    interval: "1h"
```

## Testing

- Handler tests: valid override, invalid duration string, and a short timeout enforced against a slow mock server.
- Config tests: valid `1m`, invalid duration string, zero, and too-large (`10m`) cases.
- `task lint` and the affected package tests pass.

## Out of scope

The issue also floated bounded retry/backoff around the per-page fetch and the hardcoded `limit=100` page size. Those are left for follow-ups.

Closes #842

🤖 Generated with [Claude Code](https://claude.com/claude-code)