### PR TITLE
Validate `api.timeout` bounds on API-created sources

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1090,24 +1090,35 @@ func validateGitConfig(git *GitConfig, prefix string) error {
 // so an unbounded value could make a single sync cycle run for hours.
 const maxAPITimeout = 5 * time.Minute
 
+// ValidateAPITimeout validates an optional api.timeout override. An empty value is
+// valid (the default timeout is used). Otherwise it must be a Go duration greater
+// than zero and no larger than maxAPITimeout. It is shared by the config-load and
+// API validation paths so both enforce identical bounds.
+func ValidateAPITimeout(timeout string) error {
+	if timeout == "" {
+		return nil
+	}
+	d, err := time.ParseDuration(timeout)
+	if err != nil {
+		return fmt.Errorf("api.timeout must be a valid duration (e.g., '30s', '1m'): %w", err)
+	}
+	if d <= 0 {
+		return fmt.Errorf("api.timeout must be greater than zero")
+	}
+	if d > maxAPITimeout {
+		return fmt.Errorf("api.timeout must not exceed %s", maxAPITimeout)
+	}
+	return nil
+}
+
 // validateAPIConfig validates API-specific configuration
 func validateAPIConfig(api *APIConfig, prefix string) error {
 	if api.Endpoint == "" {
 		return fmt.Errorf("%s: api.endpoint is required", prefix)
 	}
 
-	// Validate timeout if specified
-	if api.Timeout != "" {
-		timeout, err := time.ParseDuration(api.Timeout)
-		if err != nil {
-			return fmt.Errorf("%s: api.timeout must be a valid duration (e.g., '30s', '1m'): %w", prefix, err)
-		}
-		if timeout <= 0 {
-			return fmt.Errorf("%s: api.timeout must be greater than zero", prefix)
-		}
-		if timeout > maxAPITimeout {
-			return fmt.Errorf("%s: api.timeout must not exceed %s", prefix, maxAPITimeout)
-		}
+	if err := ValidateAPITimeout(api.Timeout); err != nil {
+		return fmt.Errorf("%s: %w", prefix, err)
 	}
 
 	return nil

--- a/internal/service/validation.go
+++ b/internal/service/validation.go
@@ -121,7 +121,7 @@ func validateAPIConfig(cfg *config.APIConfig) error {
 		return fmt.Errorf("api.endpoint is required")
 	}
 
-	return nil
+	return config.ValidateAPITimeout(cfg.Timeout)
 }
 
 // validateFileConfig validates File source configuration

--- a/internal/service/validation_test.go
+++ b/internal/service/validation_test.go
@@ -527,6 +527,41 @@ func TestValidateAPIConfig(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "valid_endpoint_with_timeout",
+			cfg: &config.APIConfig{
+				Endpoint: "https://api.example.com",
+				Timeout:  "1m",
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid_timeout_duration",
+			cfg: &config.APIConfig{
+				Endpoint: "https://api.example.com",
+				Timeout:  "not-a-duration",
+			},
+			wantErr: true,
+			errMsg:  "api.timeout must be a valid duration",
+		},
+		{
+			name: "zero_timeout_returns_error",
+			cfg: &config.APIConfig{
+				Endpoint: "https://api.example.com",
+				Timeout:  "0s",
+			},
+			wantErr: true,
+			errMsg:  "api.timeout must be greater than zero",
+		},
+		{
+			name: "timeout_exceeds_max",
+			cfg: &config.APIConfig{
+				Endpoint: "https://api.example.com",
+				Timeout:  "10m",
+			},
+			wantErr: true,
+			errMsg:  "api.timeout must not exceed",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

Follow-up to #844. That PR added the `api.timeout` field and validated its bounds at config load (`config.validateAPIConfig`), but sources created or updated through the admin API validate via a separate path (`service.validateAPIConfig`) that never looked at the timeout. So an API caller could set an unparseable, zero, negative, or excessively large timeout and only hit trouble at fetch time (or make a single sync cycle run for hours, since the timeout is per-request and pagination loops up to `maxPaginationPages`).

## Changes

- Extract the bounds check into an exported `config.ValidateAPITimeout` (parseable Go duration, `> 0`, `<= 5m`).
- Call it from both `config.validateAPIConfig` (config load) and `service.validateAPIConfig` (API writes), so both paths enforce identical limits from one source of truth.
- Add service-layer validation tests for valid, unparseable, zero, and over-max timeouts.

No behavior change for config-loaded sources; this closes the gap for API-created ones.

## Note on OpenAPI

The `api.timeout` field is already accepted over the API because `service.SourceCreateRequest.API` embeds `config.APIConfig`. It doesn't show up in the generated swagger because the `PUT /v1/sources/{name}` handler has no request-body annotation, so no source config schema (git/api/file) is documented today. That's a pre-existing gap across all source types and is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)