### PR TITLE
Fix request-body schemas in generated OpenAPI spec

### DIFF
--- a/docs/thv-registry-api/docs.go
+++ b/docs/thv-registry-api/docs.go
@@ -8,6 +8,42 @@ const docTemplate = `{
     "schemes": {{ marshal .Schemes }},
     "components": {
         "schemas": {
+            "github_com_stacklok_toolhive-registry-server_internal_config.APIConfig": {
+                "description": "API endpoint source",
+                "properties": {
+                    "endpoint": {
+                        "description": "Endpoint is the base API URL (without path)\nThe registry handler will append the appropriate paths for the MCP Registry API v0.1:\n  - /v0.1/servers - List all servers\n  - /v0.1/servers/{name}/versions - List server versions\n  - /v0.1/servers/{name}/versions/{version} - Get specific version\nExample: \"http://my-registry-api.default.svc.cluster.local/registry\"",
+                        "type": "string"
+                    },
+                    "timeout": {
+                        "description": "Timeout is the per-request timeout for HTTP requests to the API endpoint\nAccepts a Go duration string (e.g., \"30s\", \"1m\"); must be \u003e 0 and \u003c= 5m\nDefaults to 10s if not specified\nUseful for public or occasionally-slow upstreams where the default is too aggressive",
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "github_com_stacklok_toolhive-registry-server_internal_config.FileConfig": {
+                "description": "Local file or URL source",
+                "properties": {
+                    "data": {
+                        "description": "Data is the inline registry data as a JSON string\nMutually exclusive with Path and URL - exactly one must be specified\nUseful for API-created registries where the data is provided directly",
+                        "type": "string"
+                    },
+                    "path": {
+                        "description": "Path is the path to the registry.json file on the local filesystem\nCan be absolute or relative to the working directory\nMutually exclusive with URL and Data - exactly one must be specified",
+                        "type": "string"
+                    },
+                    "timeout": {
+                        "description": "Timeout is the timeout for HTTP requests when using URL\nDefaults to 30s if not specified\nOnly applicable when URL is set",
+                        "type": "string"
+                    },
+                    "url": {
+                        "description": "URL is the HTTP/HTTPS URL to fetch the registry file from\nMutually exclusive with Path and Data - exactly one must be specified\nHTTPS is required unless the host is localhost or THV_REGISTRY_INSECURE_URL=true",
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
             "github_com_stacklok_toolhive-registry-server_internal_config.FilterConfig": {
                 "description": "Filtering rules",
                 "properties": {
@@ -18,6 +54,57 @@ const docTemplate = `{
                         "$ref": "#/components/schemas/github_com_stacklok_toolhive-registry-server_internal_config.TagFilterConfig"
                     }
                 },
+                "type": "object"
+            },
+            "github_com_stacklok_toolhive-registry-server_internal_config.GitAuthConfig": {
+                "description": "Auth contains optional authentication for private repositories",
+                "properties": {
+                    "passwordFile": {
+                        "description": "PasswordFile is the path to a file containing the Git password/token\nMust be an absolute path; whitespace is trimmed from the content",
+                        "type": "string"
+                    },
+                    "username": {
+                        "description": "Username is the Git username for HTTP Basic authentication",
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "github_com_stacklok_toolhive-registry-server_internal_config.GitConfig": {
+                "description": "Git repository source",
+                "properties": {
+                    "auth": {
+                        "$ref": "#/components/schemas/github_com_stacklok_toolhive-registry-server_internal_config.GitAuthConfig"
+                    },
+                    "branch": {
+                        "description": "Branch is the Git branch to use (mutually exclusive with Tag and Commit)",
+                        "type": "string"
+                    },
+                    "commit": {
+                        "description": "Commit is the Git commit SHA to use (mutually exclusive with Branch and Tag)",
+                        "type": "string"
+                    },
+                    "path": {
+                        "description": "Path is the path to the registry file within the repository",
+                        "type": "string"
+                    },
+                    "repository": {
+                        "description": "Repository is the Git repository URL (HTTP/HTTPS/SSH)",
+                        "type": "string"
+                    },
+                    "tag": {
+                        "description": "Tag is the Git tag to use (mutually exclusive with Branch and Commit)",
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "github_com_stacklok_toolhive-registry-server_internal_config.KubernetesConfig": {
+                "description": "Kubernetes discovery source",
+                "type": "object"
+            },
+            "github_com_stacklok_toolhive-registry-server_internal_config.ManagedConfig": {
+                "description": "Managed registry (no sync)",
                 "type": "object"
             },
             "github_com_stacklok_toolhive-registry-server_internal_config.NameFilterConfig": {
@@ -56,6 +143,15 @@ const docTemplate = `{
                     "SourceTypeManaged",
                     "SourceTypeKubernetes"
                 ]
+            },
+            "github_com_stacklok_toolhive-registry-server_internal_config.SyncPolicyConfig": {
+                "description": "Sync schedule configuration",
+                "properties": {
+                    "interval": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
             },
             "github_com_stacklok_toolhive-registry-server_internal_config.TagFilterConfig": {
                 "properties": {
@@ -104,6 +200,24 @@ const docTemplate = `{
                     },
                     "version": {
                         "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "github_com_stacklok_toolhive-registry-server_internal_service.RegistryCreateRequest": {
+                "properties": {
+                    "claims": {
+                        "additionalProperties": {},
+                        "description": "Authorization claims",
+                        "type": "object"
+                    },
+                    "sources": {
+                        "description": "ordered list of source names",
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array",
+                        "uniqueItems": false
                     }
                 },
                 "type": "object"
@@ -306,6 +420,37 @@ const docTemplate = `{
                     },
                     "url": {
                         "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "github_com_stacklok_toolhive-registry-server_internal_service.SourceCreateRequest": {
+                "properties": {
+                    "api": {
+                        "$ref": "#/components/schemas/github_com_stacklok_toolhive-registry-server_internal_config.APIConfig"
+                    },
+                    "claims": {
+                        "additionalProperties": {},
+                        "description": "Authorization claims",
+                        "type": "object"
+                    },
+                    "file": {
+                        "$ref": "#/components/schemas/github_com_stacklok_toolhive-registry-server_internal_config.FileConfig"
+                    },
+                    "filter": {
+                        "$ref": "#/components/schemas/github_com_stacklok_toolhive-registry-server_internal_config.FilterConfig"
+                    },
+                    "git": {
+                        "$ref": "#/components/schemas/github_com_stacklok_toolhive-registry-server_internal_config.GitConfig"
+                    },
+                    "kubernetes": {
+                        "$ref": "#/components/schemas/github_com_stacklok_toolhive-registry-server_internal_config.KubernetesConfig"
+                    },
+                    "managed": {
+                        "$ref": "#/components/schemas/github_com_stacklok_toolhive-registry-server_internal_config.ManagedConfig"
+                    },
+                    "syncPolicy": {
+                        "$ref": "#/components/schemas/github_com_stacklok_toolhive-registry-server_internal_config.SyncPolicyConfig"
                     }
                 },
                 "type": "object"
@@ -1220,15 +1365,6 @@ const docTemplate = `{
                         }
                     }
                 ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "object"
-                            }
-                        }
-                    }
-                },
                 "responses": {
                     "200": {
                         "content": {
@@ -1314,15 +1450,6 @@ const docTemplate = `{
                         }
                     }
                 ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "object"
-                            }
-                        }
-                    }
-                },
                 "responses": {
                     "200": {
                         "content": {
@@ -1417,15 +1544,6 @@ const docTemplate = `{
                         }
                     }
                 ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "object"
-                            }
-                        }
-                    }
-                },
                 "responses": {
                     "200": {
                         "content": {
@@ -1534,15 +1652,6 @@ const docTemplate = `{
                         }
                     }
                 ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "object"
-                            }
-                        }
-                    }
-                },
                 "responses": {
                     "200": {
                         "content": {
@@ -1624,15 +1733,6 @@ const docTemplate = `{
                         }
                     }
                 ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "object"
-                            }
-                        }
-                    }
-                },
                 "responses": {
                     "200": {
                         "content": {
@@ -1727,15 +1827,6 @@ const docTemplate = `{
                         }
                     }
                 ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "object"
-                            }
-                        }
-                    }
-                },
                 "responses": {
                     "200": {
                         "content": {
@@ -1839,15 +1930,6 @@ const docTemplate = `{
                         }
                     }
                 ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "object"
-                            }
-                        }
-                    }
-                },
                 "responses": {
                     "200": {
                         "content": {
@@ -2141,15 +2223,6 @@ const docTemplate = `{
                         }
                     }
                 ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "object"
-                            }
-                        }
-                    }
-                },
                 "responses": {
                     "204": {
                         "description": "No Content"
@@ -2237,15 +2310,6 @@ const docTemplate = `{
         "/v1/registries": {
             "get": {
                 "description": "List all registries",
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "object"
-                            }
-                        }
-                    }
-                },
                 "responses": {
                     "200": {
                         "content": {
@@ -2291,15 +2355,6 @@ const docTemplate = `{
                         }
                     }
                 ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "object"
-                            }
-                        }
-                    }
-                },
                 "responses": {
                     "204": {
                         "description": "Registry deleted"
@@ -2375,15 +2430,6 @@ const docTemplate = `{
                         }
                     }
                 ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "object"
-                            }
-                        }
-                    }
-                },
                 "responses": {
                     "200": {
                         "content": {
@@ -2457,10 +2503,21 @@ const docTemplate = `{
                     "content": {
                         "application/json": {
                             "schema": {
-                                "type": "object"
+                                "oneOf": [
+                                    {
+                                        "type": "object"
+                                    },
+                                    {
+                                        "$ref": "#/components/schemas/github_com_stacklok_toolhive-registry-server_internal_service.RegistryCreateRequest",
+                                        "summary": "request",
+                                        "description": "Registry configuration"
+                                    }
+                                ]
                             }
                         }
-                    }
+                    },
+                    "description": "Registry configuration",
+                    "required": true
                 },
                 "responses": {
                     "200": {
@@ -2543,15 +2600,6 @@ const docTemplate = `{
                         }
                     }
                 ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "object"
-                            }
-                        }
-                    }
-                },
                 "responses": {
                     "200": {
                         "content": {
@@ -2612,15 +2660,6 @@ const docTemplate = `{
         "/v1/sources": {
             "get": {
                 "description": "List all sources",
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "object"
-                            }
-                        }
-                    }
-                },
                 "responses": {
                     "200": {
                         "content": {
@@ -2666,15 +2705,6 @@ const docTemplate = `{
                         }
                     }
                 ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "object"
-                            }
-                        }
-                    }
-                },
                 "responses": {
                     "204": {
                         "description": "Source deleted"
@@ -2763,15 +2793,6 @@ const docTemplate = `{
                         }
                     }
                 ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "object"
-                            }
-                        }
-                    }
-                },
                 "responses": {
                     "200": {
                         "content": {
@@ -2845,10 +2866,21 @@ const docTemplate = `{
                     "content": {
                         "application/json": {
                             "schema": {
-                                "type": "object"
+                                "oneOf": [
+                                    {
+                                        "type": "object"
+                                    },
+                                    {
+                                        "$ref": "#/components/schemas/github_com_stacklok_toolhive-registry-server_internal_service.SourceCreateRequest",
+                                        "summary": "request",
+                                        "description": "Source configuration"
+                                    }
+                                ]
                             }
                         }
-                    }
+                    },
+                    "description": "Source configuration",
+                    "required": true
                 },
                 "responses": {
                     "200": {
@@ -2944,15 +2976,6 @@ const docTemplate = `{
                         }
                     }
                 ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "object"
-                            }
-                        }
-                    }
-                },
                 "responses": {
                     "200": {
                         "content": {

--- a/docs/thv-registry-api/swagger.json
+++ b/docs/thv-registry-api/swagger.json
@@ -1,6 +1,42 @@
 {
     "components": {
         "schemas": {
+            "github_com_stacklok_toolhive-registry-server_internal_config.APIConfig": {
+                "description": "API endpoint source",
+                "properties": {
+                    "endpoint": {
+                        "description": "Endpoint is the base API URL (without path)\nThe registry handler will append the appropriate paths for the MCP Registry API v0.1:\n  - /v0.1/servers - List all servers\n  - /v0.1/servers/{name}/versions - List server versions\n  - /v0.1/servers/{name}/versions/{version} - Get specific version\nExample: \"http://my-registry-api.default.svc.cluster.local/registry\"",
+                        "type": "string"
+                    },
+                    "timeout": {
+                        "description": "Timeout is the per-request timeout for HTTP requests to the API endpoint\nAccepts a Go duration string (e.g., \"30s\", \"1m\"); must be \u003e 0 and \u003c= 5m\nDefaults to 10s if not specified\nUseful for public or occasionally-slow upstreams where the default is too aggressive",
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "github_com_stacklok_toolhive-registry-server_internal_config.FileConfig": {
+                "description": "Local file or URL source",
+                "properties": {
+                    "data": {
+                        "description": "Data is the inline registry data as a JSON string\nMutually exclusive with Path and URL - exactly one must be specified\nUseful for API-created registries where the data is provided directly",
+                        "type": "string"
+                    },
+                    "path": {
+                        "description": "Path is the path to the registry.json file on the local filesystem\nCan be absolute or relative to the working directory\nMutually exclusive with URL and Data - exactly one must be specified",
+                        "type": "string"
+                    },
+                    "timeout": {
+                        "description": "Timeout is the timeout for HTTP requests when using URL\nDefaults to 30s if not specified\nOnly applicable when URL is set",
+                        "type": "string"
+                    },
+                    "url": {
+                        "description": "URL is the HTTP/HTTPS URL to fetch the registry file from\nMutually exclusive with Path and Data - exactly one must be specified\nHTTPS is required unless the host is localhost or THV_REGISTRY_INSECURE_URL=true",
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
             "github_com_stacklok_toolhive-registry-server_internal_config.FilterConfig": {
                 "description": "Filtering rules",
                 "properties": {
@@ -11,6 +47,57 @@
                         "$ref": "#/components/schemas/github_com_stacklok_toolhive-registry-server_internal_config.TagFilterConfig"
                     }
                 },
+                "type": "object"
+            },
+            "github_com_stacklok_toolhive-registry-server_internal_config.GitAuthConfig": {
+                "description": "Auth contains optional authentication for private repositories",
+                "properties": {
+                    "passwordFile": {
+                        "description": "PasswordFile is the path to a file containing the Git password/token\nMust be an absolute path; whitespace is trimmed from the content",
+                        "type": "string"
+                    },
+                    "username": {
+                        "description": "Username is the Git username for HTTP Basic authentication",
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "github_com_stacklok_toolhive-registry-server_internal_config.GitConfig": {
+                "description": "Git repository source",
+                "properties": {
+                    "auth": {
+                        "$ref": "#/components/schemas/github_com_stacklok_toolhive-registry-server_internal_config.GitAuthConfig"
+                    },
+                    "branch": {
+                        "description": "Branch is the Git branch to use (mutually exclusive with Tag and Commit)",
+                        "type": "string"
+                    },
+                    "commit": {
+                        "description": "Commit is the Git commit SHA to use (mutually exclusive with Branch and Tag)",
+                        "type": "string"
+                    },
+                    "path": {
+                        "description": "Path is the path to the registry file within the repository",
+                        "type": "string"
+                    },
+                    "repository": {
+                        "description": "Repository is the Git repository URL (HTTP/HTTPS/SSH)",
+                        "type": "string"
+                    },
+                    "tag": {
+                        "description": "Tag is the Git tag to use (mutually exclusive with Branch and Commit)",
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "github_com_stacklok_toolhive-registry-server_internal_config.KubernetesConfig": {
+                "description": "Kubernetes discovery source",
+                "type": "object"
+            },
+            "github_com_stacklok_toolhive-registry-server_internal_config.ManagedConfig": {
+                "description": "Managed registry (no sync)",
                 "type": "object"
             },
             "github_com_stacklok_toolhive-registry-server_internal_config.NameFilterConfig": {
@@ -49,6 +136,15 @@
                     "SourceTypeManaged",
                     "SourceTypeKubernetes"
                 ]
+            },
+            "github_com_stacklok_toolhive-registry-server_internal_config.SyncPolicyConfig": {
+                "description": "Sync schedule configuration",
+                "properties": {
+                    "interval": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
             },
             "github_com_stacklok_toolhive-registry-server_internal_config.TagFilterConfig": {
                 "properties": {
@@ -97,6 +193,24 @@
                     },
                     "version": {
                         "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "github_com_stacklok_toolhive-registry-server_internal_service.RegistryCreateRequest": {
+                "properties": {
+                    "claims": {
+                        "additionalProperties": {},
+                        "description": "Authorization claims",
+                        "type": "object"
+                    },
+                    "sources": {
+                        "description": "ordered list of source names",
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array",
+                        "uniqueItems": false
                     }
                 },
                 "type": "object"
@@ -299,6 +413,37 @@
                     },
                     "url": {
                         "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "github_com_stacklok_toolhive-registry-server_internal_service.SourceCreateRequest": {
+                "properties": {
+                    "api": {
+                        "$ref": "#/components/schemas/github_com_stacklok_toolhive-registry-server_internal_config.APIConfig"
+                    },
+                    "claims": {
+                        "additionalProperties": {},
+                        "description": "Authorization claims",
+                        "type": "object"
+                    },
+                    "file": {
+                        "$ref": "#/components/schemas/github_com_stacklok_toolhive-registry-server_internal_config.FileConfig"
+                    },
+                    "filter": {
+                        "$ref": "#/components/schemas/github_com_stacklok_toolhive-registry-server_internal_config.FilterConfig"
+                    },
+                    "git": {
+                        "$ref": "#/components/schemas/github_com_stacklok_toolhive-registry-server_internal_config.GitConfig"
+                    },
+                    "kubernetes": {
+                        "$ref": "#/components/schemas/github_com_stacklok_toolhive-registry-server_internal_config.KubernetesConfig"
+                    },
+                    "managed": {
+                        "$ref": "#/components/schemas/github_com_stacklok_toolhive-registry-server_internal_config.ManagedConfig"
+                    },
+                    "syncPolicy": {
+                        "$ref": "#/components/schemas/github_com_stacklok_toolhive-registry-server_internal_config.SyncPolicyConfig"
                     }
                 },
                 "type": "object"
@@ -1213,15 +1358,6 @@
                         }
                     }
                 ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "object"
-                            }
-                        }
-                    }
-                },
                 "responses": {
                     "200": {
                         "content": {
@@ -1307,15 +1443,6 @@
                         }
                     }
                 ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "object"
-                            }
-                        }
-                    }
-                },
                 "responses": {
                     "200": {
                         "content": {
@@ -1410,15 +1537,6 @@
                         }
                     }
                 ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "object"
-                            }
-                        }
-                    }
-                },
                 "responses": {
                     "200": {
                         "content": {
@@ -1527,15 +1645,6 @@
                         }
                     }
                 ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "object"
-                            }
-                        }
-                    }
-                },
                 "responses": {
                     "200": {
                         "content": {
@@ -1617,15 +1726,6 @@
                         }
                     }
                 ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "object"
-                            }
-                        }
-                    }
-                },
                 "responses": {
                     "200": {
                         "content": {
@@ -1720,15 +1820,6 @@
                         }
                     }
                 ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "object"
-                            }
-                        }
-                    }
-                },
                 "responses": {
                     "200": {
                         "content": {
@@ -1832,15 +1923,6 @@
                         }
                     }
                 ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "object"
-                            }
-                        }
-                    }
-                },
                 "responses": {
                     "200": {
                         "content": {
@@ -2134,15 +2216,6 @@
                         }
                     }
                 ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "object"
-                            }
-                        }
-                    }
-                },
                 "responses": {
                     "204": {
                         "description": "No Content"
@@ -2230,15 +2303,6 @@
         "/v1/registries": {
             "get": {
                 "description": "List all registries",
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "object"
-                            }
-                        }
-                    }
-                },
                 "responses": {
                     "200": {
                         "content": {
@@ -2284,15 +2348,6 @@
                         }
                     }
                 ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "object"
-                            }
-                        }
-                    }
-                },
                 "responses": {
                     "204": {
                         "description": "Registry deleted"
@@ -2368,15 +2423,6 @@
                         }
                     }
                 ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "object"
-                            }
-                        }
-                    }
-                },
                 "responses": {
                     "200": {
                         "content": {
@@ -2450,10 +2496,21 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "type": "object"
+                                "oneOf": [
+                                    {
+                                        "type": "object"
+                                    },
+                                    {
+                                        "$ref": "#/components/schemas/github_com_stacklok_toolhive-registry-server_internal_service.RegistryCreateRequest",
+                                        "summary": "request",
+                                        "description": "Registry configuration"
+                                    }
+                                ]
                             }
                         }
-                    }
+                    },
+                    "description": "Registry configuration",
+                    "required": true
                 },
                 "responses": {
                     "200": {
@@ -2536,15 +2593,6 @@
                         }
                     }
                 ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "object"
-                            }
-                        }
-                    }
-                },
                 "responses": {
                     "200": {
                         "content": {
@@ -2605,15 +2653,6 @@
         "/v1/sources": {
             "get": {
                 "description": "List all sources",
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "object"
-                            }
-                        }
-                    }
-                },
                 "responses": {
                     "200": {
                         "content": {
@@ -2659,15 +2698,6 @@
                         }
                     }
                 ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "object"
-                            }
-                        }
-                    }
-                },
                 "responses": {
                     "204": {
                         "description": "Source deleted"
@@ -2756,15 +2786,6 @@
                         }
                     }
                 ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "object"
-                            }
-                        }
-                    }
-                },
                 "responses": {
                     "200": {
                         "content": {
@@ -2838,10 +2859,21 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "type": "object"
+                                "oneOf": [
+                                    {
+                                        "type": "object"
+                                    },
+                                    {
+                                        "$ref": "#/components/schemas/github_com_stacklok_toolhive-registry-server_internal_service.SourceCreateRequest",
+                                        "summary": "request",
+                                        "description": "Source configuration"
+                                    }
+                                ]
                             }
                         }
-                    }
+                    },
+                    "description": "Source configuration",
+                    "required": true
                 },
                 "responses": {
                     "200": {
@@ -2937,15 +2969,6 @@
                         }
                     }
                 ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "object"
-                            }
-                        }
-                    }
-                },
                 "responses": {
                     "200": {
                         "content": {

--- a/docs/thv-registry-api/swagger.yaml
+++ b/docs/thv-registry-api/swagger.yaml
@@ -1,5 +1,53 @@
 components:
   schemas:
+    github_com_stacklok_toolhive-registry-server_internal_config.APIConfig:
+      description: API endpoint source
+      properties:
+        endpoint:
+          description: |-
+            Endpoint is the base API URL (without path)
+            The registry handler will append the appropriate paths for the MCP Registry API v0.1:
+              - /v0.1/servers - List all servers
+              - /v0.1/servers/{name}/versions - List server versions
+              - /v0.1/servers/{name}/versions/{version} - Get specific version
+            Example: "http://my-registry-api.default.svc.cluster.local/registry"
+          type: string
+        timeout:
+          description: |-
+            Timeout is the per-request timeout for HTTP requests to the API endpoint
+            Accepts a Go duration string (e.g., "30s", "1m"); must be > 0 and <= 5m
+            Defaults to 10s if not specified
+            Useful for public or occasionally-slow upstreams where the default is too aggressive
+          type: string
+      type: object
+    github_com_stacklok_toolhive-registry-server_internal_config.FileConfig:
+      description: Local file or URL source
+      properties:
+        data:
+          description: |-
+            Data is the inline registry data as a JSON string
+            Mutually exclusive with Path and URL - exactly one must be specified
+            Useful for API-created registries where the data is provided directly
+          type: string
+        path:
+          description: |-
+            Path is the path to the registry.json file on the local filesystem
+            Can be absolute or relative to the working directory
+            Mutually exclusive with URL and Data - exactly one must be specified
+          type: string
+        timeout:
+          description: |-
+            Timeout is the timeout for HTTP requests when using URL
+            Defaults to 30s if not specified
+            Only applicable when URL is set
+          type: string
+        url:
+          description: |-
+            URL is the HTTP/HTTPS URL to fetch the registry file from
+            Mutually exclusive with Path and Data - exactly one must be specified
+            HTTPS is required unless the host is localhost or THV_REGISTRY_INSECURE_URL=true
+          type: string
+      type: object
     github_com_stacklok_toolhive-registry-server_internal_config.FilterConfig:
       description: Filtering rules
       properties:
@@ -7,6 +55,48 @@ components:
           $ref: '#/components/schemas/github_com_stacklok_toolhive-registry-server_internal_config.NameFilterConfig'
         tags:
           $ref: '#/components/schemas/github_com_stacklok_toolhive-registry-server_internal_config.TagFilterConfig'
+      type: object
+    github_com_stacklok_toolhive-registry-server_internal_config.GitAuthConfig:
+      description: Auth contains optional authentication for private repositories
+      properties:
+        passwordFile:
+          description: |-
+            PasswordFile is the path to a file containing the Git password/token
+            Must be an absolute path; whitespace is trimmed from the content
+          type: string
+        username:
+          description: Username is the Git username for HTTP Basic authentication
+          type: string
+      type: object
+    github_com_stacklok_toolhive-registry-server_internal_config.GitConfig:
+      description: Git repository source
+      properties:
+        auth:
+          $ref: '#/components/schemas/github_com_stacklok_toolhive-registry-server_internal_config.GitAuthConfig'
+        branch:
+          description: Branch is the Git branch to use (mutually exclusive with Tag
+            and Commit)
+          type: string
+        commit:
+          description: Commit is the Git commit SHA to use (mutually exclusive with
+            Branch and Tag)
+          type: string
+        path:
+          description: Path is the path to the registry file within the repository
+          type: string
+        repository:
+          description: Repository is the Git repository URL (HTTP/HTTPS/SSH)
+          type: string
+        tag:
+          description: Tag is the Git tag to use (mutually exclusive with Branch and
+            Commit)
+          type: string
+      type: object
+    github_com_stacklok_toolhive-registry-server_internal_config.KubernetesConfig:
+      description: Kubernetes discovery source
+      type: object
+    github_com_stacklok_toolhive-registry-server_internal_config.ManagedConfig:
+      description: Managed registry (no sync)
       type: object
     github_com_stacklok_toolhive-registry-server_internal_config.NameFilterConfig:
       properties:
@@ -36,6 +126,12 @@ components:
       - SourceTypeFile
       - SourceTypeManaged
       - SourceTypeKubernetes
+    github_com_stacklok_toolhive-registry-server_internal_config.SyncPolicyConfig:
+      description: Sync schedule configuration
+      properties:
+        interval:
+          type: string
+      type: object
     github_com_stacklok_toolhive-registry-server_internal_config.TagFilterConfig:
       properties:
         exclude:
@@ -70,6 +166,19 @@ components:
           type: string
         version:
           type: string
+      type: object
+    github_com_stacklok_toolhive-registry-server_internal_service.RegistryCreateRequest:
+      properties:
+        claims:
+          additionalProperties: {}
+          description: Authorization claims
+          type: object
+        sources:
+          description: ordered list of source names
+          items:
+            type: string
+          type: array
+          uniqueItems: false
       type: object
     github_com_stacklok_toolhive-registry-server_internal_service.RegistryEntriesResponse:
       properties:
@@ -205,6 +314,27 @@ components:
           type: string
         url:
           type: string
+      type: object
+    github_com_stacklok_toolhive-registry-server_internal_service.SourceCreateRequest:
+      properties:
+        api:
+          $ref: '#/components/schemas/github_com_stacklok_toolhive-registry-server_internal_config.APIConfig'
+        claims:
+          additionalProperties: {}
+          description: Authorization claims
+          type: object
+        file:
+          $ref: '#/components/schemas/github_com_stacklok_toolhive-registry-server_internal_config.FileConfig'
+        filter:
+          $ref: '#/components/schemas/github_com_stacklok_toolhive-registry-server_internal_config.FilterConfig'
+        git:
+          $ref: '#/components/schemas/github_com_stacklok_toolhive-registry-server_internal_config.GitConfig'
+        kubernetes:
+          $ref: '#/components/schemas/github_com_stacklok_toolhive-registry-server_internal_config.KubernetesConfig'
+        managed:
+          $ref: '#/components/schemas/github_com_stacklok_toolhive-registry-server_internal_config.ManagedConfig'
+        syncPolicy:
+          $ref: '#/components/schemas/github_com_stacklok_toolhive-registry-server_internal_config.SyncPolicyConfig'
       type: object
     github_com_stacklok_toolhive-registry-server_internal_service.SourceEntriesResponse:
       properties:
@@ -884,11 +1014,6 @@ paths:
         name: version
         schema:
           type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
       responses:
         "200":
           content:
@@ -942,11 +1067,6 @@ paths:
         required: true
         schema:
           type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
       responses:
         "200":
           content:
@@ -1007,11 +1127,6 @@ paths:
         required: true
         schema:
           type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
       responses:
         "200":
           content:
@@ -1078,11 +1193,6 @@ paths:
         name: cursor
         schema:
           type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
       responses:
         "200":
           content:
@@ -1133,11 +1243,6 @@ paths:
         required: true
         schema:
           type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
       responses:
         "200":
           content:
@@ -1196,11 +1301,6 @@ paths:
         required: true
         schema:
           type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
       responses:
         "200":
           content:
@@ -1265,11 +1365,6 @@ paths:
         required: true
         schema:
           type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
       responses:
         "200":
           content:
@@ -1450,11 +1545,6 @@ paths:
         required: true
         schema:
           type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
       responses:
         "204":
           description: No Content
@@ -1509,11 +1599,6 @@ paths:
   /v1/registries:
     get:
       description: List all registries
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
       responses:
         "200":
           content:
@@ -1542,11 +1627,6 @@ paths:
         required: true
         schema:
           type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
       responses:
         "204":
           description: Registry deleted
@@ -1594,11 +1674,6 @@ paths:
         required: true
         schema:
           type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
       responses:
         "200":
           content:
@@ -1646,7 +1721,13 @@ paths:
         content:
           application/json:
             schema:
-              type: object
+              oneOf:
+              - type: object
+              - $ref: '#/components/schemas/github_com_stacklok_toolhive-registry-server_internal_service.RegistryCreateRequest'
+                description: Registry configuration
+                summary: request
+        description: Registry configuration
+        required: true
       responses:
         "200":
           content:
@@ -1697,11 +1778,6 @@ paths:
         required: true
         schema:
           type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
       responses:
         "200":
           content:
@@ -1739,11 +1815,6 @@ paths:
   /v1/sources:
     get:
       description: List all sources
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
       responses:
         "200":
           content:
@@ -1772,11 +1843,6 @@ paths:
         required: true
         schema:
           type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
       responses:
         "204":
           description: Source deleted
@@ -1832,11 +1898,6 @@ paths:
         required: true
         schema:
           type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
       responses:
         "200":
           content:
@@ -1884,7 +1945,13 @@ paths:
         content:
           application/json:
             schema:
-              type: object
+              oneOf:
+              - type: object
+              - $ref: '#/components/schemas/github_com_stacklok_toolhive-registry-server_internal_service.SourceCreateRequest'
+                description: Source configuration
+                summary: request
+        description: Source configuration
+        required: true
       responses:
         "200":
           content:
@@ -1943,11 +2010,6 @@ paths:
         required: true
         schema:
           type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
       responses:
         "200":
           content:

--- a/internal/api/registry/v01/routes.go
+++ b/internal/api/registry/v01/routes.go
@@ -161,7 +161,6 @@ func (routes *Routes) handleListServers(w http.ResponseWriter, r *http.Request, 
 // @Summary		List servers in specific registry
 // @Description	Get a list of available servers from a specific registry
 // @Tags		registry
-// @Accept		json
 // @Produce		json
 // @Param		registryName	path	string	true	"Registry name"
 // @Param		cursor			query	string	false	"Pagination cursor for retrieving next set of results"
@@ -250,7 +249,6 @@ func (routes *Routes) handleListVersions(w http.ResponseWriter, r *http.Request,
 // @Summary		List all versions of an MCP server in specific registry
 // @Description	Returns all available versions for a specific MCP server from a specific registry
 // @Tags		registry
-// @Accept		json
 // @Produce		json
 // @Param		registryName	path	string	true	"Registry name"
 // @Param		serverName	path		string	true	"URL-encoded server name (e.g., \"com.example%2Fmy-server\")"
@@ -322,7 +320,6 @@ func (routes *Routes) handleGetVersion(w http.ResponseWriter, r *http.Request, r
 // @Description	Returns detailed information about a specific version of an MCP server from a specific registry.
 // @Description	Use the special version `latest` to get the latest version.
 // @Tags		registry
-// @Accept		json
 // @Produce		json
 // @Param		registryName	path		string	true	"Registry name"
 // @Param		serverName		path		string	true	"URL-encoded server name (e.g., \"com.example%2Fmy-server\")"

--- a/internal/api/v1/entries.go
+++ b/internal/api/v1/entries.go
@@ -119,7 +119,6 @@ func writePublishError(w http.ResponseWriter, r *http.Request, err error) {
 // @Summary		Delete published entry
 // @Description	Delete a published entry version
 // @Tags		v1
-// @Accept		json
 // @Produce		json
 // @Param		type	path	string	true	"Entry Type (server or skill)"
 // @Param		name	path	string	true	"Entry Name"

--- a/internal/api/v1/registries.go
+++ b/internal/api/v1/registries.go
@@ -20,7 +20,6 @@ type registryListResponse struct {
 // @Summary		List registries
 // @Description	List all registries
 // @Tags		v1
-// @Accept		json
 // @Produce		json
 // @Success		200	{object}	registryListResponse	"Registries list"
 // @Failure		500	{object}	map[string]string		"Internal server error"
@@ -41,7 +40,6 @@ func (routes *Routes) listRegistries(w http.ResponseWriter, r *http.Request) {
 // @Summary		Get registry
 // @Description	Get a registry by name
 // @Tags		v1
-// @Accept		json
 // @Produce		json
 // @Param		name	path		string					true	"Registry Name"
 // @Success		200		{object}	service.RegistryInfo	"Registry details"
@@ -73,6 +71,7 @@ func (routes *Routes) getRegistry(w http.ResponseWriter, r *http.Request) {
 // @Accept		json
 // @Produce		json
 // @Param		name	path		string					true	"Registry Name"
+// @Param		request	body		service.RegistryCreateRequest	true	"Registry configuration"
 // @Success		200		{object}	service.RegistryInfo	"Registry updated"
 // @Success		201		{object}	service.RegistryInfo	"Registry created"
 // @Failure		400		{object}	map[string]string		"Bad request"
@@ -118,7 +117,6 @@ func (routes *Routes) upsertRegistry(w http.ResponseWriter, r *http.Request) {
 // @Summary		Delete registry
 // @Description	Delete a registry by name
 // @Tags		v1
-// @Accept		json
 // @Produce		json
 // @Param		name	path	string	true	"Registry Name"
 // @Success		204	"Registry deleted"
@@ -147,7 +145,6 @@ func (routes *Routes) deleteRegistry(w http.ResponseWriter, r *http.Request) {
 // @Summary		List registry entries
 // @Description	List all entries for a registry
 // @Tags		v1
-// @Accept		json
 // @Produce		json
 // @Param		name	path		string							true	"Registry Name"
 // @Success		200		{object}	service.RegistryEntriesResponse	"Registry entries"

--- a/internal/api/v1/sources.go
+++ b/internal/api/v1/sources.go
@@ -15,7 +15,6 @@ import (
 // @Summary		List sources
 // @Description	List all sources
 // @Tags		v1
-// @Accept		json
 // @Produce		json
 // @Success		200	{object}	service.SourceListResponse	"Sources list"
 // @Failure		500	{object}	map[string]string			"Internal server error"
@@ -36,7 +35,6 @@ func (routes *Routes) listSources(w http.ResponseWriter, r *http.Request) {
 // @Summary		Get source
 // @Description	Get a source by name
 // @Tags		v1
-// @Accept		json
 // @Produce		json
 // @Param		name	path		string				true	"Source Name"
 // @Success		200		{object}	service.SourceInfo	"Source details"
@@ -68,6 +66,7 @@ func (routes *Routes) getSource(w http.ResponseWriter, r *http.Request) {
 // @Accept		json
 // @Produce		json
 // @Param		name	path		string				true	"Source Name"
+// @Param		request	body		service.SourceCreateRequest	true	"Source configuration"
 // @Success		200		{object}	service.SourceInfo	"Source updated"
 // @Success		201		{object}	service.SourceInfo	"Source created"
 // @Failure		400		{object}	map[string]string	"Bad request"
@@ -114,7 +113,6 @@ func (routes *Routes) upsertSource(w http.ResponseWriter, r *http.Request) {
 // @Summary		Delete source
 // @Description	Delete a source by name
 // @Tags		v1
-// @Accept		json
 // @Produce		json
 // @Param		name	path	string	true	"Source Name"
 // @Success		204	"Source deleted"
@@ -144,7 +142,6 @@ func (routes *Routes) deleteSource(w http.ResponseWriter, r *http.Request) {
 // @Summary		List source entries
 // @Description	List all entries for a source
 // @Tags		v1
-// @Accept		json
 // @Produce		json
 // @Param		name	path		string						true	"Source Name"
 // @Success		200		{object}	service.SourceEntriesResponse	"Source entries"

--- a/internal/api/x/skills/routes.go
+++ b/internal/api/x/skills/routes.go
@@ -47,7 +47,6 @@ type Routes struct {
 // @Summary		List skills in registry
 // @Description	List skills in a registry (paginated, latest versions).
 // @Tags		skills
-// @Accept		json
 // @Produce		json
 // @Param		registryName	path		string	true	"Registry name"
 // @Param		search		query		string	false	"Filter by name/description substring"
@@ -108,7 +107,6 @@ func (routes *Routes) listSkills(w http.ResponseWriter, r *http.Request) {
 // @Summary		Get latest skill version
 // @Description	Get the latest version of a skill by namespace and name.
 // @Tags		skills
-// @Accept		json
 // @Produce		json
 // @Param		registryName	path		string	true	"Registry name"
 // @Param		namespace	path		string	true	"Skill namespace (reverse-DNS)"
@@ -160,7 +158,6 @@ func (routes *Routes) getLatestVersion(w http.ResponseWriter, r *http.Request) {
 // @Summary		List skill versions
 // @Description	List all versions of a skill.
 // @Tags		skills
-// @Accept		json
 // @Produce		json
 // @Param		registryName	path		string	true	"Registry name"
 // @Param		namespace	path		string	true	"Skill namespace (reverse-DNS)"
@@ -219,7 +216,6 @@ func (routes *Routes) listVersions(w http.ResponseWriter, r *http.Request) {
 // @Summary		Get specific skill version
 // @Description	Get a specific version of a skill.
 // @Tags		skills
-// @Accept		json
 // @Produce		json
 // @Param		registryName	path		string	true	"Registry name"
 // @Param		namespace	path		string	true	"Skill namespace (reverse-DNS)"


### PR DESCRIPTION
## Summary

The generated OpenAPI spec misrepresented request bodies in two ways, which is why write endpoints rendered as bare `type: object` and read endpoints showed spurious bodies.

**1. Missing body schemas on the upsert endpoints.** `PUT /v1/sources/{name}` and `PUT /v1/registries/{name}` had no `@Param ... body` annotation, so swag emitted an empty `requestBody: {schema: {type: object}}` with no properties. This PR adds body params referencing `service.SourceCreateRequest` and `service.RegistryCreateRequest`, which pulls the full source/registry config schema into the spec, including the `api.timeout` field added in #844.

**2. Spurious request bodies on read endpoints.** Every GET handler (and the DELETE handlers) carried a stray `@Accept json`, which swag turns into an empty request body on operations that don't consume one. Dropped `@Accept json` from all GET and DELETE handlers; it now appears only on the four operations that actually take a JSON body (`POST /v1/entries`, `PUT /v1/entries/{type}/{name}/claims`, and the two upserts).

## Effect on the spec

- `requestBody` blocks dropped from ~20 down to the 4 real ones.
- `PUT /v1/sources/{name}` and `PUT /v1/registries/{name}` now reference `SourceCreateRequest` / `RegistryCreateRequest`, so the rendered schema shows git/api/file/managed/kubernetes config (and `api.timeout`).
- GET/DELETE operations no longer show a request body.

## Notes

- No handler behavior changes; this is annotations plus the regenerated spec (`task docs`).
- The `oneOf: [type: object, $ref]` wrapper swag emits around body schemas is a pre-existing v3.1 quirk (the entries endpoints already had it) and is left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)