### PR TITLE
Gate publishing on the managed source's claims

### DIFF
--- a/.claude/rules/auth.md
+++ b/.claude/rules/auth.md
@@ -129,9 +129,10 @@ every claim-bearing caller. Two recovery paths:
   `PUT /v1/entries/{type}/{name}/claims` (or the equivalent source/registry endpoints).
 - **Operator-managed sources**: tag the managed source itself with a tenant-wide claim
   (e.g. `{org: "acme"}`) in config so writers can reference it; otherwise no
-  non-super-admin caller can publish to it. This is the most common stumbling block when
-  enabling authz on an existing deployment — forgetting to tag the managed source looks
-  like a permissions bug at publish time.
+  non-super-admin caller can publish to it (enforced by the publish source-claims gate —
+  §5). This is the most common stumbling block when enabling authz on an existing
+  deployment — forgetting to tag the managed source looks like a permissions bug at
+  publish time.
 
 There is intentionally no automatic "backfill claims from JWT" path — that would
 re-introduce the "empty = the caller's identity" behavior that this rule rejects.
@@ -161,6 +162,9 @@ list, get, and delete paths agree (§4).
 - Source/registry/entry read, delete
 - The "cover current claims" check on update
 - Covering each referenced source's claims when creating/updating a registry
+- Publishing into the managed source — the caller must cover the *source's* claims
+  (§4; #845), in addition to the entry-claims subset check above. An untagged managed
+  source is therefore publishable only by super-admin (default-deny).
 
 **Detect**: a create/update/publish handler that doesn't call `validateClaimsSubset` on its
 incoming request claims; a read/delete/gate that calls `validateClaimsSubset` instead of a

--- a/internal/service/db/impl_mcp.go
+++ b/internal/service/db/impl_mcp.go
@@ -581,6 +581,7 @@ func getManagedSource(ctx context.Context, querier *sqlc.Queries) (*sqlc.Source,
 		Name:         row.Name,
 		SourceType:   row.SourceType,
 		CreationType: row.CreationType,
+		Claims:       row.Claims,
 		CreatedAt:    row.CreatedAt,
 		UpdatedAt:    row.UpdatedAt,
 	}, nil
@@ -647,7 +648,7 @@ func (s *dbService) PublishServerVersion(
 	}
 
 	// Execute the publish operation in a transaction
-	sourceName, err := s.executePublishTransaction(ctx, serverData, claimsJSON)
+	sourceName, err := s.executePublishTransaction(ctx, serverData, claimsJSON, gateClaims)
 	if err != nil {
 		otel.RecordError(span, err)
 		return nil, err
@@ -712,6 +713,7 @@ func (s *dbService) executePublishTransaction(
 	ctx context.Context,
 	serverData *upstreamv0.ServerJSON,
 	claimsJSON []byte,
+	gateClaims map[string]any,
 ) (string, error) {
 	// Begin transaction
 	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{
@@ -733,6 +735,13 @@ func (s *dbService) executePublishTransaction(
 	// Find the managed source automatically
 	source, err := getManagedSource(ctx, querier)
 	if err != nil {
+		return "", err
+	}
+
+	// Verify the caller may publish into this source: their JWT must cover the
+	// source's claims (visibility / OR — auth.md §3/§5). An untagged managed
+	// source is publishable only by super-admin (default-deny, #845).
+	if err := validateClaimsVisibleBytes(ctx, gateClaims, source.Claims); err != nil {
 		return "", err
 	}
 

--- a/internal/service/db/impl_skills.go
+++ b/internal/service/db/impl_skills.go
@@ -354,7 +354,7 @@ func (s *dbService) PublishSkill(
 		}
 	}
 
-	sourceName, err := s.executePublishSkillTransaction(ctx, skill, claimsJSON)
+	sourceName, err := s.executePublishSkillTransaction(ctx, skill, claimsJSON, gateClaims)
 	if err != nil {
 		otel.RecordError(span, err)
 		return nil, err
@@ -439,6 +439,7 @@ func (s *dbService) executePublishSkillTransaction(
 	ctx context.Context,
 	skill *service.Skill,
 	claimsJSON []byte,
+	gateClaims map[string]any,
 ) (string, error) {
 	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{
 		IsoLevel:   pgx.Serializable,
@@ -458,6 +459,13 @@ func (s *dbService) executePublishSkillTransaction(
 
 	managedSource, err := getManagedSource(ctx, querier)
 	if err != nil {
+		return "", err
+	}
+
+	// Verify the caller may publish into this source: their JWT must cover the
+	// source's claims (visibility / OR — auth.md §3/§5). An untagged managed
+	// source is publishable only by super-admin (default-deny, #845).
+	if err := validateClaimsVisibleBytes(ctx, gateClaims, managedSource.Claims); err != nil {
 		return "", err
 	}
 	sourceName := managedSource.Name

--- a/internal/service/db/publish_claims_test.go
+++ b/internal/service/db/publish_claims_test.go
@@ -8,12 +8,25 @@ import (
 	upstreamv0 "github.com/modelcontextprotocol/registry/pkg/api/v0"
 	"github.com/stretchr/testify/require"
 
+	"github.com/stacklok/toolhive-registry-server/internal/auth"
+	"github.com/stacklok/toolhive-registry-server/internal/db"
 	"github.com/stacklok/toolhive-registry-server/internal/db/sqlc"
 	"github.com/stacklok/toolhive-registry-server/internal/service"
 )
 
-// createManagedSource is a helper that creates a managed source for publish tests.
+// createManagedSource creates a managed source tagged with the default test
+// claims ({org: acme}). Publishing now gates on the source's claims (#845), so
+// the source must carry a claim the publisher's JWT covers; every publish setup
+// in these tests uses an org:acme (or nil) JWT. Use createManagedSourceWithClaims
+// to control the source's claims explicitly.
 func createManagedSource(t *testing.T, svc *dbService, name string) {
+	t.Helper()
+	createManagedSourceWithClaims(t, svc, name, map[string]any{"org": "acme"})
+}
+
+// createManagedSourceWithClaims creates a managed source with the given claims
+// (pass nil for an untagged source).
+func createManagedSourceWithClaims(t *testing.T, svc *dbService, name string, claims map[string]any) {
 	t.Helper()
 
 	ctx := context.Background()
@@ -24,13 +37,22 @@ func createManagedSource(t *testing.T, svc *dbService, name string) {
 		CreationType: sqlc.CreationTypeCONFIG,
 		SourceType:   "managed",
 		Syncable:     false,
+		Claims:       db.SerializeClaims(claims),
 	})
 	require.NoError(t, err)
 }
 
-// createManagedSourceWithRegistry creates a managed source and a registry linked to it.
-// This is needed for skill operations which require a registry.
+// createManagedSourceWithRegistry creates a managed source (tagged {org: acme})
+// and a registry linked to it. This is needed for skill operations which require
+// a registry.
 func createManagedSourceWithRegistry(t *testing.T, svc *dbService, name string) {
+	t.Helper()
+	createManagedSourceWithRegistryClaims(t, svc, name, map[string]any{"org": "acme"})
+}
+
+// createManagedSourceWithRegistryClaims is createManagedSourceWithRegistry with
+// explicit source claims (pass nil for an untagged source).
+func createManagedSourceWithRegistryClaims(t *testing.T, svc *dbService, name string, claims map[string]any) {
 	t.Helper()
 
 	ctx := context.Background()
@@ -41,6 +63,7 @@ func createManagedSourceWithRegistry(t *testing.T, svc *dbService, name string) 
 		CreationType: sqlc.CreationTypeCONFIG,
 		SourceType:   "managed",
 		Syncable:     false,
+		Claims:       db.SerializeClaims(claims),
 	})
 	require.NoError(t, err)
 
@@ -135,6 +158,188 @@ func TestPublishServerVersion_ClaimsSubset(t *testing.T) {
 				require.NoError(t, err)
 				require.NotNil(t, result)
 				require.Equal(t, "1.0.0", result.Version)
+			}
+		})
+	}
+}
+
+// TestPublishServerVersion_SourceClaimsGate covers #845: publishing must also
+// verify the caller's JWT covers the managed source's claims (visibility / OR),
+// independent of the entry-claims subset check.
+func TestPublishServerVersion_SourceClaimsGate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		slug         string
+		sourceClaims map[string]any
+		entryClaims  map[string]any
+		jwtClaims    map[string]any
+		superAdmin   bool
+		wantErr      error
+	}{
+		{
+			name:         "caller covers source claims succeeds",
+			slug:         "covered",
+			sourceClaims: map[string]any{"org": "acme"},
+			entryClaims:  map[string]any{"org": "acme"},
+			jwtClaims:    map[string]any{"org": "acme", "team": "eng"},
+			wantErr:      nil,
+		},
+		{
+			name:         "caller does not cover source claims returns ErrClaimsInsufficient",
+			slug:         "uncovered",
+			sourceClaims: map[string]any{"org": "acme"},
+			entryClaims:  map[string]any{"org": "contoso"},
+			jwtClaims:    map[string]any{"org": "contoso"},
+			wantErr:      service.ErrClaimsInsufficient,
+		},
+		{
+			name:         "untagged source denies claim-bearing caller (default-deny)",
+			slug:         "untagged",
+			sourceClaims: nil,
+			entryClaims:  map[string]any{"org": "acme"},
+			jwtClaims:    map[string]any{"org": "acme"},
+			wantErr:      service.ErrClaimsInsufficient,
+		},
+		{
+			name:         "untagged source with nil JWT (anonymous/skipAuthz) succeeds",
+			slug:         "untagged-anon",
+			sourceClaims: nil,
+			entryClaims:  map[string]any{"org": "acme"},
+			jwtClaims:    nil,
+			wantErr:      nil,
+		},
+		{
+			name:         "caller shares one value of source array claim succeeds (OR)",
+			slug:         "array-or",
+			sourceClaims: map[string]any{"org": "acme", "team": []any{"platform", teamDataClaim}},
+			entryClaims:  map[string]any{"org": "acme", "team": "platform"},
+			jwtClaims:    map[string]any{"org": "acme", "team": "platform"},
+			wantErr:      nil,
+		},
+		{
+			name:         "super-admin bypasses source claims gate",
+			slug:         "superadmin",
+			sourceClaims: map[string]any{"org": "acme"},
+			entryClaims:  map[string]any{"org": "contoso"},
+			jwtClaims:    map[string]any{"org": "contoso"},
+			superAdmin:   true,
+			wantErr:      nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			svc, cleanup := setupTestService(t)
+			defer cleanup()
+
+			createManagedSourceWithClaims(t, svc, "pubsrc-"+tt.slug, tt.sourceClaims)
+
+			ctx := context.Background()
+			if tt.superAdmin {
+				ctx = auth.ContextWithRoles(ctx, []auth.Role{auth.RoleSuperAdmin})
+			}
+
+			opts := []service.Option{
+				service.WithServerData(&upstreamv0.ServerJSON{
+					Name:    "com.test/pubsrc-" + tt.slug,
+					Version: "1.0.0",
+				}),
+			}
+			if tt.entryClaims != nil {
+				opts = append(opts, service.WithClaims(tt.entryClaims))
+			}
+			if tt.jwtClaims != nil {
+				opts = append(opts, service.WithJWTClaims(tt.jwtClaims))
+			}
+
+			result, err := svc.PublishServerVersion(ctx, opts...)
+
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+				require.Nil(t, result)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, result)
+			}
+		})
+	}
+}
+
+// TestPublishSkill_SourceClaimsGate is the skill counterpart of the #845 gate.
+func TestPublishSkill_SourceClaimsGate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		slug         string
+		sourceClaims map[string]any
+		entryClaims  map[string]any
+		jwtClaims    map[string]any
+		wantErr      error
+	}{
+		{
+			name:         "caller covers source claims succeeds",
+			slug:         "covered",
+			sourceClaims: map[string]any{"org": "acme"},
+			entryClaims:  map[string]any{"org": "acme"},
+			jwtClaims:    map[string]any{"org": "acme", "team": "eng"},
+			wantErr:      nil,
+		},
+		{
+			name:         "caller does not cover source claims returns ErrClaimsInsufficient",
+			slug:         "uncovered",
+			sourceClaims: map[string]any{"org": "acme"},
+			entryClaims:  map[string]any{"org": "contoso"},
+			jwtClaims:    map[string]any{"org": "contoso"},
+			wantErr:      service.ErrClaimsInsufficient,
+		},
+		{
+			name:         "untagged source denies claim-bearing caller (default-deny)",
+			slug:         "untagged",
+			sourceClaims: nil,
+			entryClaims:  map[string]any{"org": "acme"},
+			jwtClaims:    map[string]any{"org": "acme"},
+			wantErr:      service.ErrClaimsInsufficient,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			svc, cleanup := setupTestService(t)
+			defer cleanup()
+
+			createManagedSourceWithRegistryClaims(t, svc, "pubskill-"+tt.slug, tt.sourceClaims)
+
+			ctx := context.Background()
+			skill := &service.Skill{
+				Namespace: "com.test",
+				Name:      "pubskill-" + tt.slug,
+				Version:   "1.0.0",
+				Title:     "Test Skill",
+			}
+
+			opts := []service.Option{}
+			if tt.entryClaims != nil {
+				opts = append(opts, service.WithClaims(tt.entryClaims))
+			}
+			if tt.jwtClaims != nil {
+				opts = append(opts, service.WithJWTClaims(tt.jwtClaims))
+			}
+
+			result, err := svc.PublishSkill(ctx, skill, opts...)
+
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+				require.Nil(t, result)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, result)
 			}
 		})
 	}


### PR DESCRIPTION
## What

Fixes #845: publishing into the managed source now requires the caller's JWT to cover the **source's** claims — not just the entry's claims.

> ⚠️ **Stacked on #848** (base branch `rdimitrov/validate-issue-843`). It builds on the `validateClaimsVisible*` helpers introduced there. Review/merge #848 first; this will retarget to `main` afterward.

## Why

`POST /v1/entries` was gated by the `manageEntries` role and an **entry-claims ⊆ JWT** check, but nothing validated the managed source's own claims (`getManagedSource` even discarded the `Claims` field). `auth.md` §4 already stated the intended behavior — *"tag the managed source … otherwise no non-super-admin caller can publish to it"* — so the code was the outlier.

**The gap:** entry claims are subset-validated, so a `contoso` writer can't create an `{org:acme}` entry — but they *could* publish an `{org:contoso}` entry **into acme's shared managed source**, squatting names in the first-come-first-served namespace. This closes that cross-tenant hole.

## Change

- `getManagedSource` now populates `Claims` (previously dropped).
- Server + skill publish transactions add a **visibility check** (caller JWT must cover the source's claims — OR-within-array, `auth.md` §3), mirroring how `resolveSourceIDsWithGate` gates referencing a source.
- An **untagged** managed source is now publishable only by super-admin (default-deny, §4).
- Docs: `auth.md` §4/§5 updated.

## Scope: publish only (deliberate)

Delete and update-claims are **not** changed — they already gate on the *entry's* own claims (`validateClaimsVisibleBytes(existing.Claims)`), which for a published entry is the meaningful per-entry authorization. Adding a redundant source-claims check there isn't necessary. Publish is the actual gap (no entry exists yet to gate on).

## Semantics: visibility (OR), not subset (AND)

The check compares the caller against the source's **existing** claims, so per the #848 taxonomy it's the **visibility** direction (OR-within-array) — consistent with referencing a source. (The issue tentatively assumed subset/AND; visibility keeps it uniform with every other existing-claims gate.)

## ⚠️ Behavior change / migration note

A managed source with **no claims**, running with authz on, becomes **super-admin-only for publishing**. This is exactly what `auth.md` §4 prescribes (unlabeled ≠ public), but it will affect existing deployments that ran with an untagged managed source. Recovery: tag the managed source with a tenant-wide claim (e.g. `{org: "acme"}`) in config. This is a maintainer-facing decision — the issue explicitly flagged "fix code vs fix spec"; this PR is the "fix code" proposal.

## Testing

- New `TestPublish{Server,Skill}Version_SourceClaimsGate` (integration): covered / not-covered / untagged-default-deny / nil-JWT-bypass / array-OR / super-admin-bypass
- Existing publish/delete/get/update claim tests updated (managed source now tagged `{org:acme}`) — all green
- Full `internal/service/db` + `internal/authz` integration suites pass (real Postgres); `go vet`, `gofmt`, `golangci-lint` clean

Fixes #845

🤖 Generated with [Claude Code](https://claude.com/claude-code)