### PR TITLE
Add lazy tools/list discovery for Kubernetes sources

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,14 @@ See [README.md](README.md#development) for complete build and development docume
 - `task lint-fix` - **Preferred** linting (auto-fixes issues)
 - `task test` - Run tests
 - `task gen` - Generate mocks (run before testing)
+- `task docs` - Regenerate OpenAPI spec (run after adding/changing Swagger annotations)
 - `task all` - Lint, test, and build
+
+**Run a single package or test:**
+```sh
+task test PACKAGES=./internal/api/v1/...
+go test -run TestFooBar ./internal/service/db/...
+```
 
 ## Code Architecture
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -34,6 +34,8 @@ tasks:
 
   install-sqlc:
     desc: Install the sqlc tool for generating database code
+    status:
+      - sqlc version 2>/dev/null | grep -q 'v1.30.0'
     cmds:
       - go install github.com/sqlc-dev/sqlc/cmd/sqlc@v1.30.0
 
@@ -65,9 +67,9 @@ tasks:
   install-golangci-lint:
     desc: Install the golangci-lint tool for linting
     status:
-      - which golangci-lint
+      - golangci-lint version 2>/dev/null | grep -q 'version v2'
     cmds:
-      - go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+      - go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
 
   install-deadcode:
     desc: Install the deadcode tool for checking for unused code

--- a/deploy/charts/toolhive-registry-server/values.yaml
+++ b/deploy/charts/toolhive-registry-server/values.yaml
@@ -206,6 +206,19 @@ config:
 #     # - name: k8s-mcp
 #     #   kubernetes:
 #     #     namespaces: ["mcp-prod"]
+#     #     discoverTimeout: "10s"
+#     #     # Optional: OAuth2 client_credentials grant for lazy tools/list discovery.
+#     #     # Registry-server obtains Bearer tokens from this IdP and attaches them to
+#     #     # MCP tools/list calls, which lets it query proxies that enforce Cedar auth.
+#     #     # The client secret is mounted as a file — never embedded inline.
+#     #     # discoverOAuth2:
+#     #     #   tokenUrl: https://keycloak.example.com/realms/toolhive/protocol/openid-connect/token
+#     #     #   clientId: registry-server-discovery
+#     #     #   clientSecretFile: /var/run/secrets/toolhive/discover-oauth2/client-secret
+#     #     #   scopes: ["mcp.discover"]
+#     #     #   # audience: registry-server              # optional (Auth0-style)
+#     #     #   # endpointParams:                       # optional extra token endpoint params
+#     #     #   #   resource: https://mcp.example
 #     #   # Per-entry claims set via toolhive.stacklok.dev/authz-claims JSON annotation on CRDs
 #
 #   registries:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -238,6 +238,19 @@ Discover MCP servers from Kubernetes deployments.
 kubernetes:
   namespaces:                    # Optional: specific namespaces to watch
     - default
+  discoverTimeout: "10s"         # Optional: per-server MCP tools/list timeout
+  # Optional: OAuth2 client_credentials for authenticated lazy tools/list discovery.
+  # Required when the MCP proxies fronting the workloads enforce Cedar authorization —
+  # anonymous tools/list would be denied. Registry-server obtains a Bearer token from
+  # this IdP and attaches it to tools/list requests.
+  discoverOAuth2:
+    tokenUrl: https://keycloak.example.com/realms/toolhive/protocol/openid-connect/token
+    clientId: registry-server-discovery
+    clientSecretFile: /var/run/secrets/toolhive/discover-oauth2/client-secret
+    scopes: ["mcp.discover"]
+    # audience: registry-server              # optional (Auth0-style)
+    # endpointParams:                        # optional extra token endpoint params
+    #   resource: https://mcp.example
 ```
 
 **Fields:**
@@ -245,6 +258,23 @@ kubernetes:
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `namespaces` | array | No | Kubernetes namespaces to watch (empty = uses `THV_REGISTRY_WATCH_NAMESPACE` env var) |
+| `discoverTimeout` | string | No | Per-server timeout for lazy MCP `tools/list` discovery calls (default `10s`) |
+| `discoverOAuth2` | object | No | OAuth2 client_credentials config for authenticated `tools/list` discovery — see below |
+
+**`discoverOAuth2` fields:**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `tokenUrl` | string | Yes | OAuth2 token endpoint. Must be HTTPS unless host is loopback or `THV_REGISTRY_INSECURE_URL=true` |
+| `clientId` | string | Yes | OAuth2 client identifier |
+| `clientSecretFile` | string | Yes | Absolute path to a file containing the client secret. Symlinks are resolved (`filepath.EvalSymlinks`) before reading. Env vars are not accepted here — mount the secret as a file (Kubernetes Secret volume) per [`secrets.md`](../.claude/rules/secrets.md) §1 |
+| `scopes` | array | No | OAuth2 scopes to request |
+| `audience` | string | No | Sent as an `audience` token-endpoint parameter (Auth0-style) |
+| `endpointParams` | object | No | Additional token-endpoint parameters merged into the request body |
+
+The client secret is transmitted in the token request body (`AuthStyleInParams`). Tokens
+are cached and reused until expiry by the OAuth2 client (`clientcredentials.Config.TokenSource`).
+When `discoverOAuth2` is omitted, discovery runs anonymously (no `Authorization` header).
 
 **Per-entry claims:** CRDs can carry per-entry authorization claims via the
 `toolhive.stacklok.dev/authz-claims` JSON annotation. The annotation value uses the same

--- a/docs/lazy-tool-discovery.md
+++ b/docs/lazy-tool-discovery.md
@@ -1,0 +1,228 @@
+# Lazy Tool Discovery
+
+When a `MCPServer`, `VirtualMCPServer`, or `MCPRemoteProxy` CRD is exported to the
+registry (via `toolhive.stacklok.dev/registry-export: "true"`) but carries no
+`toolhive.stacklok.dev/tool-definitions` annotation, the registry-server controller
+automatically connects to the proxy's Service URL and calls `tools/list` to discover the
+tool set at reconcile time. The result is written directly to the database; no Kubernetes
+patch is performed and no new RBAC is required.
+
+---
+
+## How it works
+
+Discovery is triggered per-CRD during the normal reconcile loop:
+
+1. The controller extracts the `registry-url` annotation as the connection target.
+2. If `tool-definitions` is **absent** and `registry-url` is present, `discoverTools` is
+   called with the configured timeout and optional OAuth2 `TokenSource`.
+3. `discoverTools` attempts a Streamable-HTTP MCP connection, falls back to SSE, performs
+   the MCP handshake, and calls `ListTools`.
+4. Non-empty results are stored in `extensions.ToolDefinitions` and persisted via the sync
+   writer. Any failure (connection error, empty list, token error) logs a warning and
+   leaves `ToolDefinitions` empty — the entry is still registered, and discovery retries
+   on the next reconcile.
+
+### Decision table
+
+| `tool-definitions` annotation | `registry-url` annotation | Source of `ToolDefinitions` |
+|:---:|:---:|---|
+| ✅ present | any | annotation value used directly — lazy discovery **not triggered** |
+| ❌ absent | ✅ present | **lazy discovery** — `tools/list` called at reconcile time |
+| ❌ absent | ❌ absent | empty — no HTTP connection |
+
+The `tools` annotation (name-only list) is independent and unaffected by lazy discovery.
+
+---
+
+## OAuth2 authentication
+
+Production MCP proxies typically enforce Cedar authorization. Anonymous `tools/list`
+requests are rejected with 401. To authenticate, configure an OAuth2
+`client_credentials` grant under the `kubernetes` source:
+
+```yaml
+sources:
+  - name: k8s-source
+    kubernetes:
+      namespaces: ["toolhive-system"]
+      discoverTimeout: "15s"
+      discoverOAuth2:
+        tokenUrl: https://keycloak.example.com/realms/toolhive/protocol/openid-connect/token
+        clientId: registry-server-discovery
+        clientSecretFile: /var/run/secrets/toolhive/discover-oauth2/client-secret
+        scopes: ["openid"]
+        # audience: registry-server       # optional (Auth0-style)
+        # endpointParams:                 # optional extra token endpoint params
+        #   resource: https://mcp.example
+```
+
+The `clientSecretFile` must be an **absolute path** to a file containing the secret
+(symlinks are resolved via `filepath.EvalSymlinks`). Tokens are cached and reused until
+expiry by `golang.org/x/oauth2/clientcredentials`.
+
+When `discoverOAuth2` is omitted, discovery runs anonymously (no `Authorization` header).
+
+### Keycloak setup (example)
+
+1. Create a confidential client `registry-server-discovery` with `client_credentials`
+   grant enabled.
+2. Create a Protocol Mapper: **User Attribute → roles**, Token Claim Name **`roles`**
+   (not `claim_roles` — the ToolHive proxy prefixes claims with `claim_`, so the Cedar
+   attribute becomes `claim_roles`).
+3. Assign the client a service account role that the Cedar policy allows for
+   `tools/list` discovery.
+4. Mount the client secret as a Kubernetes `Secret` volume at the path given in
+   `clientSecretFile`.
+
+> **Note on the `claim_X` convention**: The ToolHive proxy maps JWT claim `X` to Cedar
+> entity attribute `claim_X`. Therefore the Protocol Mapper Token Claim Name must be the
+> bare claim name (e.g. `roles`), not the prefixed form (e.g. `claim_roles`), to avoid
+> a double-prefix (`claim_claim_roles`) that Cedar policies do not match.
+
+---
+
+## Configuration reference
+
+### `discoverOAuth2` fields
+
+| Field | Type | Required | Description |
+|-------|------|:--------:|-------------|
+| `tokenUrl` | string | **Yes** | OAuth2 token endpoint URL |
+| `clientId` | string | **Yes** | OAuth2 client identifier |
+| `clientSecretFile` | string | **Yes** | Absolute path to the file containing the client secret |
+| `scopes` | []string | No | OAuth2 scopes to request |
+| `audience` | string | No | `audience` parameter sent to the token endpoint (Auth0-style) |
+| `endpointParams` | map[string]string | No | Additional token-endpoint parameters |
+
+### `discoverTimeout`
+
+Per-server timeout for the `tools/list` call (default `10s`). Set higher if proxies are
+slow to initialize.
+
+---
+
+## Kubernetes deployment (Helm)
+
+Mount the client secret as a volume and reference it via `clientSecretFile`:
+
+```yaml
+# values.yaml
+config:
+  sources:
+    - name: k8s-source
+      kubernetes:
+        namespaces: ["toolhive-system"]
+        discoverTimeout: "15s"
+        discoverOAuth2:
+          tokenUrl: https://keycloak.example.com/realms/toolhive/protocol/openid-connect/token
+          clientId: registry-server-discovery
+          clientSecretFile: /var/run/secrets/toolhive/discover-oauth2/client-secret
+          scopes: ["openid"]
+
+extraVolumes:
+  - name: discover-oauth2
+    secret:
+      secretName: registry-discovery-oauth2
+      items:
+        - key: client-secret
+          path: client-secret
+
+extraVolumeMounts:
+  - name: discover-oauth2
+    mountPath: /var/run/secrets/toolhive/discover-oauth2
+    readOnly: true
+```
+
+Create the Kubernetes Secret:
+
+```bash
+kubectl create secret generic registry-discovery-oauth2 \
+  --from-literal=client-secret=<your-client-secret> \
+  -n toolhive-system
+```
+
+If the proxy enforces an HTTP (non-TLS) issuer URL in development, set:
+
+```yaml
+extraEnv:
+  - name: THV_REGISTRY_INSECURE_URL
+    value: "true"
+```
+
+---
+
+## Workload annotations reference
+
+All three CRD types (`MCPServer`, `VirtualMCPServer`, `MCPRemoteProxy`) support:
+
+| Annotation | Required | Description |
+|------------|:--------:|-------------|
+| `toolhive.stacklok.dev/registry-export` | **Yes** | Must be `"true"` to include in the registry |
+| `toolhive.stacklok.dev/registry-url` | **Yes** | Proxy Service endpoint URL (also the lazy discovery target) |
+| `toolhive.stacklok.dev/registry-description` | **Yes** | Description shown in the registry listing |
+| `toolhive.stacklok.dev/registry-title` | No | Human-readable display name |
+| `toolhive.stacklok.dev/registry-icon` | No | Icon URL |
+| `toolhive.stacklok.dev/registry-category` | No | Category tag for grouping and filtering |
+| `toolhive.stacklok.dev/tools` | No | JSON array of tool **names** — independent of lazy discovery |
+| `toolhive.stacklok.dev/tool-definitions` | No | JSON array of full tool definitions (name, description, inputSchema, …) — if absent, lazy discovery is triggered |
+| `toolhive.stacklok.dev/authz-claims` | No | JSON object of authorization claims controlling entry visibility |
+
+### Tool definitions format
+
+Each entry in `tool-definitions` follows the MCP spec:
+
+```json
+[
+  {
+    "name": "analyze_code",
+    "description": "Analyze code for potential issues",
+    "inputSchema": {
+      "type": "object",
+      "properties": { "file": { "type": "string" } },
+      "required": ["file"]
+    }
+  }
+]
+```
+
+Only JSON syntax is validated; schema semantics are not checked. Invalid JSON is logged
+as a warning and the tool definitions are omitted, but the server entry is still
+registered.
+
+---
+
+## Registry API response structure
+
+Tool definitions appear in the `_meta` field, nested under the proxy URL from
+`registry-url`:
+
+```json
+{
+  "_meta": {
+    "io.modelcontextprotocol.registry/publisher-provided": {
+      "io.github.stacklok": {
+        "https://mcp.example.com/servers/my-mcp-server": {
+          "tool_definitions": [
+            { "name": "analyze_code", "description": "..." }
+          ]
+        }
+      }
+    }
+  }
+}
+```
+
+To extract tool names with `jq`:
+
+```bash
+curl -s http://localhost:8080/registry/default/v0.1/servers | jq '
+  [.servers[] | {
+    name: .name,
+    tools: (
+      (.server._meta["io.modelcontextprotocol.registry/publisher-provided"] // {})
+      | to_entries[] | .value | to_entries[] | .value.tool_definitions? // []
+      | .[].name
+    )
+  }]'
+```

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/jackc/pgpassfile v1.0.0
 	github.com/jackc/pgx/v5 v5.10.0
+	github.com/mark3labs/mcp-go v0.55.1
 	github.com/modelcontextprotocol/registry v1.8.0
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/viper v1.21.0
@@ -32,6 +33,7 @@ require (
 	go.opentelemetry.io/otel/sdk/metric v1.44.0
 	go.opentelemetry.io/otel/trace v1.44.0
 	go.uber.org/mock v0.6.0
+	golang.org/x/oauth2 v0.36.0
 	golang.org/x/term v0.45.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/apimachinery v0.36.2
@@ -148,7 +150,6 @@ require (
 	github.com/lib/pq v1.10.9 // indirect
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
 	github.com/magiconair/properties v1.8.10 // indirect
-	github.com/mark3labs/mcp-go v0.55.1 // indirect
 	github.com/mattn/goveralls v0.0.12 // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect
 	github.com/moby/go-archive v0.2.0 // indirect
@@ -236,7 +237,6 @@ require (
 	golang.org/x/exp/jsonrpc2 v0.0.0-20260611194520-c48552f49976 // indirect
 	golang.org/x/mod v0.38.0 // indirect
 	golang.org/x/net v0.57.0 // indirect
-	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sync v0.22.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/text v0.40.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stacklok/toolhive-registry-server
 
-go 1.26.0
+go 1.26.5
 
 require (
 	github.com/Masterminds/semver/v3 v3.5.0

--- a/internal/app/builder.go
+++ b/internal/app/builder.go
@@ -13,6 +13,7 @@ import (
 	"github.com/go-chi/chi/v5/middleware"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
+	"golang.org/x/oauth2"
 
 	"github.com/stacklok/toolhive-registry-server/internal/api"
 	"github.com/stacklok/toolhive-registry-server/internal/app/storage"
@@ -613,6 +614,19 @@ func setupKubernetesReconciler(ctx context.Context, cfg *config.Config, syncWrit
 			opts = append(opts, kubernetes.WithNamespaces(namespaces...))
 		}
 
+		if reg.Kubernetes != nil && reg.Kubernetes.DiscoverTimeout != "" {
+			d, _ := time.ParseDuration(reg.Kubernetes.DiscoverTimeout) // already validated at config load
+			opts = append(opts, kubernetes.WithDiscoverTimeout(d))
+		}
+
+		if reg.Kubernetes != nil && reg.Kubernetes.DiscoverOAuth2 != nil {
+			ts, err := buildDiscoverTokenSource(ctx, reg.Kubernetes.DiscoverOAuth2)
+			if err != nil {
+				return fmt.Errorf("failed to build discover OAuth2 token source for source %s: %w", reg.Name, err)
+			}
+			opts = append(opts, kubernetes.WithDiscoverTokenSource(ts))
+		}
+
 		// Each K8s source needs a unique leader election ID to avoid lease conflicts.
 		// Source names are validated as unique (config validation rejects duplicates),
 		// so appending the source name is sufficient for uniqueness. We intentionally
@@ -633,6 +647,28 @@ func setupKubernetesReconciler(ctx context.Context, cfg *config.Config, syncWrit
 		}
 	}
 	return nil
+}
+
+// buildDiscoverTokenSource resolves the YAML-side DiscoverOAuth2 block into a
+// concrete oauth2.TokenSource. The client secret is read at wire time via
+// readSecretFromFile semantics (delegated to config.DiscoverOAuth2Yaml.GetClientSecret);
+// the returned TokenSource then caches and refreshes tokens on its own.
+func buildDiscoverTokenSource(ctx context.Context, yaml *config.DiscoverOAuth2Yaml) (oauth2.TokenSource, error) {
+	if yaml == nil {
+		return nil, nil
+	}
+	secret, err := yaml.GetClientSecret()
+	if err != nil {
+		return nil, err
+	}
+	return kubernetes.NewTokenSource(ctx, &kubernetes.DiscoverOAuth2Config{
+		TokenURL:       yaml.TokenURL,
+		ClientID:       yaml.ClientID,
+		ClientSecret:   secret,
+		Scopes:         yaml.Scopes,
+		Audience:       yaml.Audience,
+		EndpointParams: yaml.EndpointParams,
+	})
 }
 
 // securityHeadersMiddleware sets baseline security response headers on every request.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -96,6 +96,9 @@ const (
 	// MaxAuditDataSize is the hard upper bound (1 MB) for captured request
 	// bodies to prevent memory exhaustion from misconfiguration.
 	MaxAuditDataSize = 1 << 20
+
+	// schemeHTTPS is the canonical HTTPS URL scheme literal.
+	schemeHTTPS = "https"
 )
 
 // AuditConfig defines audit logging configuration.
@@ -333,6 +336,64 @@ type KubernetesConfig struct {
 	// Namespaces is a list of Kubernetes namespaces to watch for MCP servers
 	// If empty, watches the namespace configured via WatchNamespace environment variable
 	Namespaces []string `yaml:"namespaces,omitempty"`
+	// DiscoverTimeout is the maximum duration for lazy tool discovery connections.
+	// Must be a valid Go duration string (e.g. "10s", "30s", "1m").
+	// Defaults to 10s if unset.
+	DiscoverTimeout string `yaml:"discoverTimeout,omitempty"`
+	// DiscoverOAuth2 configures the OAuth2 client_credentials grant used to obtain
+	// bearer tokens for MCP `tools/list` calls issued by the reconciler. When unset,
+	// discovery calls are made without an Authorization header (anonymous).
+	DiscoverOAuth2 *DiscoverOAuth2Yaml `yaml:"discoverOAuth2,omitempty"`
+}
+
+// DiscoverOAuth2Yaml configures the OAuth2 client_credentials grant used by
+// the Kubernetes reconciler when fetching tool metadata from MCP proxies.
+//
+// The client secret is read from ClientSecretFile using readSecretFromFile
+// (absolute path + EvalSymlinks). Secrets are never accepted inline.
+type DiscoverOAuth2Yaml struct {
+	// TokenURL is the OAuth2 token endpoint (must be absolute; HTTPS unless
+	// THV_REGISTRY_INSECURE_URL=true or a loopback host).
+	TokenURL string `yaml:"tokenUrl"`
+	// ClientID identifies the confidential client registered at the IdP.
+	ClientID string `yaml:"clientId"`
+	// ClientSecretFile is an absolute path to a file whose contents are the
+	// OAuth2 client secret. Symlinks are resolved before reading.
+	ClientSecretFile string `yaml:"clientSecretFile"`
+	// Scopes is the optional list of OAuth2 scopes to request.
+	Scopes []string `yaml:"scopes,omitempty"`
+	// Audience is an optional `audience` parameter sent alongside the token request.
+	// Some IdPs (e.g. Auth0) require it; for Keycloak it can be left empty.
+	Audience string `yaml:"audience,omitempty"`
+	// EndpointParams are additional URL-encoded parameters passed to the token
+	// endpoint (e.g. resource-specific hints). Values are opaque strings.
+	EndpointParams map[string]string `yaml:"endpointParams,omitempty"`
+}
+
+// GetClientSecret returns the client secret by reading from the file specified in ClientSecretFile.
+// Returns empty string if ClientSecretFile is not configured.
+// Returns an error if the file cannot be read.
+func (d *DiscoverOAuth2Yaml) GetClientSecret() (string, error) {
+	secret, err := readSecretFromFile(d.ClientSecretFile)
+	if err != nil {
+		return "", fmt.Errorf("failed to read discover oauth2 client secret: %w", err)
+	}
+	return secret, nil
+}
+
+// LogValue implements slog.LogValuer to prevent accidental secret leakage.
+// Only presence-indicators and non-sensitive fields are emitted.
+func (d *DiscoverOAuth2Yaml) LogValue() slog.Value {
+	if d == nil {
+		return slog.StringValue("<nil>")
+	}
+	return slog.GroupValue(
+		slog.String("tokenUrl", d.TokenURL),
+		slog.String("clientId", d.ClientID),
+		slog.Bool("hasClientSecretFile", d.ClientSecretFile != ""),
+		slog.Any("scopes", d.Scopes),
+		slog.String("audience", d.Audience),
+	)
 }
 
 // SyncPolicyConfig defines synchronization settings
@@ -506,7 +567,7 @@ func (p *OAuthProviderConfig) validateProvider(index int, insecureAllowHTTP bool
 	}
 
 	// Enforce HTTPS unless THV_REGISTRY_INSECURE_URL=true or localhost
-	if issuerURL.Scheme != "https" && !insecureAllowHTTP {
+	if issuerURL.Scheme != schemeHTTPS && !insecureAllowHTTP {
 		host := issuerURL.Hostname()
 		if !isLoopbackHost(host) {
 			const msg = "must use HTTPS (set THV_REGISTRY_INSECURE_URL=true to allow HTTP)"
@@ -936,7 +997,7 @@ func (c *Config) validate() error {
 }
 
 // validateSourceConfig validates a single source configuration
-func (*Config) validateSourceConfig(src *SourceConfig, index int) error {
+func (c *Config) validateSourceConfig(src *SourceConfig, index int) error {
 	prefix := fmt.Sprintf("source[%d] (%s)", index, src.Name)
 
 	// Validate exactly one source type is configured
@@ -945,8 +1006,13 @@ func (*Config) validateSourceConfig(src *SourceConfig, index int) error {
 	}
 
 	// Non-synced sources (managed and kubernetes) don't require sync policy or filter
-	// If syncPolicy or filter are set for these sources, they will be silently ignored
+	// If syncPolicy or filter are set for these sources, they will be silently ignored.
+	// Kubernetes sources still need their type-specific block validated
+	// (discoverTimeout, discoverOAuth2), so fall through to validateSourceSpecificConfig.
 	if src.IsNonSyncedSource() {
+		if src.Kubernetes != nil {
+			return validateSourceSpecificConfig(src, prefix, c.insecureAllowHTTP)
+		}
 		return nil
 	}
 
@@ -956,7 +1022,7 @@ func (*Config) validateSourceConfig(src *SourceConfig, index int) error {
 	}
 
 	// Validate type-specific settings
-	return validateSourceSpecificConfig(src, prefix)
+	return validateSourceSpecificConfig(src, prefix, c.insecureAllowHTTP)
 }
 
 // validateRegistries validates the registries section of the configuration
@@ -1046,7 +1112,7 @@ func validateSourceTypeCount(src *SourceConfig, prefix string) error {
 }
 
 // validateSourceSpecificConfig validates the configuration for each source type
-func validateSourceSpecificConfig(src *SourceConfig, prefix string) error {
+func validateSourceSpecificConfig(src *SourceConfig, prefix string, insecureAllowHTTP bool) error {
 	if src.Git != nil {
 		return validateGitConfig(src.Git, prefix)
 	}
@@ -1059,6 +1125,57 @@ func validateSourceSpecificConfig(src *SourceConfig, prefix string) error {
 		return validateFileConfig(src.File, prefix)
 	}
 
+	if src.Kubernetes != nil {
+		return validateKubernetesConfig(src.Kubernetes, prefix, insecureAllowHTTP)
+	}
+
+	return nil
+}
+
+// validateKubernetesConfig validates Kubernetes-specific configuration
+func validateKubernetesConfig(k *KubernetesConfig, prefix string, insecureAllowHTTP bool) error {
+	if k.DiscoverTimeout != "" {
+		if _, err := time.ParseDuration(k.DiscoverTimeout); err != nil {
+			return fmt.Errorf("%s: kubernetes.discoverTimeout must be a valid duration (e.g., '10s', '1m'): %w", prefix, err)
+		}
+	}
+	if k.DiscoverOAuth2 != nil {
+		if err := validateDiscoverOAuth2(k.DiscoverOAuth2, prefix, insecureAllowHTTP); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// validateDiscoverOAuth2 validates the OAuth2 client_credentials configuration
+// used by the K8s reconciler to fetch tool metadata.
+func validateDiscoverOAuth2(d *DiscoverOAuth2Yaml, prefix string, insecureAllowHTTP bool) error {
+	if d.TokenURL == "" {
+		return fmt.Errorf("%s: kubernetes.discoverOAuth2.tokenUrl is required", prefix)
+	}
+	if d.ClientID == "" {
+		return fmt.Errorf("%s: kubernetes.discoverOAuth2.clientId is required", prefix)
+	}
+	if d.ClientSecretFile == "" {
+		return fmt.Errorf("%s: kubernetes.discoverOAuth2.clientSecretFile is required", prefix)
+	}
+	if !filepath.IsAbs(d.ClientSecretFile) {
+		return fmt.Errorf("%s: kubernetes.discoverOAuth2.clientSecretFile must be an absolute path", prefix)
+	}
+
+	tokenURL, err := url.Parse(d.TokenURL)
+	if err != nil {
+		return fmt.Errorf("%s: kubernetes.discoverOAuth2.tokenUrl is invalid: %w", prefix, err)
+	}
+	if !tokenURL.IsAbs() || tokenURL.Host == "" {
+		return fmt.Errorf("%s: kubernetes.discoverOAuth2.tokenUrl must be an absolute URL with host", prefix)
+	}
+	if tokenURL.Scheme != schemeHTTPS && !insecureAllowHTTP {
+		if !isLoopbackHost(tokenURL.Hostname()) {
+			return fmt.Errorf("%s: kubernetes.discoverOAuth2.tokenUrl must use HTTPS "+
+				"(set THV_REGISTRY_INSECURE_URL=true to allow HTTP)", prefix)
+		}
+	}
 	return nil
 }
 
@@ -1166,7 +1283,7 @@ func validateFileURL(rawURL string, prefix string) error {
 	}
 
 	// Only allow HTTP and HTTPS schemes
-	if parsedURL.Scheme != "http" && parsedURL.Scheme != "https" {
+	if parsedURL.Scheme != "http" && parsedURL.Scheme != schemeHTTPS {
 		return fmt.Errorf("%s: file.url must use http or https scheme", prefix)
 	}
 

--- a/internal/config/kubernetes_discover_test.go
+++ b/internal/config/kubernetes_discover_test.go
@@ -1,0 +1,150 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateKubernetesConfig_DiscoverTimeout(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		cfg     *KubernetesConfig
+		wantErr bool
+	}{
+		{"empty", &KubernetesConfig{}, false},
+		{"valid duration", &KubernetesConfig{DiscoverTimeout: "10s"}, false},
+		{"invalid duration", &KubernetesConfig{DiscoverTimeout: "not-a-duration"}, true},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := validateKubernetesConfig(tt.cfg, "src", false)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestValidateDiscoverOAuth2(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+	secretPath := filepath.Join(tmpDir, "secret")
+	require.NoError(t, os.WriteFile(secretPath, []byte("s3cret"), 0o600))
+
+	base := func() *DiscoverOAuth2Yaml {
+		return &DiscoverOAuth2Yaml{
+			TokenURL:         "https://idp.example/token",
+			ClientID:         "cid",
+			ClientSecretFile: secretPath,
+		}
+	}
+
+	t.Run("valid HTTPS config", func(t *testing.T) {
+		t.Parallel()
+		assert.NoError(t, validateDiscoverOAuth2(base(), "src", false))
+	})
+
+	t.Run("missing tokenUrl", func(t *testing.T) {
+		t.Parallel()
+		c := base()
+		c.TokenURL = ""
+		assert.Error(t, validateDiscoverOAuth2(c, "src", false))
+	})
+
+	t.Run("missing clientId", func(t *testing.T) {
+		t.Parallel()
+		c := base()
+		c.ClientID = ""
+		assert.Error(t, validateDiscoverOAuth2(c, "src", false))
+	})
+
+	t.Run("missing clientSecretFile", func(t *testing.T) {
+		t.Parallel()
+		c := base()
+		c.ClientSecretFile = ""
+		assert.Error(t, validateDiscoverOAuth2(c, "src", false))
+	})
+
+	t.Run("relative clientSecretFile rejected", func(t *testing.T) {
+		t.Parallel()
+		c := base()
+		c.ClientSecretFile = "relative/path"
+		assert.Error(t, validateDiscoverOAuth2(c, "src", false))
+	})
+
+	t.Run("invalid tokenUrl format rejected", func(t *testing.T) {
+		t.Parallel()
+		c := base()
+		c.TokenURL = ":://bad"
+		assert.Error(t, validateDiscoverOAuth2(c, "src", false))
+	})
+
+	t.Run("HTTP tokenUrl rejected without insecure flag", func(t *testing.T) {
+		t.Parallel()
+		c := base()
+		c.TokenURL = "http://idp.example/token"
+		assert.Error(t, validateDiscoverOAuth2(c, "src", false))
+	})
+
+	t.Run("HTTP tokenUrl allowed with insecure flag", func(t *testing.T) {
+		t.Parallel()
+		c := base()
+		c.TokenURL = "http://idp.example/token"
+		assert.NoError(t, validateDiscoverOAuth2(c, "src", true))
+	})
+
+	t.Run("HTTP tokenUrl on loopback host is allowed", func(t *testing.T) {
+		t.Parallel()
+		c := base()
+		c.TokenURL = "http://127.0.0.1:8080/token"
+		assert.NoError(t, validateDiscoverOAuth2(c, "src", false))
+	})
+}
+
+func TestDiscoverOAuth2Yaml_GetClientSecret(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "s")
+	require.NoError(t, os.WriteFile(path, []byte("  topsecret  \n"), 0o600))
+
+	d := &DiscoverOAuth2Yaml{ClientSecretFile: path}
+	got, err := d.GetClientSecret()
+	require.NoError(t, err)
+	assert.Equal(t, "topsecret", got)
+}
+
+func TestDiscoverOAuth2Yaml_LogValueRedactsSecret(t *testing.T) {
+	t.Parallel()
+	d := &DiscoverOAuth2Yaml{
+		TokenURL:         "https://idp/token",
+		ClientID:         "cid",
+		ClientSecretFile: "/etc/secret",
+		Audience:         "aud",
+	}
+	// LogValue must not expose the ClientSecretFile path directly and must
+	// carry only a presence indicator for the secret material.
+	attrs := d.LogValue().Group()
+	found := false
+	for _, a := range attrs {
+		if a.Key == "hasClientSecretFile" {
+			found = true
+			assert.True(t, a.Value.Bool())
+		}
+		if a.Key == "clientSecretFile" {
+			t.Fatalf("LogValue must not emit clientSecretFile directly")
+		}
+	}
+	assert.True(t, found, "hasClientSecretFile indicator must be present")
+}

--- a/internal/kubernetes/builder.go
+++ b/internal/kubernetes/builder.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"golang.org/x/oauth2"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
@@ -32,7 +33,8 @@ const (
 	defaultRegistryToolsAnnotation           = "toolhive.stacklok.dev/tools"
 	defaultAuthzClaimsAnnotation             = "toolhive.stacklok.dev/authz-claims"
 
-	defaultRequeueAfter = 10 * time.Second
+	defaultRequeueAfter    = 10 * time.Second
+	defaultDiscoverTimeout = 10 * time.Second
 
 	leaderElectionID = "toolhive-registry-server-leader-election"
 )
@@ -56,11 +58,13 @@ func hasRequiredRegistryAnnotations(annotations map[string]string) bool {
 }
 
 type mcpServerReconcilerOptions struct {
-	namespaces       []string
-	requeueAfter     time.Duration
-	syncWriter       writer.SyncWriter
-	registryName     string
-	leaderElectionID string
+	namespaces          []string
+	requeueAfter        time.Duration
+	discoverTimeout     time.Duration
+	discoverTokenSource oauth2.TokenSource
+	syncWriter          writer.SyncWriter
+	registryName        string
+	leaderElectionID    string
 }
 
 // Option is a function that sets an option for the MCPServerReconciler.
@@ -141,6 +145,27 @@ func WithRequeueAfter(requeueAfter time.Duration) Option {
 	}
 }
 
+// WithDiscoverTimeout sets the timeout for lazy tool discovery connections.
+func WithDiscoverTimeout(d time.Duration) Option {
+	return func(o *mcpServerReconcilerOptions) error {
+		if d <= 0 {
+			return fmt.Errorf("discoverTimeout must be greater than 0")
+		}
+		o.discoverTimeout = d
+		return nil
+	}
+}
+
+// WithDiscoverTokenSource configures the OAuth2 token source used to fetch
+// Bearer tokens for MCP tools/list discovery calls. Passing nil leaves the
+// reconciler in anonymous discovery mode (no Authorization header).
+func WithDiscoverTokenSource(ts oauth2.TokenSource) Option {
+	return func(o *mcpServerReconcilerOptions) error {
+		o.discoverTokenSource = ts
+		return nil
+	}
+}
+
 // WithSyncWriter sets the sync writer.
 func WithSyncWriter(sw writer.SyncWriter) Option {
 	return func(o *mcpServerReconcilerOptions) error {
@@ -183,8 +208,9 @@ func NewMCPServerReconciler(
 	opts ...Option,
 ) (ctrl.Manager, error) {
 	o := &mcpServerReconcilerOptions{
-		namespaces:   []string{},
-		requeueAfter: defaultRequeueAfter,
+		namespaces:      []string{},
+		requeueAfter:    defaultRequeueAfter,
+		discoverTimeout: defaultDiscoverTimeout,
 	}
 
 	for _, opt := range opts {
@@ -239,9 +265,11 @@ func NewMCPServerReconciler(
 	}
 
 	controller := &MCPServerReconciler{
-		requeueAfter: o.requeueAfter,
-		syncWriter:   o.syncWriter,
-		registryName: o.registryName,
+		requeueAfter:        o.requeueAfter,
+		discoverTimeout:     o.discoverTimeout,
+		discoverTokenSource: o.discoverTokenSource,
+		syncWriter:          o.syncWriter,
+		registryName:        o.registryName,
 	}
 
 	if err := controller.SetupWithManager(mgr); err != nil {

--- a/internal/kubernetes/controller.go
+++ b/internal/kubernetes/controller.go
@@ -10,6 +10,7 @@ import (
 	upstreamv0 "github.com/modelcontextprotocol/registry/pkg/api/v0"
 	toolhivetypes "github.com/stacklok/toolhive-core/registry/types"
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"golang.org/x/oauth2"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -33,18 +34,22 @@ type reconcileResult struct {
 
 // MCPServerReconciler reconciles MCPServer objects
 type MCPServerReconciler struct {
-	client       client.Client
-	scheme       *runtime.Scheme
-	requeueAfter time.Duration
-	syncWriter   writer.SyncWriter
-	registryName string
+	client          client.Client
+	scheme          *runtime.Scheme
+	requeueAfter    time.Duration
+	discoverTimeout time.Duration
+	// discoverTokenSource, when non-nil, supplies OAuth2 access tokens attached
+	// as Bearer credentials on MCP tools/list calls. Nil means anonymous.
+	discoverTokenSource oauth2.TokenSource
+	syncWriter          writer.SyncWriter
+	registryName        string
 }
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
 func (r *MCPServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	// Fetch the MCPServer instance
-	result, err := getMCPServerList(ctx, r.client, req.Namespace)
+	result, err := getMCPServerList(ctx, r.client, req.Namespace, r.discoverTimeout, r.discoverTokenSource)
 	if err != nil {
 		slog.Error("Failed to get MCPServer list", "error", err)
 		return ctrl.Result{}, err
@@ -173,13 +178,14 @@ func (r *MCPServerReconciler) SetupWithManager(mgr ctrl.Manager) error {
 }
 
 // extractorFunc converts a K8s resource into a ServerJSON.
-type extractorFunc func(client.Object) (*upstreamv0.ServerJSON, error)
+type extractorFunc func(context.Context, client.Object) (*upstreamv0.ServerJSON, error)
 
 // processResources filters, extracts, and builds per-entry claims for a list of K8s resources.
 // Returns the extracted servers appended to serverJSONs and populates perEntryClaims for
 // entries that have valid authz-claims annotations. Entries without the annotation get no
 // claims — they are visible in anonymous mode but invisible when authz is configured.
 func processResources(
+	ctx context.Context,
 	items []client.Object,
 	typeName string,
 	extractor extractorFunc,
@@ -190,7 +196,7 @@ func processResources(
 		if !hasRequiredRegistryAnnotations(obj.GetAnnotations()) {
 			continue
 		}
-		serverJSON, err := extractor(obj)
+		serverJSON, err := extractor(ctx, obj)
 		if err != nil {
 			slog.Warn("Failed to extract ServerJSON from K8s resource, skipping",
 				"type", typeName,
@@ -223,7 +229,7 @@ func processResources(
 // getMCPServerList retrieves all MCPServer objects, extracts ServerJSON objects,
 // and builds per-entry claims from the authz-claims annotation.
 func getMCPServerList(
-	ctx context.Context, c client.Client, namespace string,
+	ctx context.Context, c client.Client, namespace string, discoverTimeout time.Duration, ts oauth2.TokenSource,
 ) (*reconcileResult, error) {
 	listOptions := []client.ListOption{
 		client.InNamespace(namespace),
@@ -250,37 +256,40 @@ func getMCPServerList(
 	for i := range mcpServerList.Items {
 		mcpObjects[i] = &mcpServerList.Items[i]
 	}
-	serverJSONs = processResources(mcpObjects, "MCPServer", func(obj client.Object) (*upstreamv0.ServerJSON, error) {
-		inner, ok := obj.(*mcpv1beta1.MCPServer)
-		if !ok {
-			return nil, fmt.Errorf("unexpected type %T", obj)
-		}
-		return extractServer(inner)
-	}, serverJSONs, perEntryClaims)
+	serverJSONs = processResources(ctx, mcpObjects, "MCPServer",
+		func(ctx context.Context, obj client.Object) (*upstreamv0.ServerJSON, error) {
+			inner, ok := obj.(*mcpv1beta1.MCPServer)
+			if !ok {
+				return nil, fmt.Errorf("unexpected type %T", obj)
+			}
+			return extractServer(ctx, inner, discoverTimeout, ts)
+		}, serverJSONs, perEntryClaims)
 
 	vmcpObjects := make([]client.Object, len(vmcpServerList.Items))
 	for i := range vmcpServerList.Items {
 		vmcpObjects[i] = &vmcpServerList.Items[i]
 	}
-	serverJSONs = processResources(vmcpObjects, "VirtualMCPServer", func(obj client.Object) (*upstreamv0.ServerJSON, error) {
-		inner, ok := obj.(*mcpv1beta1.VirtualMCPServer)
-		if !ok {
-			return nil, fmt.Errorf("unexpected type %T", obj)
-		}
-		return extractVirtualMCPServer(inner)
-	}, serverJSONs, perEntryClaims)
+	serverJSONs = processResources(ctx, vmcpObjects, "VirtualMCPServer",
+		func(ctx context.Context, obj client.Object) (*upstreamv0.ServerJSON, error) {
+			inner, ok := obj.(*mcpv1beta1.VirtualMCPServer)
+			if !ok {
+				return nil, fmt.Errorf("unexpected type %T", obj)
+			}
+			return extractVirtualMCPServer(ctx, inner, discoverTimeout, ts)
+		}, serverJSONs, perEntryClaims)
 
 	mcpProxyObjects := make([]client.Object, len(mcpRemoteProxyList.Items))
 	for i := range mcpRemoteProxyList.Items {
 		mcpProxyObjects[i] = &mcpRemoteProxyList.Items[i]
 	}
-	serverJSONs = processResources(mcpProxyObjects, "MCPRemoteProxy", func(obj client.Object) (*upstreamv0.ServerJSON, error) {
-		inner, ok := obj.(*mcpv1beta1.MCPRemoteProxy)
-		if !ok {
-			return nil, fmt.Errorf("unexpected type %T", obj)
-		}
-		return extractMCPRemoteProxy(inner)
-	}, serverJSONs, perEntryClaims)
+	serverJSONs = processResources(ctx, mcpProxyObjects, "MCPRemoteProxy",
+		func(ctx context.Context, obj client.Object) (*upstreamv0.ServerJSON, error) {
+			inner, ok := obj.(*mcpv1beta1.MCPRemoteProxy)
+			if !ok {
+				return nil, fmt.Errorf("unexpected type %T", obj)
+			}
+			return extractMCPRemoteProxy(ctx, inner, discoverTimeout, ts)
+		}, serverJSONs, perEntryClaims)
 
 	// Return nil instead of empty map when no per-entry claims exist
 	var resultClaims map[string][]byte

--- a/internal/kubernetes/controller_claims_test.go
+++ b/internal/kubernetes/controller_claims_test.go
@@ -1,6 +1,7 @@
 package kubernetes
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"testing"
@@ -244,7 +245,7 @@ func TestProcessResources(t *testing.T) {
 
 	// A simple extractor that returns a ServerJSON with the object's name.
 	// If the object name starts with "error-", it returns an error.
-	goodExtractor := func(obj client.Object) (*upstreamv0.ServerJSON, error) {
+	goodExtractor := func(_ context.Context, obj client.Object) (*upstreamv0.ServerJSON, error) {
 		name := obj.GetName()
 		if len(name) > 6 && name[:6] == "error-" {
 			return nil, fmt.Errorf("extractor failure for %s", name)
@@ -361,7 +362,7 @@ func TestProcessResources(t *testing.T) {
 			var serverJSONs []upstreamv0.ServerJSON
 			perEntryClaims := make(map[string][]byte)
 
-			serverJSONs = processResources(tt.items, "MCPServer", goodExtractor, serverJSONs, perEntryClaims)
+			serverJSONs = processResources(context.Background(), tt.items, "MCPServer", goodExtractor, serverJSONs, perEntryClaims)
 
 			// Verify serverJSONs count and names
 			if tt.wantServerNames == nil {

--- a/internal/kubernetes/discover.go
+++ b/internal/kubernetes/discover.go
@@ -1,0 +1,138 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package kubernetes
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	mcpclient "github.com/mark3labs/mcp-go/client"
+	"github.com/mark3labs/mcp-go/client/transport"
+	"github.com/mark3labs/mcp-go/mcp"
+	"golang.org/x/oauth2"
+)
+
+const (
+	discoverClientName = "toolhive-registry-discovery"
+)
+
+// discoverTools connects to the MCP proxy at registryURL and returns its
+// tools/list response. Returns nil on any error — callers treat nil as
+// "leave ToolDefinitions empty, retry on next reconcile".
+//
+// When ts is non-nil, a Bearer token is fetched via oauth2.TokenSource and
+// injected as an Authorization header on the transport. Token fetch failures
+// yield a nil result (skip this reconcile) rather than crashing the loop.
+func discoverTools(
+	ctx context.Context,
+	registryURL, serverName, namespace string,
+	timeout time.Duration,
+	ts oauth2.TokenSource,
+) []mcp.Tool {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	slog.Debug("lazy discovery: starting",
+		"url", registryURL, "server", serverName,
+		"namespace", namespace, "timeout", timeout, "oauth2", ts != nil)
+
+	headers, err := buildAuthHeaders(ts)
+	if err != nil {
+		slog.Warn("lazy discovery: failed to obtain OAuth2 token, skipping",
+			"url", registryURL, "server", serverName,
+			"namespace", namespace, "error", err)
+		return nil
+	}
+
+	c, err := connectMCPClient(ctx, registryURL, headers)
+	if err != nil {
+		slog.Warn("lazy discovery: failed to connect, skipping",
+			"url", registryURL, "server", serverName,
+			"namespace", namespace, "error", err)
+		return nil
+	}
+	defer func() { _ = c.Close() }()
+
+	resp, err := c.ListTools(ctx, mcp.ListToolsRequest{})
+	if err != nil {
+		slog.Warn("lazy discovery: tools/list failed, skipping",
+			"url", registryURL, "server", serverName,
+			"namespace", namespace, "error", err)
+		return nil
+	}
+	if len(resp.Tools) == 0 {
+		slog.Warn("lazy discovery: tools/list returned empty list; "+
+			"if Cedar is configured verify that mcp_tool_discovery role is granted",
+			"url", registryURL, "server", serverName, "namespace", namespace)
+		return nil
+	}
+
+	slog.Info("lazy discovery: discovered tools",
+		"server", serverName, "namespace", namespace, "count", len(resp.Tools))
+	return resp.Tools
+}
+
+// buildAuthHeaders returns the HTTP headers to attach to the MCP client
+// transport. Returns nil headers (and nil error) when ts is nil — anonymous
+// discovery is a supported mode.
+func buildAuthHeaders(ts oauth2.TokenSource) (map[string]string, error) {
+	if ts == nil {
+		return nil, nil
+	}
+	tok, err := ts.Token()
+	if err != nil {
+		return nil, fmt.Errorf("fetch oauth2 token: %w", err)
+	}
+	return map[string]string{
+		"Authorization": tok.Type() + " " + tok.AccessToken,
+	}, nil
+}
+
+// connectMCPClient is a var so unit tests can replace it with a mock without
+// needing an interface. Tries streamable-http first, falls back to SSE.
+var connectMCPClient = func(ctx context.Context, url string, headers map[string]string) (*mcpclient.Client, error) {
+	var streamOpts []transport.StreamableHTTPCOption
+	if len(headers) > 0 {
+		streamOpts = append(streamOpts, transport.WithHTTPHeaders(headers))
+	}
+	if c, err := mcpclient.NewStreamableHttpClient(url, streamOpts...); err == nil {
+		startErr := initMCPClient(ctx, c)
+		if startErr == nil {
+			slog.Debug("lazy discovery: connected via streamable-http", "url", url)
+			return c, nil
+		}
+		slog.Debug("lazy discovery: streamable-http init failed, falling back to SSE",
+			"url", url, "error", startErr)
+		_ = c.Close()
+	}
+	var sseOpts []transport.ClientOption
+	if len(headers) > 0 {
+		sseOpts = append(sseOpts, mcpclient.WithHeaders(headers))
+	}
+	c, err := mcpclient.NewSSEMCPClient(url, sseOpts...)
+	if err != nil {
+		return nil, fmt.Errorf("create MCP client (tried streamable-http and SSE): %w", err)
+	}
+	if err := initMCPClient(ctx, c); err != nil {
+		_ = c.Close()
+		return nil, fmt.Errorf("initialize MCP client: %w", err)
+	}
+	slog.Debug("lazy discovery: connected via SSE", "url", url)
+	return c, nil
+}
+
+func initMCPClient(ctx context.Context, c *mcpclient.Client) error {
+	if err := c.Start(ctx); err != nil {
+		return fmt.Errorf("start: %w", err)
+	}
+	req := mcp.InitializeRequest{}
+	req.Params.ProtocolVersion = mcp.LATEST_PROTOCOL_VERSION
+	req.Params.ClientInfo = mcp.Implementation{Name: discoverClientName, Version: "1.0"}
+	if _, err := c.Initialize(ctx, req); err != nil {
+		return fmt.Errorf("initialize: %w", err)
+	}
+	return nil
+}

--- a/internal/kubernetes/discover_test.go
+++ b/internal/kubernetes/discover_test.go
@@ -1,0 +1,204 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package kubernetes
+
+import (
+	"context"
+	"fmt"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	mcpclient "github.com/mark3labs/mcp-go/client"
+	"github.com/mark3labs/mcp-go/mcp"
+	mcpserver "github.com/mark3labs/mcp-go/server"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
+)
+
+// stubTokenSource is a minimal oauth2.TokenSource used to exercise the
+// header-injection path without hitting a real IdP.
+type stubTokenSource struct {
+	tok *oauth2.Token
+	err error
+}
+
+func (s stubTokenSource) Token() (*oauth2.Token, error) { return s.tok, s.err }
+
+//nolint:paralleltest,tparallel // subtests write connectMCPClient package-level var and must run sequentially
+func TestDiscoverTools(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name          string
+		setupServer   func(t *testing.T) *httptest.Server
+		stubConnect   func(t *testing.T)
+		tokenSource   oauth2.TokenSource
+		expectedCount int
+		expectedNames []string
+		expectNil     bool
+		timeout       time.Duration
+	}{
+		{
+			name: "success with two tools",
+			setupServer: func(t *testing.T) *httptest.Server {
+				t.Helper()
+				s := mcpserver.NewMCPServer("test-server", "1.0")
+				s.AddTool(mcp.NewTool("tool_a", mcp.WithDescription("first tool")),
+					func(_ context.Context, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+						return mcp.NewToolResultText("ok"), nil
+					})
+				s.AddTool(mcp.NewTool("tool_b", mcp.WithDescription("second tool")),
+					func(_ context.Context, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+						return mcp.NewToolResultText("ok"), nil
+					})
+				handler := mcpserver.NewStreamableHTTPServer(s)
+				return httptest.NewServer(handler)
+			},
+			expectedCount: 2,
+			expectedNames: []string{"tool_a", "tool_b"},
+		},
+		{
+			name: "connect failure returns nil",
+			stubConnect: func(t *testing.T) {
+				t.Helper()
+				connectMCPClient = func(_ context.Context, _ string, _ map[string]string) (*mcpclient.Client, error) {
+					return nil, fmt.Errorf("connection refused")
+				}
+			},
+			expectNil: true,
+		},
+		{
+			name: "empty tools list returns nil",
+			setupServer: func(t *testing.T) *httptest.Server {
+				t.Helper()
+				s := mcpserver.NewMCPServer("empty-server", "1.0")
+				handler := mcpserver.NewStreamableHTTPServer(s)
+				return httptest.NewServer(handler)
+			},
+			expectNil: true,
+		},
+		{
+			name: "context cancelled before connect completes returns nil",
+			stubConnect: func(t *testing.T) {
+				t.Helper()
+				connectMCPClient = func(ctx context.Context, _ string, _ map[string]string) (*mcpclient.Client, error) {
+					<-ctx.Done()
+					return nil, ctx.Err()
+				}
+			},
+			expectNil: true,
+			timeout:   100 * time.Millisecond,
+		},
+		{
+			name: "token source error skips discovery (nil result)",
+			stubConnect: func(t *testing.T) {
+				t.Helper()
+				connectMCPClient = func(_ context.Context, _ string, _ map[string]string) (*mcpclient.Client, error) {
+					t.Fatalf("connectMCPClient must not be called when token fetch fails")
+					return nil, nil
+				}
+			},
+			tokenSource: stubTokenSource{err: fmt.Errorf("idp down")},
+			expectNil:   true,
+		},
+		{
+			name: "token source success injects Authorization header",
+			stubConnect: func(t *testing.T) {
+				t.Helper()
+				connectMCPClient = func(_ context.Context, _ string, headers map[string]string) (*mcpclient.Client, error) {
+					require.NotNil(t, headers)
+					assert.Equal(t, "Bearer abc123", headers["Authorization"])
+					return nil, fmt.Errorf("stop-after-header-check")
+				}
+			},
+			tokenSource: stubTokenSource{tok: &oauth2.Token{AccessToken: "abc123", TokenType: "Bearer"}},
+			expectNil:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		//nolint:paralleltest // subtests share connectMCPClient package-level var; parallel writes would race
+		t.Run(tt.name, func(t *testing.T) {
+			original := connectMCPClient
+			t.Cleanup(func() { connectMCPClient = original })
+
+			var serverURL string
+
+			if tt.setupServer != nil {
+				ts := tt.setupServer(t)
+				defer ts.Close()
+				serverURL = ts.URL
+			}
+
+			if tt.stubConnect != nil {
+				tt.stubConnect(t)
+				if serverURL == "" {
+					serverURL = "http://unused"
+				}
+			}
+
+			ctx := context.Background()
+			if tt.timeout > 0 {
+				var cancel context.CancelFunc
+				ctx, cancel = context.WithTimeout(ctx, tt.timeout)
+				defer cancel()
+			}
+
+			result := discoverTools(ctx, serverURL, "test-server", "default", defaultDiscoverTimeout, tt.tokenSource)
+
+			if tt.expectNil {
+				assert.Nil(t, result)
+				return
+			}
+
+			require.NotNil(t, result)
+			assert.Len(t, result, tt.expectedCount)
+
+			if tt.expectedNames != nil {
+				names := make([]string, len(result))
+				for i, tool := range result {
+					names[i] = tool.Name
+				}
+				assert.ElementsMatch(t, tt.expectedNames, names)
+			}
+		})
+	}
+}
+
+func TestBuildAuthHeaders(t *testing.T) {
+	t.Parallel()
+	t.Run("nil TokenSource returns nil headers, nil error", func(t *testing.T) {
+		t.Parallel()
+		h, err := buildAuthHeaders(nil)
+		assert.NoError(t, err)
+		assert.Nil(t, h)
+	})
+
+	t.Run("error propagates", func(t *testing.T) {
+		t.Parallel()
+		_, err := buildAuthHeaders(stubTokenSource{err: fmt.Errorf("boom")})
+		assert.Error(t, err)
+	})
+
+	t.Run("Bearer header formatted correctly", func(t *testing.T) {
+		t.Parallel()
+		h, err := buildAuthHeaders(stubTokenSource{
+			tok: &oauth2.Token{AccessToken: "xyz", TokenType: "Bearer"},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "Bearer xyz", h["Authorization"])
+	})
+
+	t.Run("default TokenType is Bearer when unset", func(t *testing.T) {
+		t.Parallel()
+		h, err := buildAuthHeaders(stubTokenSource{
+			tok: &oauth2.Token{AccessToken: "xyz"},
+		})
+		require.NoError(t, err)
+		// oauth2.Token.Type() returns "Bearer" when TokenType is empty
+		assert.Equal(t, "Bearer xyz", h["Authorization"])
+	})
+}

--- a/internal/kubernetes/oauth.go
+++ b/internal/kubernetes/oauth.go
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package kubernetes
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/clientcredentials"
+)
+
+// DiscoverOAuth2Config carries the resolved OAuth2 client_credentials
+// parameters used to obtain Bearer tokens for MCP tools/list calls.
+//
+// The struct is intentionally IdP-agnostic — the caller decides how to
+// populate ClientSecret (from a file, env, or a secret manager). This
+// package never reads secrets from disk directly.
+type DiscoverOAuth2Config struct {
+	TokenURL       string
+	ClientID       string
+	ClientSecret   string
+	Scopes         []string
+	Audience       string
+	EndpointParams map[string]string
+}
+
+// NewTokenSource returns a cached oauth2.TokenSource that lazily fetches
+// tokens via the client_credentials grant and refreshes them on expiry.
+//
+// The returned TokenSource wraps oauth2.ReuseTokenSource so callers can invoke
+// Token() on every discovery attempt without triggering a token request until
+// the previous token nears expiry.
+//
+// Returns (nil, nil) when cfg is nil, which callers interpret as "anonymous
+// discovery" — no Authorization header is attached.
+func NewTokenSource(ctx context.Context, cfg *DiscoverOAuth2Config) (oauth2.TokenSource, error) {
+	if cfg == nil {
+		return nil, nil
+	}
+	if cfg.TokenURL == "" {
+		return nil, fmt.Errorf("oauth2: tokenURL is required")
+	}
+	if cfg.ClientID == "" {
+		return nil, fmt.Errorf("oauth2: clientID is required")
+	}
+	if cfg.ClientSecret == "" {
+		return nil, fmt.Errorf("oauth2: clientSecret is required")
+	}
+
+	params := url.Values{}
+	if cfg.Audience != "" {
+		params.Set("audience", cfg.Audience)
+	}
+	for k, v := range cfg.EndpointParams {
+		params.Set(k, v)
+	}
+
+	cc := &clientcredentials.Config{
+		ClientID:       cfg.ClientID,
+		ClientSecret:   cfg.ClientSecret,
+		TokenURL:       cfg.TokenURL,
+		Scopes:         cfg.Scopes,
+		EndpointParams: params,
+		AuthStyle:      oauth2.AuthStyleInParams,
+	}
+	return cc.TokenSource(ctx), nil
+}

--- a/internal/kubernetes/oauth_test.go
+++ b/internal/kubernetes/oauth_test.go
@@ -1,0 +1,67 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package kubernetes
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewTokenSource(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	t.Run("nil config returns nil source and nil error", func(t *testing.T) {
+		t.Parallel()
+		ts, err := NewTokenSource(ctx, nil)
+		assert.NoError(t, err)
+		assert.Nil(t, ts)
+	})
+
+	t.Run("missing TokenURL is rejected", func(t *testing.T) {
+		t.Parallel()
+		_, err := NewTokenSource(ctx, &DiscoverOAuth2Config{
+			ClientID:     "cid",
+			ClientSecret: "sec",
+		})
+		assert.Error(t, err)
+	})
+
+	t.Run("missing ClientID is rejected", func(t *testing.T) {
+		t.Parallel()
+		_, err := NewTokenSource(ctx, &DiscoverOAuth2Config{
+			TokenURL:     "https://idp.example/token",
+			ClientSecret: "sec",
+		})
+		assert.Error(t, err)
+	})
+
+	t.Run("missing ClientSecret is rejected", func(t *testing.T) {
+		t.Parallel()
+		_, err := NewTokenSource(ctx, &DiscoverOAuth2Config{
+			TokenURL: "https://idp.example/token",
+			ClientID: "cid",
+		})
+		assert.Error(t, err)
+	})
+
+	t.Run("valid config returns non-nil source", func(t *testing.T) {
+		t.Parallel()
+		ts, err := NewTokenSource(ctx, &DiscoverOAuth2Config{
+			TokenURL:     "https://idp.example/token",
+			ClientID:     "cid",
+			ClientSecret: "sec",
+			Scopes:       []string{"mcp:tools"},
+			Audience:     "registry",
+			EndpointParams: map[string]string{
+				"resource": "https://mcp.example",
+			},
+		})
+		require.NoError(t, err)
+		assert.NotNil(t, ts)
+	})
+}

--- a/internal/kubernetes/types.go
+++ b/internal/kubernetes/types.go
@@ -1,16 +1,19 @@
 package kubernetes
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log/slog"
 	"strings"
+	"time"
 
 	upstreamv0 "github.com/modelcontextprotocol/registry/pkg/api/v0"
 	model "github.com/modelcontextprotocol/registry/pkg/model"
 	mcp "github.com/stacklok/toolhive-core/mcpcompat/mcp"
 	registry "github.com/stacklok/toolhive-core/registry/types"
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"golang.org/x/oauth2"
 )
 
 const (
@@ -28,7 +31,12 @@ const (
 // extractServer converts an MCPServer to a ServerJSON object
 //
 //nolint:unparam
-func extractServer(mcpServer *mcpv1beta1.MCPServer) (*upstreamv0.ServerJSON, error) {
+func extractServer(
+	ctx context.Context,
+	mcpServer *mcpv1beta1.MCPServer,
+	discoverTimeout time.Duration,
+	ts oauth2.TokenSource,
+) (*upstreamv0.ServerJSON, error) {
 	// Generate reverse-DNS formatted server name
 	serverName, err := GenerateServerName(mcpServer.Namespace, mcpServer.Name)
 	if err != nil {
@@ -96,9 +104,14 @@ func extractServer(mcpServer *mcpv1beta1.MCPServer) (*upstreamv0.ServerJSON, err
 		},
 	}
 
-	// Add tool definitions if present
+	// Add tool definitions if present; otherwise attempt lazy discovery via the proxy URL.
+	// The proxy's ListToolsMappingMiddleware already applies toolsFilter, so the discovered
+	// list equals the set of tools that are actually callable — solving both sync and
+	// consistency problems in one step.
 	if toolDefs := extractToolDefinitions(annotations, mcpServer.Name, mcpServer.Namespace); toolDefs != nil {
 		extensions.ToolDefinitions = toolDefs
+	} else {
+		extensions.ToolDefinitions = discoverTools(ctx, transportURL, mcpServer.Name, mcpServer.Namespace, discoverTimeout, ts)
 	}
 
 	// Add tools if present
@@ -124,7 +137,12 @@ func extractServer(mcpServer *mcpv1beta1.MCPServer) (*upstreamv0.ServerJSON, err
 // extractVirtualMCPServer converts a VirtualMCPServer to a ServerJSON object
 //
 //nolint:unparam
-func extractVirtualMCPServer(virtualMCPServer *mcpv1beta1.VirtualMCPServer) (*upstreamv0.ServerJSON, error) {
+func extractVirtualMCPServer(
+	ctx context.Context,
+	virtualMCPServer *mcpv1beta1.VirtualMCPServer,
+	discoverTimeout time.Duration,
+	ts oauth2.TokenSource,
+) (*upstreamv0.ServerJSON, error) {
 	// Generate reverse-DNS formatted server name
 	serverName, err := GenerateServerName(virtualMCPServer.Namespace, virtualMCPServer.Name)
 	if err != nil {
@@ -186,9 +204,11 @@ func extractVirtualMCPServer(virtualMCPServer *mcpv1beta1.VirtualMCPServer) (*up
 		},
 	}
 
-	// Add tool definitions if present
 	if toolDefs := extractToolDefinitions(annotations, virtualMCPServer.Name, virtualMCPServer.Namespace); toolDefs != nil {
 		extensions.ToolDefinitions = toolDefs
+	} else {
+		extensions.ToolDefinitions = discoverTools(
+			ctx, transportURL, virtualMCPServer.Name, virtualMCPServer.Namespace, discoverTimeout, ts)
 	}
 
 	// Add tools if present
@@ -214,7 +234,12 @@ func extractVirtualMCPServer(virtualMCPServer *mcpv1beta1.VirtualMCPServer) (*up
 // extractMCPRemoteProxy converts a MCPRemoteProxy to a ServerJSON object
 //
 //nolint:unparam
-func extractMCPRemoteProxy(mcpRemoteProxy *mcpv1beta1.MCPRemoteProxy) (*upstreamv0.ServerJSON, error) {
+func extractMCPRemoteProxy(
+	ctx context.Context,
+	mcpRemoteProxy *mcpv1beta1.MCPRemoteProxy,
+	discoverTimeout time.Duration,
+	ts oauth2.TokenSource,
+) (*upstreamv0.ServerJSON, error) {
 	// Generate reverse-DNS formatted server name
 	serverName, err := GenerateServerName(mcpRemoteProxy.Namespace, mcpRemoteProxy.Name)
 	if err != nil {
@@ -276,9 +301,11 @@ func extractMCPRemoteProxy(mcpRemoteProxy *mcpv1beta1.MCPRemoteProxy) (*upstream
 		},
 	}
 
-	// Add tool definitions if present
 	if toolDefs := extractToolDefinitions(annotations, mcpRemoteProxy.Name, mcpRemoteProxy.Namespace); toolDefs != nil {
 		extensions.ToolDefinitions = toolDefs
+	} else {
+		extensions.ToolDefinitions = discoverTools(
+			ctx, transportURL, mcpRemoteProxy.Name, mcpRemoteProxy.Namespace, discoverTimeout, ts)
 	}
 
 	// Add tools if present

--- a/internal/kubernetes/types_test.go
+++ b/internal/kubernetes/types_test.go
@@ -1,10 +1,13 @@
 package kubernetes
 
 import (
+	"context"
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/google/uuid"
+	mcpclient "github.com/mark3labs/mcp-go/client"
 	upstreamv0 "github.com/modelcontextprotocol/registry/pkg/api/v0"
 	model "github.com/modelcontextprotocol/registry/pkg/model"
 	"github.com/stacklok/toolhive-core/registry/types"
@@ -28,8 +31,14 @@ func createTestMCPServer(name, namespace string, annotations map[string]string, 
 	}
 }
 
+//nolint:paralleltest,tparallel // writes connectMCPClient package-level var; must run sequentially to prevent data race
 func TestExtractServer(t *testing.T) {
-	t.Parallel()
+	// stub connectMCPClient to avoid real network calls during extract* tests
+	origConnect := connectMCPClient
+	connectMCPClient = func(_ context.Context, _ string, _ map[string]string) (*mcpclient.Client, error) {
+		return nil, fmt.Errorf("lazy discovery disabled in unit tests")
+	}
+	t.Cleanup(func() { connectMCPClient = origConnect })
 
 	tests := []struct {
 		name        string
@@ -567,7 +576,7 @@ func TestExtractServer(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			result, err := extractServer(tt.mcpServer)
+			result, err := extractServer(context.Background(), tt.mcpServer, defaultDiscoverTimeout, nil)
 
 			if tt.wantErr {
 				require.Error(t, err)
@@ -757,8 +766,14 @@ func createTestVirtualMCPServer(name, namespace string, annotations map[string]s
 	}
 }
 
+//nolint:paralleltest,tparallel // writes connectMCPClient package-level var; must run sequentially to prevent data race
 func TestExtractVirtualMCPServer(t *testing.T) {
-	t.Parallel()
+	// stub connectMCPClient to avoid real network calls during extract* tests
+	origConnect := connectMCPClient
+	connectMCPClient = func(_ context.Context, _ string, _ map[string]string) (*mcpclient.Client, error) {
+		return nil, fmt.Errorf("lazy discovery disabled in unit tests")
+	}
+	t.Cleanup(func() { connectMCPClient = origConnect })
 
 	tests := []struct {
 		name        string
@@ -1034,7 +1049,7 @@ func TestExtractVirtualMCPServer(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			result, err := extractVirtualMCPServer(tt.vmcpServer)
+			result, err := extractVirtualMCPServer(context.Background(), tt.vmcpServer, defaultDiscoverTimeout, nil)
 
 			if tt.wantErr {
 				require.Error(t, err)
@@ -1071,8 +1086,14 @@ func createTestMCPRemoteProxy(name, namespace string, annotations map[string]str
 	}
 }
 
+//nolint:paralleltest,tparallel // writes connectMCPClient package-level var; must run sequentially to prevent data race
 func TestExtractMCPRemoteProxy(t *testing.T) {
-	t.Parallel()
+	// stub connectMCPClient to avoid real network calls during extract* tests
+	origConnect := connectMCPClient
+	connectMCPClient = func(_ context.Context, _ string, _ map[string]string) (*mcpclient.Client, error) {
+		return nil, fmt.Errorf("lazy discovery disabled in unit tests")
+	}
+	t.Cleanup(func() { connectMCPClient = origConnect })
 
 	tests := []struct {
 		name           string
@@ -1355,7 +1376,7 @@ func TestExtractMCPRemoteProxy(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			result, err := extractMCPRemoteProxy(tt.mcpRemoteProxy)
+			result, err := extractMCPRemoteProxy(context.Background(), tt.mcpRemoteProxy, defaultDiscoverTimeout, nil)
 
 			if tt.wantErr {
 				require.Error(t, err)


### PR DESCRIPTION
## Summary

When a `MCPServer`, `VirtualMCPServer`, or `MCPRemoteProxy` CRD is exported to the registry (`toolhive.stacklok.dev/registry-export: "true"`) but carries no `tool-definitions` annotation, the K8s controller now automatically connects to the proxy's `registry-url` and calls `tools/list` at reconcile time, storing the discovered tools in the database.

This removes the need for operators to manually annotate every tool on each CRD — the registry self-populates from the running proxy and stays up-to-date on every reconcile.

## Changes

- **`internal/kubernetes/discover.go`** (new) — Streamable-HTTP MCP client with SSE fallback; injects OAuth2 Bearer token when `TokenSource` is configured
- **`internal/kubernetes/oauth.go`** (new) — `golang.org/x/oauth2/clientcredentials` wrapper; nil `TokenSource` means anonymous (backward compatible)
- **`internal/config/config.go`** — New `discoverTimeout` and `discoverOAuth2` fields on `KubernetesConfig`; client secret read from file path per project secrets policy
- **`internal/kubernetes/types.go`** — `extractServer`, `extractVirtualMCPServer`, `extractMCPRemoteProxy` fall back to `discoverTools` when `tool-definitions` annotation is absent
- **`internal/kubernetes/controller.go`** — `extractorFunc` extended with `ctx` and `tokenSource`
- **`internal/app/builder.go`** — Constructs `TokenSource` from config and injects it via `WithDiscoverTokenSource`
- **`docs/lazy-tool-discovery.md`** (new) — Feature overview, OAuth2 setup, Helm deployment guide, annotation reference
- **`docs/configuration.md`** — `discoverOAuth2` field table added to Kubernetes source section
- **`deploy/charts/.../values.yaml`** — Example `discoverOAuth2` block added to Helm values comments

## Behavior

| `tool-definitions` annotation | `registry-url` annotation | Result |
|:---:|:---:|---|
| ✅ present | any | annotation used directly — lazy discovery not triggered |
| ❌ absent | ✅ present | **lazy discovery** — `tools/list` called at reconcile time |
| ❌ absent | ❌ absent | empty — no HTTP connection made |

Discovery failures are non-fatal: a warning is logged and the entry is still registered; retry happens on the next reconcile.

## OAuth2 support

Production MCP proxies typically enforce Cedar authorization. The new `discoverOAuth2` config block enables `client_credentials` authentication:

```yaml
sources:
  - name: k8s-source
    kubernetes:
      namespaces: ["toolhive-system"]
      discoverTimeout: "15s"
      discoverOAuth2:
        tokenUrl: https://keycloak.example.com/realms/toolhive/protocol/openid-connect/token
        clientId: registry-server-discovery
        clientSecretFile: /var/run/secrets/toolhive/discover-oauth2/client-secret
        scopes: ["openid"]
```

When `discoverOAuth2` is omitted, discovery runs anonymously (backward compatible).

## Testing

- `task lint-fix` — 0 issues
- `task test PACKAGES=./internal/kubernetes/...` — all pass, no data race
- `task test PACKAGES=./internal/config/...` — all pass
- Manually verified against a Cedar-protected ToolHive deployment: `tools/list` returns discovered tools which appear in `/registry/{name}/v0.1/servers`