### PR TITLE
Address metrics-standardization review findings

### DIFF
--- a/internal/telemetry/metrics.go
+++ b/internal/telemetry/metrics.go
@@ -3,6 +3,7 @@ package telemetry
 
 import (
 	"context"
+	"log/slog"
 	"sync"
 	"time"
 
@@ -84,12 +85,17 @@ type cachingRegistryMetricReader struct {
 	ttl      time.Duration
 	errorTTL time.Duration
 	now      func() time.Time
+	// logger is nil in production, which resolves to slog.Default() at call
+	// time. Tests set it so they can assert on the transition without swapping
+	// the process-wide default logger out from under parallel siblings.
+	logger *slog.Logger
 
 	mu        sync.Mutex
 	expiresAt time.Time
 	counts    []RegistryMetricCount
 	haveCount bool
 	err       error
+	degraded  bool
 }
 
 func newCachingRegistryMetricReader(reader RegistryMetricReader) *cachingRegistryMetricReader {
@@ -107,9 +113,11 @@ func (c *cachingRegistryMetricReader) RegistryMetricCounts(ctx context.Context) 
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	// Stamp the deadline from before the query, not after: measuring the TTL
-	// from completion would push each expiry out by the query's own duration
-	// and drift the refresh cadence past the export interval.
+	// Stamp the success deadline from before the query, not after: measuring
+	// the TTL from completion would push each expiry out by the query's own
+	// duration and drift the refresh cadence past the export interval. This
+	// relies on the reader's own query timeout being shorter than ttl, which
+	// registryMetricCountsQueryTimeout is.
 	started := c.now()
 	if started.Before(c.expiresAt) {
 		return c.counts, c.err
@@ -117,21 +125,67 @@ func (c *cachingRegistryMetricReader) RegistryMetricCounts(ctx context.Context) 
 
 	counts, err := c.reader.RegistryMetricCounts(ctx)
 	if err != nil {
+		// The negative TTL is stamped from after the query, unlike the success
+		// TTL above. A failing read most often fails by exhausting the
+		// reader's query timeout, which is longer than errorTTL, so stamping
+		// from `started` would write an entry that is already expired and let
+		// the very next caller re-run the full-table aggregate — turning an
+		// unreachable or saturated database into a back-to-back stream of
+		// them, which is exactly what this cache exists to prevent.
+		c.expiresAt = c.now().Add(c.errorTTL)
+		c.noteDegraded(err)
+
 		// Fall back to the last known-good counts if we have any, so one
 		// failed read doesn't black out the whole export.
 		if c.haveCount {
 			c.err = nil
-			c.expiresAt = started.Add(c.errorTTL)
 			return c.counts, nil
 		}
 		c.err = err
-		c.expiresAt = started.Add(c.errorTTL)
 		return nil, err
 	}
 
+	c.noteRecovered()
 	c.counts, c.haveCount, c.err = counts, true, nil
 	c.expiresAt = started.Add(c.ttl)
 	return c.counts, nil
+}
+
+// noteDegraded records that a refresh failed. It logs only on the transition
+// into the degraded state: the negative TTL means a persistently unreachable
+// database retries every few seconds, so logging every failure would emit a
+// line per retry for the length of the outage. Callers must hold c.mu.
+func (c *cachingRegistryMetricReader) noteDegraded(err error) {
+	if c.degraded {
+		return
+	}
+	c.degraded = true
+
+	// Without this the fallback below is invisible: the error is swallowed,
+	// the gauges keep reporting their last value with a fresh timestamp, and
+	// nothing distinguishes "counts are steady" from "counts are frozen".
+	c.log().Warn("Registry metric counts refresh failed",
+		"error", err,
+		"serving_stale_counts", c.haveCount)
+}
+
+// log returns the logger to report state transitions on, defaulting to the
+// process logger at call time so a later slog.SetDefault still applies.
+func (c *cachingRegistryMetricReader) log() *slog.Logger {
+	if c.logger != nil {
+		return c.logger
+	}
+	return slog.Default()
+}
+
+// noteRecovered records that a refresh succeeded after a failure. Callers must
+// hold c.mu.
+func (c *cachingRegistryMetricReader) noteRecovered() {
+	if !c.degraded {
+		return
+	}
+	c.degraded = false
+	c.log().Info("Registry metric counts refresh recovered")
 }
 
 // NewRegistryMetrics creates a new RegistryMetrics instance with the given meter provider.

--- a/internal/telemetry/metrics_test.go
+++ b/internal/telemetry/metrics_test.go
@@ -1,8 +1,10 @@
 package telemetry
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"log/slog"
 	"testing"
 	"time"
 
@@ -36,6 +38,22 @@ type countingRegistryMetricReader struct {
 func (r *countingRegistryMetricReader) RegistryMetricCounts(ctx context.Context) ([]RegistryMetricCount, error) {
 	r.calls++
 	return r.inner.RegistryMetricCounts(ctx)
+}
+
+// clockAdvancingFailingReader fails only after consuming dur of simulated
+// wall-clock, modelling how this read actually fails in production: by
+// exhausting registryMetricCountsQueryTimeout against a stalled or saturated
+// database, rather than by an instant connection refusal.
+type clockAdvancingFailingReader struct {
+	clock *time.Time
+	dur   time.Duration
+	calls int
+}
+
+func (r *clockAdvancingFailingReader) RegistryMetricCounts(_ context.Context) ([]RegistryMetricCount, error) {
+	r.calls++
+	*r.clock = r.clock.Add(r.dur)
+	return nil, errors.New("query timeout")
 }
 
 func TestNewRegistryMetrics(t *testing.T) {
@@ -316,6 +334,74 @@ func TestCachingRegistryMetricReader(t *testing.T) {
 
 		assert.Less(t, registryMetricCountsErrorCacheTTL, registryMetricCountsCacheTTL,
 			"holding a failure for the full success TTL prolongs an export blackout past the DB's recovery")
+	})
+
+	// The sibling case above uses a reader that fails instantly, so it only
+	// exercises the half of the negative TTL that holds regardless of how the
+	// expiry is stamped. A read that fails by exhausting its query timeout
+	// takes longer than the negative TTL itself, which is the case that
+	// actually decides whether a struggling database gets left alone.
+	t.Run("negative TTL holds when the read fails slowly, not just instantly", func(t *testing.T) {
+		t.Parallel()
+
+		clock := time.Now()
+		inner := &clockAdvancingFailingReader{clock: &clock, dur: registryMetricCountsErrorCacheTTL * 4}
+		cache := newCachingRegistryMetricReader(inner)
+		cache.now = func() time.Time { return clock }
+
+		_, err := cache.RegistryMetricCounts(context.Background())
+		require.Error(t, err)
+
+		// Immediately afterwards, with no idle time at all. Stamping the
+		// negative TTL from before the query would have written an entry that
+		// already expired while the query was running, letting this call
+		// straight through to the database.
+		_, err = cache.RegistryMetricCounts(context.Background())
+		require.Error(t, err)
+
+		assert.Equal(t, 1, inner.calls,
+			"a slow failure must still be memoized: re-querying immediately turns an unreachable "+
+				"database into a back-to-back stream of full-table aggregates")
+	})
+
+	t.Run("reports entering and leaving the degraded state", func(t *testing.T) {
+		t.Parallel()
+
+		var buf bytes.Buffer
+		static := &staticRegistryMetricReader{counts: []RegistryMetricCount{{SourceName: "s", ServerCount: 1}}}
+		now := time.Now()
+		cache := newCachingRegistryMetricReader(static)
+		cache.now = func() time.Time { return now }
+		cache.logger = slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+
+		_, err := cache.RegistryMetricCounts(context.Background())
+		require.NoError(t, err)
+		require.Empty(t, buf.String(), "a healthy refresh should say nothing")
+
+		// Fail, so the reader starts serving stale counts. Without a log line
+		// this is entirely invisible: the error is swallowed, and the gauges
+		// keep reporting their last value with a fresh timestamp.
+		static.err = errors.New("db unavailable")
+		now = now.Add(registryMetricCountsCacheTTL + time.Second)
+		counts, err := cache.RegistryMetricCounts(context.Background())
+		require.NoError(t, err, "stale counts should still be served")
+		require.Len(t, counts, 1)
+		assert.Contains(t, buf.String(), "Registry metric counts refresh failed")
+		assert.Contains(t, buf.String(), "serving_stale_counts=true")
+
+		// Still failing: no second line, or a lengthy outage would emit one
+		// per retry for as long as it lasts.
+		buf.Reset()
+		now = now.Add(registryMetricCountsErrorCacheTTL + time.Second)
+		_, err = cache.RegistryMetricCounts(context.Background())
+		require.NoError(t, err)
+		assert.Empty(t, buf.String(), "the degraded state should be reported on transition, not per retry")
+
+		static.err = nil
+		now = now.Add(registryMetricCountsErrorCacheTTL + time.Second)
+		_, err = cache.RegistryMetricCounts(context.Background())
+		require.NoError(t, err)
+		assert.Contains(t, buf.String(), "Registry metric counts refresh recovered")
 	})
 }
 

--- a/internal/telemetry/middleware.go
+++ b/internal/telemetry/middleware.go
@@ -141,7 +141,7 @@ func (m *HTTPMetrics) Middleware(next http.Handler) http.Handler {
 		// reused on the decrement, so every series returns to zero — an
 		// unlabeled +1 paired with a labeled -1 would leak in-flight counts.
 		activeAttrs := metric.WithAttributes(
-			semconv.HTTPRequestMethodKey.String(r.Method),
+			httpMethodAttr(r.Method),
 			semconv.URLScheme(requestScheme(r)),
 		)
 
@@ -163,7 +163,7 @@ func (m *HTTPMetrics) Middleware(next http.Handler) http.Handler {
 		// metric emitted by any other semconv-instrumented service. url.scheme
 		// is Required on that metric alongside http.request.method.
 		attrs := []attribute.KeyValue{
-			semconv.HTTPRequestMethodKey.String(r.Method),
+			httpMethodAttr(r.Method),
 			semconv.URLScheme(requestScheme(r)),
 			semconv.HTTPRoute(routePattern),
 			semconv.HTTPResponseStatusCode(ww.Status()),
@@ -184,6 +184,42 @@ func (m *HTTPMetrics) Middleware(next http.Handler) http.Handler {
 			))
 		}
 	})
+}
+
+// knownHTTPMethods is the set of methods semconv v1.26 treats as known. Any
+// other value is reported as _OTHER, which the spec requires and which also
+// bounds the label: net/http accepts any RFC 9110 token as a method, and the
+// metrics middleware is deliberately mounted ahead of authentication, so an
+// unauthenticated client could otherwise mint an unbounded number of series on
+// three cumulative instruments — and they are exposed on an unauthenticated
+// /metrics endpoint.
+//
+// Matching is case-sensitive, per the spec: "get" is not GET, and normalizing
+// it would hide a misbehaving client rather than report it as _OTHER.
+var knownHTTPMethods = map[string]struct{}{
+	http.MethodConnect: {},
+	http.MethodDelete:  {},
+	http.MethodGet:     {},
+	http.MethodHead:    {},
+	http.MethodOptions: {},
+	http.MethodPatch:   {},
+	http.MethodPost:    {},
+	http.MethodPut:     {},
+	http.MethodTrace:   {},
+}
+
+// httpMethodAttr returns the bounded semconv http.request.method attribute for
+// a request method.
+//
+// The spec's companion attribute http.request.method_original, which carries
+// the unrecognised value verbatim, is deliberately not recorded: it is exactly
+// the unbounded value this normalization exists to keep off a metric. It
+// belongs on a span, where cardinality is not cumulative.
+func httpMethodAttr(method string) attribute.KeyValue {
+	if _, ok := knownHTTPMethods[method]; ok {
+		return semconv.HTTPRequestMethodKey.String(method)
+	}
+	return semconv.HTTPRequestMethodOther
 }
 
 // requestScheme returns the url.scheme value for a request. semconv v1.26

--- a/internal/telemetry/middleware_test.go
+++ b/internal/telemetry/middleware_test.go
@@ -3,6 +3,7 @@ package telemetry
 import (
 	"context"
 	"crypto/tls"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -198,6 +199,46 @@ func TestHTTPMetrics_Middleware(t *testing.T) {
 		// returns to zero and reads as a permanent in-flight leak.
 		assert.Equal(t, int64(0), sum.DataPoints[0].Value,
 			"active_requests must return to zero after the request completes")
+	})
+
+	t.Run("arbitrary request methods collapse to a single _OTHER series", func(t *testing.T) {
+		t.Parallel()
+
+		reader := sdkmetric.NewManualReader()
+		mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+		defer func() { _ = mp.Shutdown(context.Background()) }()
+
+		metrics, err := NewHTTPMetrics(mp)
+		require.NoError(t, err)
+
+		r := chi.NewRouter()
+		r.Use(metrics.Middleware)
+		r.Get("/things", func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })
+
+		// net/http accepts any RFC 9110 token as a method, and this middleware
+		// runs ahead of authentication, so these are reachable unauthenticated.
+		// Without _OTHER normalization each one mints its own series on three
+		// cumulative instruments, all exposed on the unauthenticated /metrics.
+		const junkMethods = 25
+		for i := range junkMethods {
+			req := httptest.NewRequest(fmt.Sprintf("SCAN%04d", i), "/things", nil)
+			r.ServeHTTP(httptest.NewRecorder(), req)
+		}
+
+		var rm metricdata.ResourceMetrics
+		require.NoError(t, reader.Collect(context.Background(), &rm))
+
+		hist := findFloat64Histogram(t, rm, "http.server.request.duration")
+		assert.Len(t, hist.DataPoints, 1,
+			"every unknown method must fold into one _OTHER series, got %d", len(hist.DataPoints))
+
+		active := findInt64Sum(t, rm, "http.server.active_requests")
+		assert.Len(t, active.DataPoints, 1,
+			"active_requests had no attributes before url.scheme was added; it must not become unbounded now")
+
+		method, present := hist.DataPoints[0].Attributes.Value(attribute.Key("http.request.method"))
+		require.True(t, present)
+		assert.Equal(t, "_OTHER", method.AsString())
 	})
 
 	t.Run("records error-by-type counter for 5xx and 4xx, but not 2xx", func(t *testing.T) {
@@ -471,4 +512,30 @@ func TestGetRoutePattern(t *testing.T) {
 		rr := httptest.NewRecorder()
 		r.ServeHTTP(rr, req)
 	})
+}
+
+func TestHTTPMethodAttr(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		method   string
+		expected string
+	}{
+		{"known method passes through verbatim", http.MethodGet, http.MethodGet},
+		{"every standard method is known", http.MethodDelete, http.MethodDelete},
+		{"unknown token collapses to _OTHER", "SCAN0001", "_OTHER"},
+		{"lowercase is not a known method", "get", "_OTHER"},
+		{"empty method", "", "_OTHER"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			attr := httpMethodAttr(tt.method)
+			assert.Equal(t, "http.request.method", string(attr.Key))
+			assert.Equal(t, tt.expected, attr.Value.AsString())
+		})
+	}
 }


### PR DESCRIPTION
Stacked on top of #853 — **base is `gautam/metrics-std-registry`, not `main`**, so this merges into that branch and #853 keeps its own history. Entirely optional: @glageju, if you'd rather fold these in yourself or disagree with any of it, close this and I'll drop it. It's here to save a round-trip, not to take the work over.

This picks up the three findings from the third review round on #853.

## What's here

**`cachingRegistryMetricReader`: negative TTL didn't hold on timeouts.** The expiry was stamped from a timestamp taken *before* the query. A failing read usually fails by exhausting `registryMetricCountsQueryTimeout` (20s), which is 4× the 5s negative TTL, so the entry was written already-expired and the next caller went straight back to the database. The negative TTL only worked for reads that failed *instantly* — not for the stalled database it exists to protect, which instead got back-to-back full-table aggregates. The error path now stamps from after the query; the success path keeps its pre-query stamp, which is what prevents the cadence drift you fixed in `a99cca4`.

Worth calling out: this is fallout from my own two suggestions interacting. Pre-query stamping (to fix cadence drift) and a short negative TTL (to avoid holding a failure past recovery) are both right on their own, and cancel out when combined. That's on me for not seeing it when I proposed them.

**Stale-count fallback was silent.** Falling back to last known-good counts discarded the error entirely — nothing propagated, nothing logged. The gauges kept reporting their last value with a fresh timestamp every collection, so there was no way to tell steady counts from frozen ones. Now logs the transition into and out of the degraded state, once each rather than per retry (the negative TTL retries every few seconds for the length of an outage).

**Unknown HTTP methods weren't normalized to `_OTHER`.** semconv requires it, and `net/http` accepts any RFC 9110 token while this middleware sits ahead of auth — so an unauthenticated client could mint unbounded series on three cumulative instruments, exposed on the unauthenticated `/metrics`. Adding the required attributes to `http.server.active_requests` in `68f4fd3` widened this, since that instrument previously had no attributes and therefore exactly one series.

## Deliberately not included

- **`http.request.method_original`.** The spec pairs it with `_OTHER`, but it carries exactly the unbounded value the normalization exists to keep off a metric. It belongs on a span.
- **A staleness bound on the fallback.** Serving stale counts indefinitely is still better than dropping the whole export, and picking a cutoff is a judgement call that's yours, not mine. The log line makes the situation diagnosable, which was the actual gap.
- **The dashboard skills/plugins panels.** Left in #862 as you filed it. Agree it shouldn't ride along here.

## Notes on the diff

The `logger` field on `cachingRegistryMetricReader` is injectable rather than calling `slog` directly. That wasn't gold-plating — capturing log output by swapping `slog.SetDefault` made `go test -race` fail against the package's parallel subtests. Nil means "use `slog.Default()` at call time", so production behaviour is unchanged.

Each test was mutation-checked: reverting the corresponding fix while keeping the test makes it fail. That was the point — the pre-existing coverage for two of these passed against the broken behaviour because it modelled the wrong case.

## Verification

- `go build ./...` clean
- `go test ./internal/...` — 30 packages, exit 0
- `go test -race ./internal/telemetry/...` clean
- `golangci-lint run ./internal/telemetry/...` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)
