### PR TITLE
Derive and validate Kubernetes entry versions

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -259,6 +259,32 @@ metadata:
     toolhive.stacklok.dev/authz-claims: '{"team": "platform"}'
 ```
 
+**Per-entry version:** the entry version is resolved in this order:
+
+1. the `toolhive.stacklok.dev/registry-version` annotation, when it holds a usable version
+2. the container image tag, when it holds a usable version (`MCPServer` only —
+   `VirtualMCPServer` and `MCPRemoteProxy` run no image, so the annotation is the only route)
+3. `1.0.0`
+
+A version is usable when it is a three-part semantic version — `MAJOR.MINOR.PATCH` with an
+optional prerelease, optionally `v`-prefixed — matching what the upstream MCP registry
+treats as semantic. Anything else falls through to the next option, because the entry
+version is part of an entry's identity, appears as a URL path segment
+(`GET .../versions/{version}`), and decides which version is served as `latest`.
+
+Values that fall through include `latest`, image digests, channel tags such as `stable` or
+`main`, two-part tags such as `1.2` or `20`, version ranges such as `1.x`, versions carrying
+`+build` metadata, and anything longer than 255 characters. An unusable *annotation* is
+logged as a warning; an unusable image tag is not, since untagged and `latest` images are
+routine.
+
+```yaml
+# Example CRD annotation pinning the entry version:
+metadata:
+  annotations:
+    toolhive.stacklok.dev/registry-version: '2.5.0'
+```
+
 **Features:**
 - Queries running Kubernetes resources
 - No background synchronization (on-demand only)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -272,11 +272,16 @@ treats as semantic. Anything else falls through to the next option, because the 
 version is part of an entry's identity, appears as a URL path segment
 (`GET .../versions/{version}`), and decides which version is served as `latest`.
 
-Values that fall through include `latest`, image digests, channel tags such as `stable` or
-`main`, two-part tags such as `1.2` or `20`, version ranges such as `1.x`, versions carrying
-`+build` metadata, and anything longer than 255 characters. An unusable *annotation* is
-logged as a warning; an unusable image tag is not, since untagged and `latest` images are
-routine.
+Values that fall through include `latest`, channel tags such as `stable` or `main`, two-part
+tags such as `1.2` or `20`, version ranges such as `1.x`, versions carrying `+build`
+metadata, and anything longer than 255 characters. An unusable *annotation* is logged as a
+warning naming the resource; an unusable image tag is not, since untagged and `latest`
+images are routine.
+
+Only the tag is read, never the digest — a digest does not order and changes on every
+rebuild. An image pinned as `db:1.4.2@sha256:...` therefore resolves to `1.4.2`, while an
+image pinned by digest alone resolves to `1.0.0`. A colon in a registry host is not
+mistaken for a tag, so `registry.internal:5000/db` is treated as untagged.
 
 ```yaml
 # Example CRD annotation pinning the entry version:

--- a/internal/kubernetes/builder.go
+++ b/internal/kubernetes/builder.go
@@ -30,6 +30,7 @@ const (
 	defaultRegistryCategoryAnnotation        = "toolhive.stacklok.dev/registry-category"
 	defaultRegistryToolDefinitionsAnnotation = "toolhive.stacklok.dev/tool-definitions"
 	defaultRegistryToolsAnnotation           = "toolhive.stacklok.dev/tools"
+	defaultRegistryVersionAnnotation         = "toolhive.stacklok.dev/registry-version"
 	defaultAuthzClaimsAnnotation             = "toolhive.stacklok.dev/authz-claims"
 
 	defaultRequeueAfter = 10 * time.Second

--- a/internal/kubernetes/types.go
+++ b/internal/kubernetes/types.go
@@ -14,8 +14,9 @@ import (
 )
 
 const (
-	// defaultServerVersion is used when an MCPServer resource does not carry
-	// an explicit version annotation.
+	// defaultServerVersion is the fallback entry version when the resource
+	// carries neither a registry-version annotation nor a versioned
+	// container image.
 	defaultServerVersion = "1.0.0"
 	// defaultServerStatus is the registry.ServerExtensions.Status value used
 	// for entries derived from running Kubernetes resources.
@@ -39,9 +40,8 @@ func extractServer(mcpServer *mcpv1beta1.MCPServer) (*upstreamv0.ServerJSON, err
 	// Note: MCPServer is a Kubernetes deployment resource, so we extract
 	// what information is available and create a minimal ServerJSON
 	serverJSON := &upstreamv0.ServerJSON{
-		Schema:  model.CurrentSchemaURL,
-		Name:    serverName,
-		Version: defaultServerVersion, // Default version, could be extracted from annotations or labels
+		Schema: model.CurrentSchemaURL,
+		Name:   serverName,
 	}
 
 	// Extract packages from MCPServer spec (using the container image)
@@ -52,6 +52,8 @@ func extractServer(mcpServer *mcpv1beta1.MCPServer) (*upstreamv0.ServerJSON, err
 	if annotations == nil {
 		return nil, fmt.Errorf("annotations not found")
 	}
+
+	serverJSON.Version = resolveServerVersion(annotations, parseImageTagOrDigest(mcpServer.Spec.Image))
 
 	desc, ok := annotations[defaultRegistryDescriptionAnnotation]
 	if !ok {
@@ -135,15 +137,17 @@ func extractVirtualMCPServer(virtualMCPServer *mcpv1beta1.VirtualMCPServer) (*up
 	// Note: VirtualMCPServer is a Kubernetes deployment resource, so we extract
 	// what information is available and create a minimal ServerJSON
 	serverJSON := &upstreamv0.ServerJSON{
-		Schema:  model.CurrentSchemaURL,
-		Name:    serverName,
-		Version: defaultServerVersion, // Default version, could be extracted from annotations or labels
+		Schema: model.CurrentSchemaURL,
+		Name:   serverName,
 	}
 
 	annotations := virtualMCPServer.GetAnnotations()
 	if annotations == nil {
 		return nil, fmt.Errorf("annotations not found")
 	}
+
+	// VirtualMCPServer has no container image to derive a version from.
+	serverJSON.Version = resolveServerVersion(annotations, "")
 
 	desc, ok := annotations[defaultRegistryDescriptionAnnotation]
 	if !ok {
@@ -225,15 +229,17 @@ func extractMCPRemoteProxy(mcpRemoteProxy *mcpv1beta1.MCPRemoteProxy) (*upstream
 	// Note: MCPRemoteProxy is a Kubernetes deployment resource, so we extract
 	// what information is available and create a minimal ServerJSON
 	serverJSON := &upstreamv0.ServerJSON{
-		Schema:  model.CurrentSchemaURL,
-		Name:    serverName,
-		Version: defaultServerVersion, // Default version, could be extracted from annotations or labels
+		Schema: model.CurrentSchemaURL,
+		Name:   serverName,
 	}
 
 	annotations := mcpRemoteProxy.GetAnnotations()
 	if annotations == nil {
 		return nil, fmt.Errorf("annotations not found")
 	}
+
+	// MCPRemoteProxy has no container image to derive a version from.
+	serverJSON.Version = resolveServerVersion(annotations, "")
 
 	desc, ok := annotations[defaultRegistryDescriptionAnnotation]
 	if !ok {
@@ -392,6 +398,21 @@ func extractPackages(mcpServer *mcpv1beta1.MCPServer) []model.Package {
 	packages = append(packages, packageModel)
 
 	return packages
+}
+
+// resolveServerVersion determines the version of a registry entry derived
+// from a Kubernetes resource. Precedence: the registry-version annotation,
+// then the container image tag or digest (for resources that run an image),
+// then defaultServerVersion. An image version equal to defaultImageVersion
+// ("latest") is not a meaningful version and is treated as absent.
+func resolveServerVersion(annotations map[string]string, imageVersion string) string {
+	if version, ok := annotations[defaultRegistryVersionAnnotation]; ok && version != "" {
+		return version
+	}
+	if imageVersion != "" && imageVersion != defaultImageVersion {
+		return imageVersion
+	}
+	return defaultServerVersion
 }
 
 // parseImageTagOrDigest is a rudimentary parser that parses the tag or digest

--- a/internal/kubernetes/types.go
+++ b/internal/kubernetes/types.go
@@ -26,6 +26,10 @@ const (
 	// defaultImageVersion is returned by parseImageTagOrDigest when no tag or
 	// digest can be extracted from the container image reference.
 	defaultImageVersion = "latest"
+	// maxLoggedValueLength bounds how much of an untrusted annotation value is
+	// written to the logs. A publishable version is at most 255 characters, so this
+	// is enough to identify the mistake in a rejected one.
+	maxLoggedValueLength = 64
 )
 
 // extractServer converts an MCPServer to a ServerJSON object
@@ -55,7 +59,7 @@ func extractServer(mcpServer *mcpv1beta1.MCPServer) (*upstreamv0.ServerJSON, err
 		return nil, fmt.Errorf("annotations not found")
 	}
 
-	serverJSON.Version = resolveServerVersion(annotations, parseImageTagOrDigest(mcpServer.Spec.Image))
+	serverJSON.Version = resolveServerVersion(annotations, mcpServer.Spec.Image, mcpServer.Name, mcpServer.Namespace)
 
 	desc, ok := annotations[defaultRegistryDescriptionAnnotation]
 	if !ok {
@@ -149,7 +153,7 @@ func extractVirtualMCPServer(virtualMCPServer *mcpv1beta1.VirtualMCPServer) (*up
 	}
 
 	// VirtualMCPServer has no container image to derive a version from.
-	serverJSON.Version = resolveServerVersion(annotations, "")
+	serverJSON.Version = resolveServerVersion(annotations, "", virtualMCPServer.Name, virtualMCPServer.Namespace)
 
 	desc, ok := annotations[defaultRegistryDescriptionAnnotation]
 	if !ok {
@@ -241,7 +245,7 @@ func extractMCPRemoteProxy(mcpRemoteProxy *mcpv1beta1.MCPRemoteProxy) (*upstream
 	}
 
 	// MCPRemoteProxy has no container image to derive a version from.
-	serverJSON.Version = resolveServerVersion(annotations, "")
+	serverJSON.Version = resolveServerVersion(annotations, "", mcpRemoteProxy.Name, mcpRemoteProxy.Namespace)
 
 	desc, ok := annotations[defaultRegistryDescriptionAnnotation]
 	if !ok {
@@ -404,33 +408,76 @@ func extractPackages(mcpServer *mcpv1beta1.MCPServer) []model.Package {
 
 // resolveServerVersion determines the version of a registry entry derived from a
 // Kubernetes resource. Precedence: the registry-version annotation, then the
-// container image tag (for resources that run an image), then defaultServerVersion.
+// container image tag, then defaultServerVersion. Resources that run no image pass
+// an empty image reference.
 //
 // Both candidates are attacker-controlled free-form strings — annotation values are
 // unconstrained, and MCPServerSpec.Image has no format validation — and nothing
 // downstream validates an entry version, so a candidate that versions.IsPublishable
-// rejects is skipped rather than published. That also removes the need to special-case
-// image references with no usable version: "latest", bare digests, and the
-// "5000/my-image" that parseImageTagOrDigest yields for an untagged image on a ported
-// registry all fail the check and fall through to the default.
-func resolveServerVersion(annotations map[string]string, imageVersion string) string {
+// rejects is skipped rather than published. That removes the need to special-case
+// image references carrying no usable version: "latest", channel tags, and bare
+// digests all fail the check and fall through to the default.
+func resolveServerVersion(annotations map[string]string, image, name, namespace string) string {
+	annotated := strings.TrimSpace(annotations[defaultRegistryVersionAnnotation])
+	if annotated != "" && versions.IsPublishable(annotated) {
+		return annotated
+	}
+
+	resolved := defaultServerVersion
+	if tag := strings.TrimSpace(parseImageTag(image)); versions.IsPublishable(tag) {
+		resolved = tag
+	}
+
 	// A rejected annotation is always an operator mistake, so it is worth a warning.
-	// A rejected image tag is routine ("latest", "stable", a digest) and is not.
-	if annotated := strings.TrimSpace(annotations[defaultRegistryVersionAnnotation]); annotated != "" {
-		if versions.IsPublishable(annotated) {
-			return annotated
-		}
-		slog.Warn("ignoring unusable registry entry version annotation",
+	// A rejected image tag is routine ("latest", "stable", a digest) and is not. The
+	// value is truncated because it is unbounded and this runs on every reconcile.
+	if annotated != "" {
+		slog.Warn("ignoring unusable registry entry version annotation, using resolved version instead",
 			"annotation", defaultRegistryVersionAnnotation,
-			"value", annotated,
-			"fallback", defaultServerVersion)
+			"value", truncateForLog(annotated),
+			"value_length", len(annotated),
+			"resolved_version", resolved,
+			"server", name,
+			"namespace", namespace)
 	}
 
-	if tag := strings.TrimSpace(imageVersion); versions.IsPublishable(tag) {
-		return tag
+	return resolved
+}
+
+// truncateForLog bounds an untrusted annotation value on its way to the logs.
+// Kubernetes allows roughly 256KiB of annotations per object and the reconciler runs
+// on every update, so echoing a value verbatim would let one oversized annotation
+// amplify into the log volume that the publishing length limit exists to prevent.
+// Truncation is trimmed back to a rune boundary so the log line stays valid UTF-8.
+func truncateForLog(value string) string {
+	if len(value) <= maxLoggedValueLength {
+		return value
+	}
+	return strings.ToValidUTF8(value[:maxLoggedValueLength], "") + "…"
+}
+
+// parseImageTag returns the tag from a container image reference, or an empty string
+// when the reference carries none.
+//
+// Unlike parseImageTagOrDigest it never returns a digest, because a digest is not a
+// version: it does not order, and it changes on every image rebuild. A reference may
+// carry both ("db:1.4.2@sha256:..." is the canonical way to pin an image while keeping
+// the tag readable), and in that case the tag is the version the operator means.
+//
+// It also declines to mistake a registry port for a tag. A colon that appears before
+// the last "/" belongs to a host:port, so "registry.internal:5000/db" has no tag.
+func parseImageTag(image string) string {
+	// A digest suffix is not a tag; drop it before looking for one.
+	if at := strings.Index(image, "@"); at != -1 {
+		image = image[:at]
 	}
 
-	return defaultServerVersion
+	colon := strings.LastIndex(image, ":")
+	if colon == -1 || strings.LastIndex(image, "/") > colon {
+		return ""
+	}
+
+	return image[colon+1:]
 }
 
 // parseImageTagOrDigest is a rudimentary parser that parses the tag or digest

--- a/internal/kubernetes/types.go
+++ b/internal/kubernetes/types.go
@@ -11,12 +11,14 @@ import (
 	mcp "github.com/stacklok/toolhive-core/mcpcompat/mcp"
 	registry "github.com/stacklok/toolhive-core/registry/types"
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+
+	"github.com/stacklok/toolhive-registry-server/internal/versions"
 )
 
 const (
-	// defaultServerVersion is the fallback entry version when the resource
-	// carries neither a registry-version annotation nor a versioned
-	// container image.
+	// defaultServerVersion is the fallback entry version when the resource carries
+	// neither a usable registry-version annotation nor a semantically versioned
+	// container image tag.
 	defaultServerVersion = "1.0.0"
 	// defaultServerStatus is the registry.ServerExtensions.Status value used
 	// for entries derived from running Kubernetes resources.
@@ -400,18 +402,34 @@ func extractPackages(mcpServer *mcpv1beta1.MCPServer) []model.Package {
 	return packages
 }
 
-// resolveServerVersion determines the version of a registry entry derived
-// from a Kubernetes resource. Precedence: the registry-version annotation,
-// then the container image tag or digest (for resources that run an image),
-// then defaultServerVersion. An image version equal to defaultImageVersion
-// ("latest") is not a meaningful version and is treated as absent.
+// resolveServerVersion determines the version of a registry entry derived from a
+// Kubernetes resource. Precedence: the registry-version annotation, then the
+// container image tag (for resources that run an image), then defaultServerVersion.
+//
+// Both candidates are attacker-controlled free-form strings — annotation values are
+// unconstrained, and MCPServerSpec.Image has no format validation — and nothing
+// downstream validates an entry version, so a candidate that versions.IsPublishable
+// rejects is skipped rather than published. That also removes the need to special-case
+// image references with no usable version: "latest", bare digests, and the
+// "5000/my-image" that parseImageTagOrDigest yields for an untagged image on a ported
+// registry all fail the check and fall through to the default.
 func resolveServerVersion(annotations map[string]string, imageVersion string) string {
-	if version, ok := annotations[defaultRegistryVersionAnnotation]; ok && version != "" {
-		return version
+	// A rejected annotation is always an operator mistake, so it is worth a warning.
+	// A rejected image tag is routine ("latest", "stable", a digest) and is not.
+	if annotated := strings.TrimSpace(annotations[defaultRegistryVersionAnnotation]); annotated != "" {
+		if versions.IsPublishable(annotated) {
+			return annotated
+		}
+		slog.Warn("ignoring unusable registry entry version annotation",
+			"annotation", defaultRegistryVersionAnnotation,
+			"value", annotated,
+			"fallback", defaultServerVersion)
 	}
-	if imageVersion != "" && imageVersion != defaultImageVersion {
-		return imageVersion
+
+	if tag := strings.TrimSpace(imageVersion); versions.IsPublishable(tag) {
+		return tag
 	}
+
 	return defaultServerVersion
 }
 

--- a/internal/kubernetes/types_test.go
+++ b/internal/kubernetes/types_test.go
@@ -231,7 +231,7 @@ func TestExtractServer(t *testing.T) {
 			),
 			wantSchema:  "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
 			wantName:    "com.toolhive.k8s.custom-ns/full-server",
-			wantVersion: "1.0.0",
+			wantVersion: "tag",
 			wantErr:     false,
 			//nolint:thelper // We want to see these lines in the test output
 			checkMeta: func(t *testing.T, sj *upstreamv0.ServerJSON) {
@@ -277,7 +277,7 @@ func TestExtractServer(t *testing.T) {
 			),
 			wantSchema:  "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
 			wantName:    "com.toolhive.k8s.default/server-with-tools",
-			wantVersion: "1.0.0",
+			wantVersion: "v1",
 			wantErr:     false,
 			//nolint:thelper // We want to see these lines in the test output
 			checkMeta: func(t *testing.T, sj *upstreamv0.ServerJSON) {
@@ -320,7 +320,7 @@ func TestExtractServer(t *testing.T) {
 			),
 			wantSchema:  "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
 			wantName:    "com.toolhive.k8s.default/server-invalid-json",
-			wantVersion: "1.0.0",
+			wantVersion: "v1",
 			wantErr:     false,
 			//nolint:thelper // We want to see these lines in the test output
 			checkMeta: func(t *testing.T, sj *upstreamv0.ServerJSON) {
@@ -348,7 +348,7 @@ func TestExtractServer(t *testing.T) {
 			),
 			wantSchema:  "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
 			wantName:    "com.toolhive.k8s.default/server-empty-tools",
-			wantVersion: "1.0.0",
+			wantVersion: "v1",
 			wantErr:     false,
 			//nolint:thelper // We want to see these lines in the test output
 			checkMeta: func(t *testing.T, sj *upstreamv0.ServerJSON) {
@@ -376,7 +376,7 @@ func TestExtractServer(t *testing.T) {
 			),
 			wantSchema:  "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
 			wantName:    "com.toolhive.k8s.default/server-multi-tools",
-			wantVersion: "1.0.0",
+			wantVersion: "v1",
 			wantErr:     false,
 			//nolint:thelper // We want to see these lines in the test output
 			checkMeta: func(t *testing.T, sj *upstreamv0.ServerJSON) {
@@ -421,7 +421,7 @@ func TestExtractServer(t *testing.T) {
 			),
 			wantSchema:  "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
 			wantName:    "com.toolhive.k8s.default/server-with-tools-list",
-			wantVersion: "1.0.0",
+			wantVersion: "v1",
 			wantErr:     false,
 			//nolint:thelper // We want to see these lines in the test output
 			checkMeta: func(t *testing.T, sj *upstreamv0.ServerJSON) {
@@ -455,7 +455,7 @@ func TestExtractServer(t *testing.T) {
 			),
 			wantSchema:  "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
 			wantName:    "com.toolhive.k8s.default/server-invalid-tools",
-			wantVersion: "1.0.0",
+			wantVersion: "v1",
 			wantErr:     false,
 			//nolint:thelper // We want to see these lines in the test output
 			checkMeta: func(t *testing.T, sj *upstreamv0.ServerJSON) {
@@ -483,7 +483,7 @@ func TestExtractServer(t *testing.T) {
 			),
 			wantSchema:  "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
 			wantName:    "com.toolhive.k8s.default/server-empty-tools-list",
-			wantVersion: "1.0.0",
+			wantVersion: "v1",
 			wantErr:     false,
 			//nolint:thelper // We want to see these lines in the test output
 			checkMeta: func(t *testing.T, sj *upstreamv0.ServerJSON) {
@@ -511,7 +511,7 @@ func TestExtractServer(t *testing.T) {
 			),
 			wantSchema:  "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
 			wantName:    "com.toolhive.k8s.default/titled-server",
-			wantVersion: "1.0.0",
+			wantVersion: "v1",
 			wantErr:     false,
 			//nolint:thelper // We want to see these lines in the test output
 			checkMeta: func(t *testing.T, sj *upstreamv0.ServerJSON) {
@@ -539,7 +539,7 @@ func TestExtractServer(t *testing.T) {
 			),
 			wantSchema:  "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
 			wantName:    "com.toolhive.k8s.default/server-with-both",
-			wantVersion: "1.0.0",
+			wantVersion: "v1",
 			wantErr:     false,
 			//nolint:thelper // We want to see these lines in the test output
 			checkMeta: func(t *testing.T, sj *upstreamv0.ServerJSON) {
@@ -560,6 +560,45 @@ func TestExtractServer(t *testing.T) {
 				assert.Equal(t, "get_weather", tools[0])
 				assert.Equal(t, "get_forecast", tools[1])
 			},
+		},
+		{
+			name: "version annotation overrides the image tag",
+			mcpServer: createTestMCPServer(
+				"test-server",
+				"default",
+				map[string]string{
+					defaultRegistryDescriptionAnnotation: "A test MCP server",
+					defaultRegistryURLAnnotation:         "https://example.com/mcp",
+					defaultRegistryVersionAnnotation:     "2.5.0",
+				},
+				mcpv1beta1.MCPServerSpec{
+					Image:     "test/image:v1.2.3",
+					Transport: "streamable-http",
+				},
+			),
+			wantSchema:  "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+			wantName:    "com.toolhive.k8s.default/test-server",
+			wantVersion: "2.5.0",
+			wantErr:     false,
+		},
+		{
+			name: "digest-pinned image uses the digest as version",
+			mcpServer: createTestMCPServer(
+				"test-server",
+				"default",
+				map[string]string{
+					defaultRegistryDescriptionAnnotation: "A test MCP server",
+					defaultRegistryURLAnnotation:         "https://example.com/mcp",
+				},
+				mcpv1beta1.MCPServerSpec{
+					Image:     "registry.example.com/image@sha256:abc123def4567890abcdef1234567890abcdef1234567890abcdef1234567890",
+					Transport: "streamable-http",
+				},
+			),
+			wantSchema:  "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+			wantName:    "com.toolhive.k8s.default/test-server",
+			wantVersion: "sha256:abc123def4567890abcdef1234567890abcdef1234567890abcdef1234567890",
+			wantErr:     false,
 		},
 	}
 
@@ -809,6 +848,22 @@ func TestExtractVirtualMCPServer(t *testing.T) {
 				assert.Equal(t, model.TransportTypeStreamableHTTP, sj.Remotes[0].Type)
 				assert.Equal(t, "https://example.com/vmcp", sj.Remotes[0].URL)
 			},
+		},
+		{
+			name: "VirtualMCPServer with version annotation",
+			vmcpServer: createTestVirtualMCPServer(
+				"test-vmcp-server",
+				"default",
+				map[string]string{
+					defaultRegistryDescriptionAnnotation: "A test Virtual MCP server",
+					defaultRegistryURLAnnotation:         "https://example.com/vmcp",
+					defaultRegistryVersionAnnotation:     "3.1.4",
+				},
+			),
+			wantSchema:  "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+			wantName:    "com.toolhive.k8s.default/test-vmcp-server",
+			wantVersion: "3.1.4",
+			wantErr:     false,
 		},
 		{
 			name: "VirtualMCPServer with nil annotations",
@@ -1125,6 +1180,22 @@ func TestExtractMCPRemoteProxy(t *testing.T) {
 			},
 		},
 		{
+			name: "MCPRemoteProxy with version annotation",
+			mcpRemoteProxy: createTestMCPRemoteProxy(
+				"test-proxy",
+				"default",
+				map[string]string{
+					defaultRegistryDescriptionAnnotation: "A test MCP Remote Proxy",
+					defaultRegistryURLAnnotation:         "https://example.com/proxy",
+					defaultRegistryVersionAnnotation:     "0.9.1",
+				},
+			),
+			wantSchema:  "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+			wantName:    "com.toolhive.k8s.default/test-proxy",
+			wantVersion: "0.9.1",
+			wantErr:     false,
+		},
+		{
 			name: "MCPRemoteProxy with nil annotations",
 			mcpRemoteProxy: createTestMCPRemoteProxy(
 				"test-proxy",
@@ -1374,6 +1445,62 @@ func TestExtractMCPRemoteProxy(t *testing.T) {
 					tt.checkMeta(t, result)
 				}
 			}
+		})
+	}
+}
+
+func TestResolveServerVersion(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		annotations  map[string]string
+		imageVersion string
+		want         string
+	}{
+		{
+			name:         "annotation wins over image version",
+			annotations:  map[string]string{defaultRegistryVersionAnnotation: "2.5.0"},
+			imageVersion: "v1.2.3",
+			want:         "2.5.0",
+		},
+		{
+			name:         "image tag used when no annotation",
+			annotations:  map[string]string{},
+			imageVersion: "v1.2.3",
+			want:         "v1.2.3",
+		},
+		{
+			name:         "image digest used when no annotation",
+			annotations:  map[string]string{},
+			imageVersion: "sha256:abc123",
+			want:         "sha256:abc123",
+		},
+		{
+			name:         "latest image version falls back to default",
+			annotations:  map[string]string{},
+			imageVersion: "latest",
+			want:         "1.0.0",
+		},
+		{
+			name:         "no annotation and no image falls back to default",
+			annotations:  map[string]string{},
+			imageVersion: "",
+			want:         "1.0.0",
+		},
+		{
+			name:         "empty annotation value is ignored",
+			annotations:  map[string]string{defaultRegistryVersionAnnotation: ""},
+			imageVersion: "v1.2.3",
+			want:         "v1.2.3",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tt.want, resolveServerVersion(tt.annotations, tt.imageVersion))
 		})
 	}
 }

--- a/internal/kubernetes/types_test.go
+++ b/internal/kubernetes/types_test.go
@@ -2,6 +2,7 @@ package kubernetes
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/google/uuid"
@@ -231,7 +232,7 @@ func TestExtractServer(t *testing.T) {
 			),
 			wantSchema:  "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
 			wantName:    "com.toolhive.k8s.custom-ns/full-server",
-			wantVersion: "tag",
+			wantVersion: "1.0.0",
 			wantErr:     false,
 			//nolint:thelper // We want to see these lines in the test output
 			checkMeta: func(t *testing.T, sj *upstreamv0.ServerJSON) {
@@ -277,7 +278,7 @@ func TestExtractServer(t *testing.T) {
 			),
 			wantSchema:  "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
 			wantName:    "com.toolhive.k8s.default/server-with-tools",
-			wantVersion: "v1",
+			wantVersion: "1.0.0",
 			wantErr:     false,
 			//nolint:thelper // We want to see these lines in the test output
 			checkMeta: func(t *testing.T, sj *upstreamv0.ServerJSON) {
@@ -320,7 +321,7 @@ func TestExtractServer(t *testing.T) {
 			),
 			wantSchema:  "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
 			wantName:    "com.toolhive.k8s.default/server-invalid-json",
-			wantVersion: "v1",
+			wantVersion: "1.0.0",
 			wantErr:     false,
 			//nolint:thelper // We want to see these lines in the test output
 			checkMeta: func(t *testing.T, sj *upstreamv0.ServerJSON) {
@@ -348,7 +349,7 @@ func TestExtractServer(t *testing.T) {
 			),
 			wantSchema:  "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
 			wantName:    "com.toolhive.k8s.default/server-empty-tools",
-			wantVersion: "v1",
+			wantVersion: "1.0.0",
 			wantErr:     false,
 			//nolint:thelper // We want to see these lines in the test output
 			checkMeta: func(t *testing.T, sj *upstreamv0.ServerJSON) {
@@ -376,7 +377,7 @@ func TestExtractServer(t *testing.T) {
 			),
 			wantSchema:  "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
 			wantName:    "com.toolhive.k8s.default/server-multi-tools",
-			wantVersion: "v1",
+			wantVersion: "1.0.0",
 			wantErr:     false,
 			//nolint:thelper // We want to see these lines in the test output
 			checkMeta: func(t *testing.T, sj *upstreamv0.ServerJSON) {
@@ -421,7 +422,7 @@ func TestExtractServer(t *testing.T) {
 			),
 			wantSchema:  "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
 			wantName:    "com.toolhive.k8s.default/server-with-tools-list",
-			wantVersion: "v1",
+			wantVersion: "1.0.0",
 			wantErr:     false,
 			//nolint:thelper // We want to see these lines in the test output
 			checkMeta: func(t *testing.T, sj *upstreamv0.ServerJSON) {
@@ -455,7 +456,7 @@ func TestExtractServer(t *testing.T) {
 			),
 			wantSchema:  "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
 			wantName:    "com.toolhive.k8s.default/server-invalid-tools",
-			wantVersion: "v1",
+			wantVersion: "1.0.0",
 			wantErr:     false,
 			//nolint:thelper // We want to see these lines in the test output
 			checkMeta: func(t *testing.T, sj *upstreamv0.ServerJSON) {
@@ -483,7 +484,7 @@ func TestExtractServer(t *testing.T) {
 			),
 			wantSchema:  "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
 			wantName:    "com.toolhive.k8s.default/server-empty-tools-list",
-			wantVersion: "v1",
+			wantVersion: "1.0.0",
 			wantErr:     false,
 			//nolint:thelper // We want to see these lines in the test output
 			checkMeta: func(t *testing.T, sj *upstreamv0.ServerJSON) {
@@ -511,7 +512,7 @@ func TestExtractServer(t *testing.T) {
 			),
 			wantSchema:  "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
 			wantName:    "com.toolhive.k8s.default/titled-server",
-			wantVersion: "v1",
+			wantVersion: "1.0.0",
 			wantErr:     false,
 			//nolint:thelper // We want to see these lines in the test output
 			checkMeta: func(t *testing.T, sj *upstreamv0.ServerJSON) {
@@ -539,7 +540,7 @@ func TestExtractServer(t *testing.T) {
 			),
 			wantSchema:  "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
 			wantName:    "com.toolhive.k8s.default/server-with-both",
-			wantVersion: "v1",
+			wantVersion: "1.0.0",
 			wantErr:     false,
 			//nolint:thelper // We want to see these lines in the test output
 			checkMeta: func(t *testing.T, sj *upstreamv0.ServerJSON) {
@@ -582,7 +583,45 @@ func TestExtractServer(t *testing.T) {
 			wantErr:     false,
 		},
 		{
-			name: "digest-pinned image uses the digest as version",
+			name: "semver image tag becomes the entry version",
+			mcpServer: createTestMCPServer(
+				"test-server",
+				"default",
+				map[string]string{
+					defaultRegistryDescriptionAnnotation: "A test MCP server",
+					defaultRegistryURLAnnotation:         "https://example.com/mcp",
+				},
+				mcpv1beta1.MCPServerSpec{
+					Image:     "registry.example.com/image:1.4.2",
+					Transport: "streamable-http",
+				},
+			),
+			wantSchema:  "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+			wantName:    "com.toolhive.k8s.default/test-server",
+			wantVersion: "1.4.2",
+			wantErr:     false,
+		},
+		{
+			name: "v-prefixed image tag is kept as written",
+			mcpServer: createTestMCPServer(
+				"test-server",
+				"default",
+				map[string]string{
+					defaultRegistryDescriptionAnnotation: "A test MCP server",
+					defaultRegistryURLAnnotation:         "https://example.com/mcp",
+				},
+				mcpv1beta1.MCPServerSpec{
+					Image:     "registry.example.com/image:v2.1.0-rc.1",
+					Transport: "streamable-http",
+				},
+			),
+			wantSchema:  "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+			wantName:    "com.toolhive.k8s.default/test-server",
+			wantVersion: "v2.1.0-rc.1",
+			wantErr:     false,
+		},
+		{
+			name: "digest-pinned image falls back to the default version",
 			mcpServer: createTestMCPServer(
 				"test-server",
 				"default",
@@ -597,7 +636,48 @@ func TestExtractServer(t *testing.T) {
 			),
 			wantSchema:  "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
 			wantName:    "com.toolhive.k8s.default/test-server",
-			wantVersion: "sha256:abc123def4567890abcdef1234567890abcdef1234567890abcdef1234567890",
+			wantVersion: defaultServerVersion,
+			wantErr:     false,
+		},
+		{
+			name: "untagged image on a ported registry falls back to the default version",
+			mcpServer: createTestMCPServer(
+				"test-server",
+				"default",
+				map[string]string{
+					defaultRegistryDescriptionAnnotation: "A test MCP server",
+					defaultRegistryURLAnnotation:         "https://example.com/mcp",
+				},
+				mcpv1beta1.MCPServerSpec{
+					// parseImageTagOrDigest yields "5000/image" here, which must not
+					// reach the entry version.
+					Image:     "registry.example.com:5000/image",
+					Transport: "streamable-http",
+				},
+			),
+			wantSchema:  "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+			wantName:    "com.toolhive.k8s.default/test-server",
+			wantVersion: defaultServerVersion,
+			wantErr:     false,
+		},
+		{
+			name: "unusable annotation falls back to the semver image tag",
+			mcpServer: createTestMCPServer(
+				"test-server",
+				"default",
+				map[string]string{
+					defaultRegistryDescriptionAnnotation: "A test MCP server",
+					defaultRegistryURLAnnotation:         "https://example.com/mcp",
+					defaultRegistryVersionAnnotation:     "REL-2024-06",
+				},
+				mcpv1beta1.MCPServerSpec{
+					Image:     "registry.example.com/image:1.4.2",
+					Transport: "streamable-http",
+				},
+			),
+			wantSchema:  "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+			wantName:    "com.toolhive.k8s.default/test-server",
+			wantVersion: "1.4.2",
 			wantErr:     false,
 		},
 	}
@@ -1459,40 +1539,108 @@ func TestResolveServerVersion(t *testing.T) {
 		want         string
 	}{
 		{
-			name:         "annotation wins over image version",
+			name:         "annotation wins over image tag",
 			annotations:  map[string]string{defaultRegistryVersionAnnotation: "2.5.0"},
-			imageVersion: "v1.2.3",
+			imageVersion: "1.2.3",
 			want:         "2.5.0",
 		},
 		{
 			name:         "image tag used when no annotation",
 			annotations:  map[string]string{},
+			imageVersion: "1.2.3",
+			want:         "1.2.3",
+		},
+		{
+			name:         "v prefix is preserved, not normalized",
+			annotations:  map[string]string{},
 			imageVersion: "v1.2.3",
 			want:         "v1.2.3",
 		},
 		{
-			name:         "image digest used when no annotation",
-			annotations:  map[string]string{},
-			imageVersion: "sha256:abc123",
-			want:         "sha256:abc123",
+			name:         "surrounding whitespace is trimmed from the annotation",
+			annotations:  map[string]string{defaultRegistryVersionAnnotation: "  2.5.0\n"},
+			imageVersion: "",
+			want:         "2.5.0",
 		},
 		{
-			name:         "latest image version falls back to default",
-			annotations:  map[string]string{},
-			imageVersion: "latest",
-			want:         "1.0.0",
+			name:         "nil annotations falls back to the image tag",
+			annotations:  nil,
+			imageVersion: "1.2.3",
+			want:         "1.2.3",
 		},
 		{
 			name:         "no annotation and no image falls back to default",
 			annotations:  map[string]string{},
 			imageVersion: "",
-			want:         "1.0.0",
+			want:         defaultServerVersion,
 		},
 		{
 			name:         "empty annotation value is ignored",
 			annotations:  map[string]string{defaultRegistryVersionAnnotation: ""},
-			imageVersion: "v1.2.3",
-			want:         "v1.2.3",
+			imageVersion: "1.2.3",
+			want:         "1.2.3",
+		},
+		{
+			name:         "whitespace-only annotation value is ignored",
+			annotations:  map[string]string{defaultRegistryVersionAnnotation: "   "},
+			imageVersion: "1.2.3",
+			want:         "1.2.3",
+		},
+		// Unusable candidates fall through instead of being published. Each of these
+		// would otherwise reach the API as an entry version and a URL path segment.
+		{
+			name:         "reserved latest annotation falls back to the image tag",
+			annotations:  map[string]string{defaultRegistryVersionAnnotation: "latest"},
+			imageVersion: "1.2.3",
+			want:         "1.2.3",
+		},
+		{
+			name:         "non-semver annotation falls back to the image tag",
+			annotations:  map[string]string{defaultRegistryVersionAnnotation: "REL-2024-06"},
+			imageVersion: "1.2.3",
+			want:         "1.2.3",
+		},
+		{
+			name:         "over-length annotation falls back to the image tag",
+			annotations:  map[string]string{defaultRegistryVersionAnnotation: "1.0.0-" + strings.Repeat("a", 250)},
+			imageVersion: "1.2.3",
+			want:         "1.2.3",
+		},
+		{
+			name:         "unusable annotation and unusable tag falls back to default",
+			annotations:  map[string]string{defaultRegistryVersionAnnotation: "1.x"},
+			imageVersion: "stable",
+			want:         defaultServerVersion,
+		},
+		{
+			name:         "latest image tag falls back to default",
+			annotations:  map[string]string{},
+			imageVersion: "latest",
+			want:         defaultServerVersion,
+		},
+		{
+			name:         "image digest falls back to default",
+			annotations:  map[string]string{},
+			imageVersion: "sha256:abc123",
+			want:         defaultServerVersion,
+		},
+		{
+			name:         "ported-registry parser fallout falls back to default",
+			annotations:  map[string]string{},
+			imageVersion: "5000/my-image",
+			want:         defaultServerVersion,
+		},
+		{
+			name:         "two-part image tag falls back to default",
+			annotations:  map[string]string{},
+			imageVersion: "1.2",
+			want:         defaultServerVersion,
+		},
+		{
+			name:         "build metadata falls back to default",
+			annotations:  map[string]string{defaultRegistryVersionAnnotation: "1.2.3+build.5"},
+			imageVersion: "",
+			want:         defaultServerVersion,
 		},
 	}
 

--- a/internal/kubernetes/types_test.go
+++ b/internal/kubernetes/types_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/google/uuid"
 	upstreamv0 "github.com/modelcontextprotocol/registry/pkg/api/v0"
@@ -621,7 +622,28 @@ func TestExtractServer(t *testing.T) {
 			wantErr:     false,
 		},
 		{
-			name: "digest-pinned image falls back to the default version",
+			name: "tagged and digest-pinned image uses the tag",
+			mcpServer: createTestMCPServer(
+				"test-server",
+				"default",
+				map[string]string{
+					defaultRegistryDescriptionAnnotation: "A test MCP server",
+					defaultRegistryURLAnnotation:         "https://example.com/mcp",
+				},
+				mcpv1beta1.MCPServerSpec{
+					// The canonical way to pin an image while keeping the tag readable.
+					// The package version keeps the digest; the entry version takes the tag.
+					Image:     "registry.example.com/image:1.4.2@sha256:abc123def4567890abcdef1234567890abcdef1234567890abcdef1234567890",
+					Transport: "streamable-http",
+				},
+			),
+			wantSchema:  "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+			wantName:    "com.toolhive.k8s.default/test-server",
+			wantVersion: "1.4.2",
+			wantErr:     false,
+		},
+		{
+			name: "digest-only image falls back to the default version",
 			mcpServer: createTestMCPServer(
 				"test-server",
 				"default",
@@ -1533,114 +1555,138 @@ func TestResolveServerVersion(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name         string
-		annotations  map[string]string
-		imageVersion string
-		want         string
+		name        string
+		annotations map[string]string
+		image       string
+		want        string
 	}{
 		{
-			name:         "annotation wins over image tag",
-			annotations:  map[string]string{defaultRegistryVersionAnnotation: "2.5.0"},
-			imageVersion: "1.2.3",
-			want:         "2.5.0",
+			name:        "annotation wins over image tag",
+			annotations: map[string]string{defaultRegistryVersionAnnotation: "2.5.0"},
+			image:       "ghcr.io/acme/db:1.2.3",
+			want:        "2.5.0",
 		},
 		{
-			name:         "image tag used when no annotation",
-			annotations:  map[string]string{},
-			imageVersion: "1.2.3",
-			want:         "1.2.3",
+			name:        "image tag used when no annotation",
+			annotations: map[string]string{},
+			image:       "ghcr.io/acme/db:1.2.3",
+			want:        "1.2.3",
 		},
 		{
-			name:         "v prefix is preserved, not normalized",
-			annotations:  map[string]string{},
-			imageVersion: "v1.2.3",
-			want:         "v1.2.3",
+			name:        "v prefix is preserved, not normalized",
+			annotations: map[string]string{},
+			image:       "ghcr.io/acme/db:v1.2.3",
+			want:        "v1.2.3",
 		},
 		{
-			name:         "surrounding whitespace is trimmed from the annotation",
-			annotations:  map[string]string{defaultRegistryVersionAnnotation: "  2.5.0\n"},
-			imageVersion: "",
-			want:         "2.5.0",
+			name:        "tagged and digest-pinned image uses the tag",
+			annotations: map[string]string{},
+			image:       "ghcr.io/acme/db:1.4.2@sha256:abc123",
+			want:        "1.4.2",
 		},
 		{
-			name:         "nil annotations falls back to the image tag",
-			annotations:  nil,
-			imageVersion: "1.2.3",
-			want:         "1.2.3",
+			name:        "tagged and pinned on a ported registry uses the tag",
+			annotations: map[string]string{},
+			image:       "registry.internal:5000/db:1.4.2@sha256:abc123",
+			want:        "1.4.2",
 		},
 		{
-			name:         "no annotation and no image falls back to default",
-			annotations:  map[string]string{},
-			imageVersion: "",
-			want:         defaultServerVersion,
+			name:        "tagged image on a ported registry uses the tag",
+			annotations: map[string]string{},
+			image:       "registry.internal:5000/db:2.0.0",
+			want:        "2.0.0",
 		},
 		{
-			name:         "empty annotation value is ignored",
-			annotations:  map[string]string{defaultRegistryVersionAnnotation: ""},
-			imageVersion: "1.2.3",
-			want:         "1.2.3",
+			name:        "surrounding whitespace is trimmed from the annotation",
+			annotations: map[string]string{defaultRegistryVersionAnnotation: "  2.5.0\n"},
+			image:       "",
+			want:        "2.5.0",
 		},
 		{
-			name:         "whitespace-only annotation value is ignored",
-			annotations:  map[string]string{defaultRegistryVersionAnnotation: "   "},
-			imageVersion: "1.2.3",
-			want:         "1.2.3",
+			name:        "nil annotations falls back to the image tag",
+			annotations: nil,
+			image:       "ghcr.io/acme/db:1.2.3",
+			want:        "1.2.3",
+		},
+		{
+			name:        "no annotation and no image falls back to default",
+			annotations: map[string]string{},
+			image:       "",
+			want:        defaultServerVersion,
+		},
+		{
+			name:        "empty annotation value is ignored",
+			annotations: map[string]string{defaultRegistryVersionAnnotation: ""},
+			image:       "ghcr.io/acme/db:1.2.3",
+			want:        "1.2.3",
+		},
+		{
+			name:        "whitespace-only annotation value is ignored",
+			annotations: map[string]string{defaultRegistryVersionAnnotation: "   "},
+			image:       "ghcr.io/acme/db:1.2.3",
+			want:        "1.2.3",
 		},
 		// Unusable candidates fall through instead of being published. Each of these
 		// would otherwise reach the API as an entry version and a URL path segment.
 		{
-			name:         "reserved latest annotation falls back to the image tag",
-			annotations:  map[string]string{defaultRegistryVersionAnnotation: "latest"},
-			imageVersion: "1.2.3",
-			want:         "1.2.3",
+			name:        "reserved latest annotation falls back to the image tag",
+			annotations: map[string]string{defaultRegistryVersionAnnotation: "latest"},
+			image:       "ghcr.io/acme/db:1.2.3",
+			want:        "1.2.3",
 		},
 		{
-			name:         "non-semver annotation falls back to the image tag",
-			annotations:  map[string]string{defaultRegistryVersionAnnotation: "REL-2024-06"},
-			imageVersion: "1.2.3",
-			want:         "1.2.3",
+			name:        "non-semver annotation falls back to the image tag",
+			annotations: map[string]string{defaultRegistryVersionAnnotation: "REL-2024-06"},
+			image:       "ghcr.io/acme/db:1.2.3",
+			want:        "1.2.3",
 		},
 		{
-			name:         "over-length annotation falls back to the image tag",
-			annotations:  map[string]string{defaultRegistryVersionAnnotation: "1.0.0-" + strings.Repeat("a", 250)},
-			imageVersion: "1.2.3",
-			want:         "1.2.3",
+			name:        "over-length annotation falls back to the image tag",
+			annotations: map[string]string{defaultRegistryVersionAnnotation: "1.0.0-" + strings.Repeat("a", 250)},
+			image:       "ghcr.io/acme/db:1.2.3",
+			want:        "1.2.3",
 		},
 		{
-			name:         "unusable annotation and unusable tag falls back to default",
-			annotations:  map[string]string{defaultRegistryVersionAnnotation: "1.x"},
-			imageVersion: "stable",
-			want:         defaultServerVersion,
+			name:        "oversized annotation falls back to the image tag",
+			annotations: map[string]string{defaultRegistryVersionAnnotation: strings.Repeat("a", 100_000)},
+			image:       "ghcr.io/acme/db:1.2.3",
+			want:        "1.2.3",
 		},
 		{
-			name:         "latest image tag falls back to default",
-			annotations:  map[string]string{},
-			imageVersion: "latest",
-			want:         defaultServerVersion,
+			name:        "unusable annotation and unusable tag falls back to default",
+			annotations: map[string]string{defaultRegistryVersionAnnotation: "1.x"},
+			image:       "ghcr.io/acme/db:stable",
+			want:        defaultServerVersion,
 		},
 		{
-			name:         "image digest falls back to default",
-			annotations:  map[string]string{},
-			imageVersion: "sha256:abc123",
-			want:         defaultServerVersion,
+			name:        "latest image tag falls back to default",
+			annotations: map[string]string{},
+			image:       "ghcr.io/acme/db:latest",
+			want:        defaultServerVersion,
 		},
 		{
-			name:         "ported-registry parser fallout falls back to default",
-			annotations:  map[string]string{},
-			imageVersion: "5000/my-image",
-			want:         defaultServerVersion,
+			name:        "digest-only image falls back to default",
+			annotations: map[string]string{},
+			image:       "ghcr.io/acme/db@sha256:abc123",
+			want:        defaultServerVersion,
 		},
 		{
-			name:         "two-part image tag falls back to default",
-			annotations:  map[string]string{},
-			imageVersion: "1.2",
-			want:         defaultServerVersion,
+			name:        "untagged image on a ported registry falls back to default",
+			annotations: map[string]string{},
+			image:       "registry.internal:5000/db",
+			want:        defaultServerVersion,
 		},
 		{
-			name:         "build metadata falls back to default",
-			annotations:  map[string]string{defaultRegistryVersionAnnotation: "1.2.3+build.5"},
-			imageVersion: "",
-			want:         defaultServerVersion,
+			name:        "two-part image tag falls back to default",
+			annotations: map[string]string{},
+			image:       "ghcr.io/acme/db:1.2",
+			want:        defaultServerVersion,
+		},
+		{
+			name:        "build metadata falls back to default",
+			annotations: map[string]string{defaultRegistryVersionAnnotation: "1.2.3+build.5"},
+			image:       "",
+			want:        defaultServerVersion,
 		},
 	}
 
@@ -1648,7 +1694,60 @@ func TestResolveServerVersion(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			assert.Equal(t, tt.want, resolveServerVersion(tt.annotations, tt.imageVersion))
+			assert.Equal(t, tt.want, resolveServerVersion(tt.annotations, tt.image, "test-server", "default"))
 		})
 	}
+}
+
+func TestParseImageTag(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		image string
+		want  string
+	}{
+		{name: "plain tag", image: "ghcr.io/acme/db:1.4.2", want: "1.4.2"},
+		{name: "no registry host", image: "db:1.4.2", want: "1.4.2"},
+		{name: "tagged and digest-pinned", image: "ghcr.io/acme/db:1.4.2@sha256:abc", want: "1.4.2"},
+		{name: "ported registry with tag", image: "registry.internal:5000/db:2.0.0", want: "2.0.0"},
+		{name: "ported registry, tagged and pinned", image: "registry.internal:5000/db:2.0.0@sha256:abc", want: "2.0.0"},
+		{name: "digest only", image: "ghcr.io/acme/db@sha256:abc", want: ""},
+		{name: "ported registry, untagged", image: "registry.internal:5000/db", want: ""},
+		{name: "untagged", image: "ghcr.io/acme/db", want: ""},
+		{name: "empty", image: "", want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tt.want, parseImageTag(tt.image))
+		})
+	}
+}
+
+func TestTruncateForLog(t *testing.T) {
+	t.Parallel()
+
+	t.Run("short values pass through unchanged", func(t *testing.T) {
+		t.Parallel()
+
+		assert.Equal(t, "1.0.0", truncateForLog("1.0.0"))
+	})
+
+	t.Run("oversized values are bounded", func(t *testing.T) {
+		t.Parallel()
+
+		got := truncateForLog(strings.Repeat("a", 100_000))
+		assert.Len(t, got, maxLoggedValueLength+len("…"))
+	})
+
+	t.Run("truncation stays valid UTF-8", func(t *testing.T) {
+		t.Parallel()
+
+		// "€" is three bytes, so a 64-byte cut lands mid-rune.
+		got := truncateForLog(strings.Repeat("€", 100))
+		assert.True(t, utf8.ValidString(got))
+	})
 }

--- a/internal/versions/publishable.go
+++ b/internal/versions/publishable.go
@@ -1,0 +1,41 @@
+package versions
+
+import (
+	"strings"
+
+	"github.com/Masterminds/semver/v3"
+)
+
+// maxVersionLength mirrors the `maxLength` constraint on `version` in the upstream
+// server.json schema.
+const maxVersionLength = 255
+
+// IsPublishable reports whether v is usable as a registry entry version.
+//
+// The gate is "a three-part semantic version", matching the official registry's own
+// semantic-version check (major.minor.patch, optional prerelease, no leading zeros).
+// Looser versions are legal per the JSON schema, which constrains only length, but
+// they sort unpredictably: the official registry marks anything it cannot parse as
+// "latest" regardless of ordering, aggregators are told to fall back to publication
+// timestamps, and IsNewerVersion degrades to lexicographic comparison. Restricting
+// generated versions to the parseable set keeps latest-version resolution consistent
+// across all three.
+//
+// A leading "v" is accepted, since the schema lists prefixed versions as allowed.
+// Callers should keep the value as written rather than stripping the prefix — the API
+// matches versions exactly, and an entry's version should stay equal to the package
+// version it was derived from.
+//
+// Build metadata is rejected: semver comparison ignores it, so two versions differing
+// only in metadata would be distinct rows that sort equal, and "+" decodes as a space
+// in `?version=` for clients that do not percent-encode it.
+func IsPublishable(v string) bool {
+	if v == "" || len(v) > maxVersionLength {
+		return false
+	}
+	if strings.ContainsRune(v, '+') {
+		return false
+	}
+	_, err := semver.StrictNewVersion(strings.TrimPrefix(v, "v"))
+	return err == nil
+}

--- a/internal/versions/publishable_test.go
+++ b/internal/versions/publishable_test.go
@@ -1,0 +1,97 @@
+package versions
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsPublishable(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		version  string
+		expected bool
+	}{
+		// Three-part semantic versions, the recommended form.
+		{name: "plain semver", version: "1.4.2", expected: true},
+		{name: "zero version", version: "0.0.1", expected: true},
+		{name: "prerelease", version: "2.1.0-alpha", expected: true},
+		{name: "dotted prerelease", version: "1.0.0-beta.1", expected: true},
+		{name: "release candidate", version: "3.0.0-rc.2", expected: true},
+		{name: "image variant reads as a prerelease", version: "1.2.3-alpine", expected: true},
+		{name: "semantic date", version: "2025.11.25", expected: true},
+
+		// A leading "v" is allowed by the upstream schema.
+		{name: "v prefix", version: "v1.2.3", expected: true},
+		{name: "v prefix with prerelease", version: "v1.2.3-alpine3.19", expected: true},
+
+		// Fewer than three parts: allowed by the schema, but the official registry
+		// does not treat these as semantic and they sort unpredictably.
+		{name: "two-part version", version: "1.2", expected: false},
+		{name: "single-part version", version: "1", expected: false},
+		{name: "v prefix, two parts", version: "v1.0", expected: false},
+		{name: "four-part version", version: "1.2.3.4", expected: false},
+
+		// Leading zeros are not valid semver.
+		{name: "leading zero in patch", version: "2025.06.18", expected: false},
+		{name: "leading zero in major", version: "01.2.3", expected: false},
+
+		// Build metadata is ignored by semver comparison and breaks `?version=`.
+		{name: "build metadata", version: "1.2.3+build.5", expected: false},
+
+		// Reserved and range-like values.
+		{name: "reserved latest", version: "latest", expected: false},
+		{name: "caret range", version: "^1.2.3", expected: false},
+		{name: "tilde range", version: "~1.2.3", expected: false},
+		{name: "comparator range", version: ">=1.2.3", expected: false},
+		{name: "x range", version: "1.x", expected: false},
+		{name: "wildcard range", version: "1.2.*", expected: false},
+
+		// Values that would be unusable as an entry version or URL path segment.
+		{name: "empty", version: "", expected: false},
+		{name: "whitespace only", version: "   ", expected: false},
+		{name: "internal whitespace", version: "1.0.0 beta", expected: false},
+		{name: "untrimmed", version: " 1.0.0 ", expected: false},
+		{name: "image digest", version: "sha256:abc123", expected: false},
+		{name: "path separator", version: "5000/my-image", expected: false},
+		{name: "channel name", version: "stable", expected: false},
+		{name: "commit tag", version: "sha-a1b2c3d", expected: false},
+		{name: "non-semver scheme", version: "REL-2024-06", expected: false},
+		{name: "underscore", version: "1.2.3_1", expected: false},
+
+		// Length limit from the upstream schema's maxLength on `version`.
+		{name: "at the length limit", version: "1.0.0-" + strings.Repeat("a", maxVersionLength-6), expected: true},
+		{name: "over the length limit", version: "1.0.0-" + strings.Repeat("a", maxVersionLength-5), expected: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tt.expected, IsPublishable(tt.version))
+		})
+	}
+}
+
+// TestIsPublishableImpliesOrderable guards the reason the gate exists: every accepted
+// version must be comparable by IsNewerVersion without falling back to lexicographic
+// comparison, so latest-version resolution stays meaningful.
+func TestIsPublishableImpliesOrderable(t *testing.T) {
+	t.Parallel()
+
+	ordered := []string{"0.9.0", "1.0.0-alpha", "1.0.0-beta.1", "1.0.0", "v1.0.1", "1.2.3", "2025.11.25"}
+
+	for i, v := range ordered {
+		require := IsPublishable(v)
+		assert.True(t, require, "%q should be publishable", v)
+
+		if i > 0 {
+			prev := ordered[i-1]
+			assert.True(t, IsNewerVersion(v, prev), "%q should sort after %q", v, prev)
+			assert.False(t, IsNewerVersion(prev, v), "%q should not sort after %q", prev, v)
+		}
+	}
+}


### PR DESCRIPTION
Supersedes #854, and keeps @chaaben-v's commit as the base — the precedence design is theirs.

Registry entries built from Kubernetes resources (`MCPServer`, `VirtualMCPServer`, `MCPRemoteProxy`) always publish version `1.0.0`, hardcoded in the kubernetes source as its own comment admits ("could be extracted from annotations or labels"). A cluster running a dozen MCPServers at different image tags publishes a dozen entries that all claim to be `1.0.0`.

The entry version is now resolved with the following precedence:

1. the `toolhive.stacklok.dev/registry-version` annotation — the only route for `VirtualMCPServer`/`MCPRemoteProxy`, which run no image
2. the container image tag; for a reference carrying both a tag and digest, such as `db:1.4.2@sha256:...`, the entry uses `1.4.2`
3. `1.0.0`, unchanged, as the fallback

## Why this adds a validation gate

Both candidates are attacker-controlled free-form strings — annotation values are unconstrained, and `MCPServerSpec.Image` carries no format validation — and **nothing downstream validates an entry version.** The reconciler writes straight through `SyncWriter`, and the publish path does not check format either, so whatever the extractor returns is stored and served verbatim.

That matters because the version is part of an entry's identity (`UNIQUE (entry_id, version)`), appears as a URL path segment in `GET .../versions/{version}`, and decides which version `latest` resolves to. Without a gate:

- an annotation could publish the reserved string `latest`, which our own SQL treats as the latest-pointer selector
- an annotation with whitespace would be stored but permanently unaddressable — `GetAndValidateURLParam` rejects whitespace, so there is no way to retrieve it
- an annotation could publish a 200KB string, echoed in every list response for that entry
- using the package-version parser for an image reference carrying a digest would produce `sha256:...`, which sorts above every numeric version under the lexicographic fallback in `IsNewerVersion` and changes identity on every image bump
- a naive colon split would mistake the port in an untagged image such as `registry.internal:5000/db` for a tag

`versions.IsPublishable` accepts only three-part semantic versions — optionally `v`-prefixed, optionally with a prerelease — matching what the upstream MCP registry treats as semantic. Looser versions are legal per the JSON schema, which constrains only `maxLength: 255`, but they sort unpredictably: the official registry marks anything it cannot parse as `latest` regardless of ordering, [aggregators are told](https://github.com/modelcontextprotocol/registry/blob/main/docs/modelcontextprotocol-io/versioning.mdx) to fall back to publication timestamps, and `IsNewerVersion` here degrades to string comparison. Restricting what we generate keeps latest-version resolution consistent across all three.

Build metadata is rejected: semver comparison ignores it, so two versions differing only in metadata would be distinct rows that sort equal, and `+` decodes as a space in `?version=` for clients that do not percent-encode it.

Entry-version resolution uses a dedicated `parseImageTag` helper. It strips any digest suffix before extracting the tag and ignores a colon before the final `/`, so a registry port is not mistaken for a tag. `parseImageTagOrDigest` remains unchanged for package metadata, where preserving the digest is intentional.

## What resolves, and what falls back

| Input | Version |
|---|---|
| image `:1.4.2`, `:v2.1.0-rc.1`, `:1.2.3-alpine`, `:2025.11.25` | the tag, as written |
| image `:1.4.2@sha256:...` | `1.4.2`; the package metadata still keeps the digest |
| annotation `2.5.0` (any resource kind) | `2.5.0` |
| image `:latest`, `:stable`, `:main`, `:sha-a1b2c3d` | `1.0.0` |
| image `:20`, `:3.12`, `:1.2`, `:v1.0` (fewer than three parts) | `1.0.0` |
| image `@sha256:...`, untagged, or untagged on a ported registry | `1.0.0` |
| unusable annotation such as `latest`, `1.x`, `+build`, whitespace, or >255 characters | the usable image tag, otherwise `1.0.0`, with a warning log |

A rejected annotation is logged because it is always an operator mistake. The warning names the server and namespace, reports the version actually selected and the rejected value's byte length, and truncates the value to 64 bytes. A rejected image tag is not logged, since untagged and `latest` images are routine.

The `v` prefix is kept as written rather than normalized: the upstream schema lists prefixed versions as allowed, the API matches versions exactly, and keeping it means the entry version stays equal to the image tag it came from.

## Behavior change

Entries for MCPServers with **semver-tagged** images move from `1.0.0` to the tag on the next reconcile, including images pinned in `tag@digest` form. Because sync deletes versions absent from the current state, the `1.0.0` row is removed and the entry-version ID changes — so `GET .../versions/1.0.0` starts returning 404 for those entries, and any cached version ID breaks. This needs a release note.

Entries whose images are tagged `latest` (by far the most common case), tagged with a channel name, untagged, or pinned by digest without a tag are unaffected, as are `VirtualMCPServer` and `MCPRemoteProxy` without the annotation.

## Testing

`task lint-fix` reports 0 issues; `go test ./internal/...` passes across all 30 packages, including the DB-backed `internal/db/sqlc` and `internal/service/db` suites.

- `TestIsPublishable` covers accepted semantic forms, reserved and range-like values, the length limit, and path-segment hazards
- `TestIsPublishableImpliesOrderable` walks an ascending version list and asserts every accepted version is strictly ordered by `IsNewerVersion` in both directions, pinning the invariant the gate exists to protect
- `TestResolveServerVersion` covers precedence, fall-through, trimming, nil annotations, tagged digests, ported registries, and oversized rejected annotations
- `TestParseImageTag` covers tagged, untagged, digest-only, `tag@digest`, and ported-registry references
- `TestTruncateForLog` covers pass-through, bounded output, and valid UTF-8 after truncation
- `TestExtractServer` covers annotation precedence, semantic and `v`-prefixed tags, tagged and digest-only pins, ported registries, and unusable annotations falling back to the tag

The annotation and its precedence are documented in `docs/configuration.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
