### PR TITLE
Align managed-source claims errors

### DIFF
--- a/docs/thv-registry-api/docs.go
+++ b/docs/thv-registry-api/docs.go
@@ -2767,19 +2767,6 @@ const docTemplate = `{
                             }
                         },
                         "description": "Internal server error"
-                    },
-                    "503": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "additionalProperties": {
-                                        "type": "string"
-                                    },
-                                    "type": "object"
-                                }
-                            }
-                        },
-                        "description": "No managed source available"
                     }
                 },
                 "summary": "Get entry claims",
@@ -2884,19 +2871,6 @@ const docTemplate = `{
                             }
                         },
                         "description": "Internal server error"
-                    },
-                    "503": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "additionalProperties": {
-                                        "type": "string"
-                                    },
-                                    "type": "object"
-                                }
-                            }
-                        },
-                        "description": "No managed source available"
                     }
                 },
                 "summary": "Update entry claims",

--- a/docs/thv-registry-api/swagger.json
+++ b/docs/thv-registry-api/swagger.json
@@ -2760,19 +2760,6 @@
                             }
                         },
                         "description": "Internal server error"
-                    },
-                    "503": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "additionalProperties": {
-                                        "type": "string"
-                                    },
-                                    "type": "object"
-                                }
-                            }
-                        },
-                        "description": "No managed source available"
                     }
                 },
                 "summary": "Get entry claims",
@@ -2877,19 +2864,6 @@
                             }
                         },
                         "description": "Internal server error"
-                    },
-                    "503": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "additionalProperties": {
-                                        "type": "string"
-                                    },
-                                    "type": "object"
-                                }
-                            }
-                        },
-                        "description": "No managed source available"
                     }
                 },
                 "summary": "Update entry claims",

--- a/docs/thv-registry-api/swagger.yaml
+++ b/docs/thv-registry-api/swagger.yaml
@@ -1916,14 +1916,6 @@ paths:
                   type: string
                 type: object
           description: Internal server error
-        "503":
-          content:
-            application/json:
-              schema:
-                additionalProperties:
-                  type: string
-                type: object
-          description: No managed source available
       summary: Get entry claims
       tags:
       - v1
@@ -1988,14 +1980,6 @@ paths:
                   type: string
                 type: object
           description: Internal server error
-        "503":
-          content:
-            application/json:
-              schema:
-                additionalProperties:
-                  type: string
-                type: object
-          description: No managed source available
       summary: Update entry claims
       tags:
       - v1

--- a/internal/api/v1/entries.go
+++ b/internal/api/v1/entries.go
@@ -246,7 +246,6 @@ type entryClaimsResponse struct {
 // @Failure		403	{object}	map[string]string	"Forbidden"
 // @Failure		404	{object}	map[string]string	"Not found"
 // @Failure		500	{object}	map[string]string	"Internal server error"
-// @Failure		503	{object}	map[string]string	"No managed source available"
 // @Router		/v1/entries/{type}/{name}/claims [get]
 func (routes *Routes) getEntryClaims(w http.ResponseWriter, r *http.Request) {
 	entryType, err := common.GetAndValidateURLParam(r, "type")
@@ -284,7 +283,7 @@ func (routes *Routes) getEntryClaims(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if errors.Is(err, service.ErrNoManagedSource) {
-			common.WriteErrorResponse(w, "no managed source available", http.StatusServiceUnavailable)
+			common.WriteErrorResponse(w, "no managed source available", http.StatusInternalServerError)
 			return
 		}
 		slog.ErrorContext(r.Context(), "failed to get entry claims", "error", err, "type", entryType)
@@ -315,7 +314,6 @@ type updateEntryClaimsRequest struct {
 // @Failure		403	{object}	map[string]string	"Forbidden"
 // @Failure		404	{object}	map[string]string	"Not found"
 // @Failure		500	{object}	map[string]string	"Internal server error"
-// @Failure		503	{object}	map[string]string	"No managed source available"
 // @Router		/v1/entries/{type}/{name}/claims [put]
 func (routes *Routes) updateEntryClaims(w http.ResponseWriter, r *http.Request) {
 	entryType, err := common.GetAndValidateURLParam(r, "type")
@@ -361,7 +359,7 @@ func (routes *Routes) updateEntryClaims(w http.ResponseWriter, r *http.Request) 
 			return
 		}
 		if errors.Is(err, service.ErrNoManagedSource) {
-			common.WriteErrorResponse(w, "no managed source available for updating claims", http.StatusServiceUnavailable)
+			common.WriteErrorResponse(w, "no managed source available for updating claims", http.StatusInternalServerError)
 			return
 		}
 		slog.ErrorContext(r.Context(), "failed to update entry claims", "error", err, "type", entryType)

--- a/internal/api/v1/entries_test.go
+++ b/internal/api/v1/entries_test.go
@@ -483,7 +483,7 @@ func TestUpdateEntryClaims(t *testing.T) {
 				m.EXPECT().UpdateEntryClaims(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(service.ErrNoManagedSource)
 			},
-			wantStatus: http.StatusServiceUnavailable,
+			wantStatus: http.StatusInternalServerError,
 			wantError:  "no managed source available for updating claims",
 		},
 		{
@@ -598,7 +598,7 @@ func TestGetEntryClaims(t *testing.T) {
 				m.EXPECT().GetEntryClaims(gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(nil, service.ErrNoManagedSource)
 			},
-			wantStatus: http.StatusServiceUnavailable,
+			wantStatus: http.StatusInternalServerError,
 			wantError:  "no managed source available",
 		},
 		{


### PR DESCRIPTION
## Summary

- return HTTP 500 for `ErrNoManagedSource` from both entry-claims handlers
- align the claims endpoints with publish/delete behavior and the data-model rule
- update handler regression tests and regenerate OpenAPI artifacts

## Verification

- `task gen`
- `task lint-fix` (zero issues)
- `task test PACKAGES=./internal/api/...`
- focused `ErrNoManagedSource` handler regressions
- independent diff review (no findings)

The repository-wide `task test` reached two unrelated database tests but Docker/Testcontainers timed out while starting Postgres; all API packages pass with the race detector.

Fixes #771