### PR TITLE
Use registry server version in internal API

### DIFF
--- a/docker/dockerfile-compose
+++ b/docker/dockerfile-compose
@@ -21,10 +21,10 @@ COPY . .
 
 # Build
 RUN CGO_ENABLED=0 LDFLAGS="-s -w \
--X github.com/stacklok/toolhive/pkg/versions.Version=${VERSION} \
--X github.com/stacklok/toolhive/pkg/versions.Commit=${COMMIT} \
--X github.com/stacklok/toolhive/pkg/versions.BuildDate=${BUILD_DATE} \
--X github.com/stacklok/toolhive/pkg/versions.BuildType=release" \
+-X github.com/stacklok/toolhive-registry-server/internal/versions.Version=${VERSION} \
+-X github.com/stacklok/toolhive-registry-server/internal/versions.Commit=${COMMIT} \
+-X github.com/stacklok/toolhive-registry-server/internal/versions.BuildDate=${BUILD_DATE} \
+-X github.com/stacklok/toolhive-registry-server/internal/versions.BuildType=release" \
 GOOS=linux go build -ldflags "${LDFLAGS}" -o main ./cmd/thv-registry-api/main.go
 
 # Use minimal base image to package the binary

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
-	"github.com/stacklok/toolhive/pkg/versions"
 	"github.com/swaggo/swag/v2"
 
 	// Import generated docs package to register OpenAPI spec via init()
@@ -19,6 +18,7 @@ import (
 	"github.com/stacklok/toolhive-registry-server/internal/auth"
 	"github.com/stacklok/toolhive-registry-server/internal/config"
 	"github.com/stacklok/toolhive-registry-server/internal/service"
+	"github.com/stacklok/toolhive-registry-server/internal/versions"
 )
 
 // ServerOption configures the registry API server

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stacklok/toolhive-registry-server/internal/api"
 	"github.com/stacklok/toolhive-registry-server/internal/auth"
 	"github.com/stacklok/toolhive-registry-server/internal/service/mocks"
+	registryversions "github.com/stacklok/toolhive-registry-server/internal/versions"
 )
 
 func TestHealthEndpoint(t *testing.T) {
@@ -130,6 +131,41 @@ func TestVersionEndpoint(t *testing.T) {
 	assert.Contains(t, response, "build_date")
 	assert.Contains(t, response, "go_version")
 	assert.Contains(t, response, "platform")
+}
+
+// TestVersionEndpointUsesRegistryServerBuildInfo mutates package-level build
+// information, so it must not run in parallel with other tests in this package.
+//
+//nolint:paralleltest,tparallel // mutates internal/versions package globals
+func TestVersionEndpointUsesRegistryServerBuildInfo(t *testing.T) {
+	previousVersion := registryversions.Version
+	previousCommit := registryversions.Commit
+	previousBuildDate := registryversions.BuildDate
+	t.Cleanup(func() {
+		registryversions.Version = previousVersion
+		registryversions.Commit = previousCommit
+		registryversions.BuildDate = previousBuildDate
+	})
+
+	registryversions.Version = "registry-server-test-version"
+	registryversions.Commit = "registry-server-test-commit"
+	registryversions.BuildDate = "registry-server-test-build-date"
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+	server := api.NewInternalServer(mocks.NewMockRegistryService(ctrl), nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/version", nil)
+	rr := httptest.NewRecorder()
+	server.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	var response api.VersionResponse
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &response))
+	assert.Equal(t, registryversions.Version, response.Version)
+	assert.Equal(t, registryversions.Commit, response.Commit)
+	assert.Equal(t, registryversions.BuildDate, response.BuildDate)
 }
 
 func TestInternalServer_MetricsEndpoint(t *testing.T) {


### PR DESCRIPTION
## Summary

- make the internal version endpoint read this service's build information
- align the compose-only Docker linker flags with every other release path
- add an HTTP-level regression test for registry-server version values

## Validation

- task gen
- task test
- task lint-fix
- task build
- linker-injected HTTP repro harness
- independent race-enabled review of internal/api

Fixes #858
