### PR TITLE
Drop deprecated `Requeue` field in `ctrl.Result`

### DIFF
--- a/internal/kubernetes/controller.go
+++ b/internal/kubernetes/controller.go
@@ -62,10 +62,7 @@ func (r *MCPServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	if err := r.syncWriter.Store(ctx, r.registryName, result.Registry, opts...); err != nil {
 		slog.Error("Failed to store MCPServer list", "error", err)
-		return ctrl.Result{
-			Requeue:      true,
-			RequeueAfter: r.requeueAfter,
-		}, err
+		return ctrl.Result{RequeueAfter: r.requeueAfter}, err
 	}
 
 	slog.Info("MCP servers stored successfully",


### PR DESCRIPTION
`controller-runtime` deprecated `Result.Requeue` in favour of `RequeueAfter`, so `staticcheck`'s SA1019 check now fails the `Lint Go Code` job on `main` — and consequently on every open pull request, including ones that touch no Go code at all (#876, #875).

The field was redundant here anyway: it was set alongside a non-zero `RequeueAfter`, which already schedules the requeue.

Verified locally: `golangci-lint run ./internal/kubernetes/...` reports 0 issues and `go test ./internal/kubernetes/...` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)