### PR TITLE
Enforce the registry metric timeout/TTL invariant

### DIFF
--- a/internal/app/storage/registry_metrics.go
+++ b/internal/app/storage/registry_metrics.go
@@ -29,6 +29,13 @@ SELECT src.name,
 // It sits above the caching reader's negative TTL but well below
 // PeriodicReader's 30s collect timeout, so a stalled query fails on this
 // deadline rather than taking the whole export down with it.
+//
+// It must also stay comfortably below telemetry.RegistryMetricCountsCacheTTL:
+// the caching reader stamps a successful entry's expiry from before the query
+// runs, so a timeout at or above the TTL produces entries that are already
+// expired. Both bounds are enforced by
+// TestRegistryMetricCountsTimeoutInvariants — raise this value and that test
+// tells you which TTL has to move with it.
 const registryMetricCountsQueryTimeout = 20 * time.Second
 
 // registryMetricCountsContext caps ctx at registryMetricCountsQueryTimeout. It

--- a/internal/app/storage/registry_metrics_test.go
+++ b/internal/app/storage/registry_metrics_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/stacklok/toolhive-registry-server/database"
+	"github.com/stacklok/toolhive-registry-server/internal/telemetry"
 )
 
 func TestRegistryMetricsReader_RegistryMetricCounts(t *testing.T) {
@@ -83,5 +84,56 @@ func TestRegistryMetricsReader_RegistryMetricCounts(t *testing.T) {
 		deadline, ok := queryCtx.Deadline()
 		require.True(t, ok)
 		require.LessOrEqual(t, time.Until(deadline), tight)
+	})
+}
+
+// The caching reader in internal/telemetry stamps a successful entry's expiry
+// from *before* the query runs, which only works while the query is guaranteed
+// to finish well inside the cache TTL. That relationship spans two packages —
+// storage imports telemetry, never the reverse — so telemetry cannot assert it
+// and it has to be checked here, where both values are visible. Without these
+// checks, raising registryMetricCountsQueryTimeout above the TTL disables the
+// cache silently: every caller re-runs the full-table aggregate, on an
+// unauthenticated /metrics endpoint, with no test going red.
+func TestRegistryMetricCountsTimeoutInvariants(t *testing.T) {
+	t.Parallel()
+
+	t.Run("query timeout is below the caching reader's success TTL", func(t *testing.T) {
+		t.Parallel()
+
+		require.Less(t, registryMetricCountsQueryTimeout, telemetry.RegistryMetricCountsCacheTTL,
+			"a query timeout at or above the success TTL writes cache entries that expired "+
+				"before they were written, so every caller re-runs the full-table aggregate")
+	})
+
+	// Being merely below the TTL is not enough. A slow-but-successful query
+	// consumes its own duration out of the entry's remaining life, so a
+	// timeout close to the TTL means a query that nearly times out yields an
+	// entry that is nearly expired on arrival — the cache technically works
+	// while bounding almost nothing. Requiring a third of the TTL to survive
+	// the slowest permitted query keeps the useful life meaningful.
+	//
+	// The current values (20s timeout, 30s TTL) sit exactly on this bound, so
+	// raising the timeout is a deliberate decision that has to raise the TTL
+	// with it rather than something that can drift in unnoticed.
+	t.Run("query timeout leaves usable cache life after a maximally slow query", func(t *testing.T) {
+		t.Parallel()
+
+		require.LessOrEqual(t, registryMetricCountsQueryTimeout, telemetry.RegistryMetricCountsCacheTTL*2/3,
+			"a query timeout this close to the success TTL leaves a slow query's result "+
+				"nearly expired on arrival, so the cache bounds almost nothing")
+	})
+
+	// The other direction, for the failure path. The caching reader stamps its
+	// negative TTL from *after* the query precisely because a failing read
+	// most often fails by exhausting this timeout; if the timeout were the
+	// shorter of the two, that reasoning — and the comment recording it —
+	// would no longer hold.
+	t.Run("query timeout is above the caching reader's negative TTL", func(t *testing.T) {
+		t.Parallel()
+
+		require.Greater(t, registryMetricCountsQueryTimeout, telemetry.RegistryMetricCountsErrorCacheTTL,
+			"the negative TTL assumes a failing read outlasts it; a shorter query timeout "+
+				"inverts that and invalidates the reader's expiry stamping")
 	})
 }

--- a/internal/telemetry/metrics.go
+++ b/internal/telemetry/metrics.go
@@ -48,7 +48,7 @@ type RegistryMetricReader interface {
 	RegistryMetricCounts(ctx context.Context) ([]RegistryMetricCount, error)
 }
 
-// registryMetricCountsCacheTTL bounds how often the observable-gauge callback
+// RegistryMetricCountsCacheTTL bounds how often the observable-gauge callback
 // re-runs RegistryMetricCounts' underlying DB aggregate. Before the Prometheus
 // reader was added, the periodic OTLP reader was the only caller, so the query
 // ran once every DefaultMetricsInterval (60s); a Prometheus scrape interval
@@ -60,15 +60,26 @@ type RegistryMetricReader interface {
 // It is deliberately strictly below DefaultMetricsInterval: at exactly 60s the
 // periodic reader's every-60s tick would alternate hit/miss, halving the
 // gauges' effective refresh rate to 120s in an OTLP-only deployment.
-const registryMetricCountsCacheTTL = 30 * time.Second
+//
+// It is exported only so that the reader implementations supplying the
+// underlying query — which import this package, not the other way round — can
+// assert their own query timeout stays below it. RegistryMetricCounts stamps a
+// successful entry's expiry from *before* the query runs, so a query timeout at
+// or above this TTL would write entries that had already expired and silently
+// disable the cache.
+const RegistryMetricCountsCacheTTL = 30 * time.Second
 
-// registryMetricCountsErrorCacheTTL is the negative TTL applied when the
+// RegistryMetricCountsErrorCacheTTL is the negative TTL applied when the
 // underlying read fails and there is no previous result to fall back on. It is
 // much shorter than the success TTL: a failed collection costs the SDK *every*
 // metric in the export (PeriodicReader.collectAndExport only exports when
 // Collect returns nil, so sync, HTTP and build_info are dropped alongside the
 // registry gauges), so a transient blip must not be held past its recovery.
-const registryMetricCountsErrorCacheTTL = 5 * time.Second
+//
+// It is exported for the same reason as RegistryMetricCountsCacheTTL: the
+// reader's query timeout has to stay above it, and only the reader's own
+// package can see both values.
+const RegistryMetricCountsErrorCacheTTL = 5 * time.Second
 
 // cachingRegistryMetricReader memoizes RegistryMetricCounts behind a TTL so
 // concurrent or frequent callers (multiple readers, a fast scrape interval)
@@ -101,8 +112,8 @@ type cachingRegistryMetricReader struct {
 func newCachingRegistryMetricReader(reader RegistryMetricReader) *cachingRegistryMetricReader {
 	return &cachingRegistryMetricReader{
 		reader:   reader,
-		ttl:      registryMetricCountsCacheTTL,
-		errorTTL: registryMetricCountsErrorCacheTTL,
+		ttl:      RegistryMetricCountsCacheTTL,
+		errorTTL: RegistryMetricCountsErrorCacheTTL,
 		now:      time.Now,
 	}
 }
@@ -116,8 +127,10 @@ func (c *cachingRegistryMetricReader) RegistryMetricCounts(ctx context.Context) 
 	// Stamp the success deadline from before the query, not after: measuring
 	// the TTL from completion would push each expiry out by the query's own
 	// duration and drift the refresh cadence past the export interval. This
-	// relies on the reader's own query timeout being shorter than ttl, which
-	// registryMetricCountsQueryTimeout is.
+	// relies on the reader's own query timeout being comfortably shorter than
+	// ttl, which registryMetricCountsQueryTimeout is — enforced by
+	// TestRegistryMetricCountsTimeoutInvariants in internal/app/storage, which
+	// is why the two TTLs above are exported.
 	started := c.now()
 	if started.Before(c.expiresAt) {
 		return c.counts, c.err

--- a/internal/telemetry/metrics_test.go
+++ b/internal/telemetry/metrics_test.go
@@ -227,7 +227,7 @@ func TestCachingRegistryMetricReader(t *testing.T) {
 		_, err := cache.RegistryMetricCounts(context.Background())
 		require.NoError(t, err)
 
-		now = now.Add(registryMetricCountsCacheTTL + time.Second)
+		now = now.Add(RegistryMetricCountsCacheTTL + time.Second)
 		_, err = cache.RegistryMetricCounts(context.Background())
 		require.NoError(t, err)
 
@@ -240,7 +240,7 @@ func TestCachingRegistryMetricReader(t *testing.T) {
 	t.Run("success TTL is below the metrics export interval", func(t *testing.T) {
 		t.Parallel()
 
-		assert.Less(t, registryMetricCountsCacheTTL, DefaultMetricsInterval,
+		assert.Less(t, RegistryMetricCountsCacheTTL, DefaultMetricsInterval,
 			"a TTL at or above the export interval halves the gauges' effective refresh rate")
 	})
 
@@ -257,7 +257,7 @@ func TestCachingRegistryMetricReader(t *testing.T) {
 		_, err := cache.RegistryMetricCounts(context.Background())
 		require.NoError(t, err)
 
-		assert.Equal(t, now.Add(registryMetricCountsCacheTTL), cache.expiresAt,
+		assert.Equal(t, now.Add(RegistryMetricCountsCacheTTL), cache.expiresAt,
 			"expiry stamped after the query would drift the refresh cadence by the query's duration")
 	})
 
@@ -276,7 +276,7 @@ func TestCachingRegistryMetricReader(t *testing.T) {
 
 		// DB goes away; the next refresh fails.
 		static.counts, static.err = nil, errors.New("db unavailable")
-		now = now.Add(registryMetricCountsCacheTTL + time.Second)
+		now = now.Add(RegistryMetricCountsCacheTTL + time.Second)
 
 		counts, err = cache.RegistryMetricCounts(context.Background())
 		require.NoError(t, err,
@@ -321,7 +321,7 @@ func TestCachingRegistryMetricReader(t *testing.T) {
 		// being held out for the full success TTL.
 		static.err = nil
 		static.counts = []RegistryMetricCount{{SourceName: "s", ServerCount: 1}}
-		now = now.Add(registryMetricCountsErrorCacheTTL + time.Second)
+		now = now.Add(RegistryMetricCountsErrorCacheTTL + time.Second)
 
 		counts, err := cache.RegistryMetricCounts(context.Background())
 		require.NoError(t, err)
@@ -332,7 +332,7 @@ func TestCachingRegistryMetricReader(t *testing.T) {
 	t.Run("negative TTL is shorter than the success TTL", func(t *testing.T) {
 		t.Parallel()
 
-		assert.Less(t, registryMetricCountsErrorCacheTTL, registryMetricCountsCacheTTL,
+		assert.Less(t, RegistryMetricCountsErrorCacheTTL, RegistryMetricCountsCacheTTL,
 			"holding a failure for the full success TTL prolongs an export blackout past the DB's recovery")
 	})
 
@@ -345,7 +345,7 @@ func TestCachingRegistryMetricReader(t *testing.T) {
 		t.Parallel()
 
 		clock := time.Now()
-		inner := &clockAdvancingFailingReader{clock: &clock, dur: registryMetricCountsErrorCacheTTL * 4}
+		inner := &clockAdvancingFailingReader{clock: &clock, dur: RegistryMetricCountsErrorCacheTTL * 4}
 		cache := newCachingRegistryMetricReader(inner)
 		cache.now = func() time.Time { return clock }
 
@@ -382,7 +382,7 @@ func TestCachingRegistryMetricReader(t *testing.T) {
 		// this is entirely invisible: the error is swallowed, and the gauges
 		// keep reporting their last value with a fresh timestamp.
 		static.err = errors.New("db unavailable")
-		now = now.Add(registryMetricCountsCacheTTL + time.Second)
+		now = now.Add(RegistryMetricCountsCacheTTL + time.Second)
 		counts, err := cache.RegistryMetricCounts(context.Background())
 		require.NoError(t, err, "stale counts should still be served")
 		require.Len(t, counts, 1)
@@ -392,13 +392,13 @@ func TestCachingRegistryMetricReader(t *testing.T) {
 		// Still failing: no second line, or a lengthy outage would emit one
 		// per retry for as long as it lasts.
 		buf.Reset()
-		now = now.Add(registryMetricCountsErrorCacheTTL + time.Second)
+		now = now.Add(RegistryMetricCountsErrorCacheTTL + time.Second)
 		_, err = cache.RegistryMetricCounts(context.Background())
 		require.NoError(t, err)
 		assert.Empty(t, buf.String(), "the degraded state should be reported on transition, not per retry")
 
 		static.err = nil
-		now = now.Add(registryMetricCountsErrorCacheTTL + time.Second)
+		now = now.Add(RegistryMetricCountsErrorCacheTTL + time.Second)
 		_, err = cache.RegistryMetricCounts(context.Background())
 		require.NoError(t, err)
 		assert.Contains(t, buf.String(), "Registry metric counts refresh recovered")


### PR DESCRIPTION
## What

`cachingRegistryMetricReader` stamps a successful cache entry's expiry from *before* the query runs (`internal/telemetry/metrics.go`). That is deliberate — measuring from completion would push each expiry out by the query's own duration and drift the refresh cadence past the export interval — but it only works while the query is guaranteed to finish well inside the TTL.

Nothing enforced that. The two values were unexported constants in different packages:

- `registryMetricCountsQueryTimeout = 20s` — `internal/app/storage/registry_metrics.go`
- `registryMetricCountsCacheTTL = 30s` — `internal/telemetry/metrics.go`

Raise the timeout above the TTL and the success path starts writing entries that expired before they were written, so every caller re-runs the full-table aggregate and the cache silently stops working — the exact failure the cache exists to prevent, on an unauthenticated `/metrics` endpoint, with the whole suite still green.

## How

The dependency runs one way (`internal/app/storage` imports `internal/telemetry`, not the reverse), so `telemetry` cannot see the timeout and the check has to live on the storage side. This is option 1 from the issue.

- Export `RegistryMetricCountsCacheTTL` and `RegistryMetricCountsErrorCacheTTL`, with doc comments stating that they are exported *only* so the reader supplying the query can assert against them.
- Add `TestRegistryMetricCountsTimeoutInvariants` in `internal/app/storage`, covering three subtests:
  1. the query timeout is strictly below the success TTL — the correctness invariant;
  2. it leaves at least a third of the TTL after a maximally slow query, so a slow-but-successful query does not yield an entry that is nearly expired on arrival;
  3. it stays *above* the negative TTL, which is what justifies the failure path stamping its expiry from after the query rather than before it.
- Cross-reference the enforcing test from both constants' comments, so raising either value points you at what has to move with it.

The 20s/30s pair sits exactly on the margin bound in (2), which is intentional: raising the timeout becomes a decision that has to raise the TTL too, rather than something that drifts in unnoticed.

## Verification

Reproduced the silent failure from the issue and confirmed it is no longer silent — setting the timeout to `40 * time.Second` fails subtests (1) and (2) with the rationale in the failure message, where previously both `./internal/telemetry/...` and `./internal/app/storage/...` stayed green.

`task lint-fix` reports 0 issues. `task test` passes except for `TestRegistryMetricsReader_RegistryMetricCounts`, which fails locally on a testcontainers/Docker startup timeout unrelated to this change; CI should cover it.

No production behaviour changes — the only non-test edits are the constant renames and comments.

Fixes #864

🤖 Generated with [Claude Code](https://claude.com/claude-code)