### PR TITLE
Add skills and plugins panels to the dashboard

### DIFF
--- a/examples/otel/grafana/dashboards/registry-server.json
+++ b/examples/otel/grafana/dashboards/registry-server.json
@@ -324,7 +324,187 @@
       "type": "timeseries"
     },
     {
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 20 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 6, "w": 12, "x": 0, "y": 20 },
+      "id": 14,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum(stacklok_registry_skills) by (source)",
+          "legendFormat": "{{ source }}",
+          "refId": "A"
+        }
+      ],
+      "title": "Skills per Source",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 6, "w": 12, "x": 12, "y": 20 },
+      "id": 15,
+      "options": {
+        "legend": { "calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "none" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum(stacklok_registry_skills) by (source)",
+          "legendFormat": "{{ source }}",
+          "refId": "A"
+        }
+      ],
+      "title": "Skills per Source (over time)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 6, "w": 12, "x": 0, "y": 26 },
+      "id": 16,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum(stacklok_registry_plugins) by (source)",
+          "legendFormat": "{{ source }}",
+          "refId": "A"
+        }
+      ],
+      "title": "Plugins per Source",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 6, "w": 12, "x": 12, "y": 26 },
+      "id": 17,
+      "options": {
+        "legend": { "calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "none" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum(stacklok_registry_plugins) by (source)",
+          "legendFormat": "{{ source }}",
+          "refId": "A"
+        }
+      ],
+      "title": "Plugins per Source (over time)",
+      "type": "timeseries"
+    },
+    {
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 32 },
       "id": 9,
       "title": "Sync Metrics",
       "type": "row"
@@ -365,7 +545,7 @@
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 21 },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 33 },
       "id": 10,
       "options": {
         "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true },
@@ -433,7 +613,7 @@
           }
         ]
       },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 21 },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 33 },
       "id": 11,
       "options": {
         "legend": { "calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true },
@@ -451,7 +631,7 @@
       "type": "timeseries"
     },
     {
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 29 },
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 41 },
       "id": 12,
       "title": "Errors",
       "type": "row"
@@ -492,7 +672,7 @@
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 30 },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 42 },
       "id": 13,
       "options": {
         "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true },


### PR DESCRIPTION
## Summary

The registry server exports three source-level gauges, but the bundled Grafana dashboard only visualised one of them. Both panels in the "Registry Metrics" row of `examples/otel/grafana/dashboards/registry-server.json` queried `sum(stacklok_registry_servers) by (source)`, so `stacklok_registry_skills` and `stacklok_registry_plugins` — both exported in `internal/telemetry/metrics.go` and documented in `docs/observability.md` — appeared in no panel.

This adds a stat + timeseries pair for each of the two missing gauges, mirroring the existing servers panels.

| Panel | id | Type | Query |
|---|---|---|---|
| Skills per Source | 14 | stat | `sum(stacklok_registry_skills) by (source)` |
| Skills per Source (over time) | 15 | timeseries | `sum(stacklok_registry_skills) by (source)` |
| Plugins per Source | 16 | stat | `sum(stacklok_registry_plugins) by (source)` |
| Plugins per Source (over time) | 17 | timeseries | `sum(stacklok_registry_plugins) by (source)` |

The timeseries variants stay `by (source)` so the per-source breakdown is preserved.

## Why a panel per entry type

The issue offered two layouts: extend the existing two panels to plot all three gauges, or add a dedicated pair per entry type. This takes the second. The "Servers per Source" stat panel works precisely because it answers one question; plotting three different entity counts in it turns a glanceable number into something you have to parse, and the legend grows to 3 types × N sources. Grafana rows collapse, so the extra height costs little.

The new panels' `fieldConfig`, `options`, and `legendFormat` blocks are byte-identical copies of the servers panels, so they render consistently with the rest of the row.

## Note on the diff

185 insertions are the four new panels. The 5 deletions are all `gridPos.y` bumps: the Registry Metrics row grew from 6 to 18 grid units tall, so the Sync Metrics row (20→32), its two panels (21→33), the Errors row (29→41), and its panel (30→42) shift down by 12. Grafana's grid is absolute rather than flow-based, so inserting a panel mid-dashboard requires re-laying-out everything below it.

## Testing

- File parses as valid JSON
- All 17 panel ids are unique
- Layout verified contiguous with no overlapping `gridPos` rectangles

New ids start at 14 rather than renumbering 9–13 to make room — Grafana only requires ids be unique within the dashboard, and renumbering would churn five unrelated panels for cosmetic ordering.

## Out of scope

No automated guard that every documented gauge appears in at least one panel. A test that parses the dashboard JSON, extracts each `expr`, and asserts coverage would catch this class of drift, but that is a new test rather than the fix for this issue.

Fixes #862

🤖 Generated with [Claude Code](https://claude.com/claude-code)